### PR TITLE
fix: improve GitHub API handling and terminal recovery

### DIFF
--- a/src/github/comment.rs
+++ b/src/github/comment.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-use super::client::{gh_api, gh_api_post};
+use super::client::{gh_api, gh_api_post, FieldValue};
 use super::pr::User;
 
 #[allow(dead_code)]
@@ -31,14 +31,15 @@ pub async fn create_review_comment(
     body: &str,
 ) -> Result<()> {
     let endpoint = format!("repos/{}/pulls/{}/comments", repo, pr_number);
+    let line_str = line.to_string();
     gh_api_post(
         &endpoint,
         &[
-            ("body", body),
-            ("commit_id", commit_id),
-            ("path", path),
-            ("line", &line.to_string()),
-            ("side", "RIGHT"),
+            ("body", FieldValue::String(body)),
+            ("commit_id", FieldValue::String(commit_id)),
+            ("path", FieldValue::String(path)),
+            ("line", FieldValue::Raw(&line_str)),
+            ("side", FieldValue::String("RIGHT")),
         ],
     )
     .await?;

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -111,12 +111,23 @@ fn render_footer(frame: &mut Frame, area: ratatui::layout::Rect) {
 }
 
 fn render_comment_preview(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
-    let preview_text = app
-        .pending_comment
-        .as_deref()
-        .unwrap_or("No comment pending");
+    let preview_lines: Vec<Line> = if let Some(ref comment) = app.pending_comment {
+        vec![
+            Line::from(vec![
+                Span::styled("Line ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    comment.line_number.to_string(),
+                    Style::default().fg(Color::Cyan),
+                ),
+            ]),
+            Line::from(""),
+            Line::from(comment.body.as_str()),
+        ]
+    } else {
+        vec![Line::from("No comment pending")]
+    };
 
-    let preview = Paragraph::new(preview_text)
+    let preview = Paragraph::new(preview_lines)
         .block(
             Block::default()
                 .borders(Borders::ALL)

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -83,7 +83,7 @@ pub fn render(frame: &mut Frame, app: &App) {
 
     // Footer
     let footer = Paragraph::new(
-        "j/k: move | Enter: view diff | a: approve | r: request changes | m: comment | q: quit | ?: help",
+        "j/k: move | Enter: view diff | a: approve | r: request changes | c: comment | q: quit | ?: help",
     )
     .block(Block::default().borders(Borders::ALL));
     frame.render_widget(footer, chunks[2]);


### PR DESCRIPTION
## Summary

- GitHub API コメント作成を修正（整数フィールドに `-F` フラグを使用）
- `CommentData` 構造体を追加して行番号を適切に追跡
- コメント/suggestion の対象行を検証（Added/Context 行のみ許可）
- パニックフックとエラーハンドラを追加してターミナル状態を復元
- file_list フッターのキーバインド表示を修正（m -> c）

## Test plan

- [ ] `cargo build` でビルド成功
- [ ] `cargo test` でテスト成功
- [ ] DiffView で `c` キーでコメント作成・投稿成功
- [ ] DiffView で `s` キーでsuggestion作成・投稿成功
- [ ] エラー発生時にターミナルが正常に復元される

🤖 Generated with [Claude Code](https://claude.com/claude-code)