### PR TITLE
feat: add AI Rally background execution feature

### DIFF
--- a/src/ai/orchestrator.rs
+++ b/src/ai/orchestrator.rs
@@ -37,6 +37,20 @@ pub enum RallyState {
     Error,
 }
 
+impl RallyState {
+    /// Rally が実行中（完了・エラー以外）かどうか
+    #[allow(dead_code)]
+    pub fn is_active(&self) -> bool {
+        !matches!(self, RallyState::Completed | RallyState::Error)
+    }
+
+    /// Rally が完了またはエラーで終了したかどうか
+    #[allow(dead_code)]
+    pub fn is_finished(&self) -> bool {
+        matches!(self, RallyState::Completed | RallyState::Error)
+    }
+}
+
 /// Event emitted during rally for TUI updates
 ///
 /// Variants are used by TUI handlers (ui/ai_rally.rs) via mpsc channel
@@ -576,5 +590,27 @@ mod tests {
         assert!(!is_bot_user("ushironoko"));
         assert!(!is_bot_user("octocat"));
         assert!(!is_bot_user("bot")); // "bot" alone is not a bot suffix
+    }
+
+    #[test]
+    fn test_rally_state_is_active() {
+        assert!(RallyState::Initializing.is_active());
+        assert!(RallyState::ReviewerReviewing.is_active());
+        assert!(RallyState::RevieweeFix.is_active());
+        assert!(RallyState::WaitingForClarification.is_active());
+        assert!(RallyState::WaitingForPermission.is_active());
+        assert!(!RallyState::Completed.is_active());
+        assert!(!RallyState::Error.is_active());
+    }
+
+    #[test]
+    fn test_rally_state_is_finished() {
+        assert!(!RallyState::Initializing.is_finished());
+        assert!(!RallyState::ReviewerReviewing.is_finished());
+        assert!(!RallyState::RevieweeFix.is_finished());
+        assert!(!RallyState::WaitingForClarification.is_finished());
+        assert!(!RallyState::WaitingForPermission.is_finished());
+        assert!(RallyState::Completed.is_finished());
+        assert!(RallyState::Error.is_finished());
     }
 }

--- a/src/ui/ai_rally.rs
+++ b/src/ui/ai_rally.rs
@@ -363,9 +363,9 @@ fn render_status_bar(frame: &mut Frame, area: Rect, state: &AiRallyState) {
             RallyState::WaitingForPermission => {
                 "n: Deny | ↑↓: Select | Enter: Detail | q: Abort (permission: WIP)"
             }
-            RallyState::Completed => "↑↓: Select | Enter: Detail | q: Close",
-            RallyState::Error => "r: Retry | ↑↓: Select | Enter: Detail | q: Close",
-            _ => "↑↓: Select | Enter: Detail | q: Abort",
+            RallyState::Completed => "↑↓: Select | Enter: Detail | b: Background | q: Close",
+            RallyState::Error => "r: Retry | ↑↓: Select | Enter: Detail | b: Background | q: Close",
+            _ => "↑↓: Select | Enter: Detail | b: Background | q: Abort",
         }
     };
 

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -1,0 +1,36 @@
+use ratatui::{
+    layout::{Alignment, Rect},
+    style::{Color, Modifier, Style},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::ai::RallyState;
+use crate::app::App;
+
+/// Render rally status bar for background rally indication
+pub fn render_rally_status_bar(frame: &mut Frame, area: Rect, app: &App) {
+    let Some(rally_state) = &app.ai_rally_state else {
+        return;
+    };
+
+    let (text, color) = match rally_state.state {
+        RallyState::Initializing => ("Initializing...", Color::Blue),
+        RallyState::ReviewerReviewing => ("Reviewer reviewing...", Color::Yellow),
+        RallyState::RevieweeFix => ("Reviewee fixing...", Color::Cyan),
+        RallyState::WaitingForClarification => ("Waiting for clarification", Color::Magenta),
+        RallyState::WaitingForPermission => ("Waiting for permission", Color::Magenta),
+        RallyState::Completed => ("Completed!", Color::Green),
+        RallyState::Error => ("Error - Press A to view", Color::Red),
+    };
+
+    let status = format!(
+        " [Rally: {} ({}/{})] ",
+        text, rally_state.iteration, rally_state.max_iterations
+    );
+
+    let bar = Paragraph::new(status)
+        .style(Style::default().fg(color).add_modifier(Modifier::BOLD))
+        .alignment(Alignment::Center);
+    frame.render_widget(bar, area);
+}

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -10,35 +10,73 @@ use syntect::easy::HighlightLines;
 use crate::app::App;
 use crate::diff::{classify_line, LineType};
 use crate::syntax::{get_theme, highlight_code_line, syntax_for_file};
+use super::common::render_rally_status_bar;
 
 pub fn render(frame: &mut Frame, app: &App) {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
+    let has_rally = app.has_background_rally();
+    let constraints = if has_rally {
+        vec![
+            Constraint::Length(3), // Header
+            Constraint::Min(0),    // Diff content
+            Constraint::Length(1), // Rally status bar
+            Constraint::Length(3), // Footer
+        ]
+    } else {
+        vec![
             Constraint::Length(3), // Header
             Constraint::Min(0),    // Diff content
             Constraint::Length(3), // Footer
-        ])
+        ]
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
         .split(frame.area());
 
     render_header(frame, app, chunks[0]);
     render_diff_content(frame, app, chunks[1]);
-    render_footer(frame, chunks[2]);
+
+    // Rally status bar (if background rally exists)
+    if has_rally {
+        render_rally_status_bar(frame, chunks[2], app);
+        render_footer(frame, chunks[3]);
+    } else {
+        render_footer(frame, chunks[2]);
+    }
 }
 
 pub fn render_with_preview(frame: &mut Frame, app: &App) {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
+    let has_rally = app.has_background_rally();
+    let constraints = if has_rally {
+        vec![
+            Constraint::Length(3),      // Header
+            Constraint::Percentage(55), // Diff content (slightly reduced)
+            Constraint::Length(1),      // Rally status bar
+            Constraint::Percentage(40), // Comment preview
+        ]
+    } else {
+        vec![
             Constraint::Length(3),      // Header
             Constraint::Percentage(60), // Diff content
             Constraint::Percentage(40), // Comment preview
-        ])
+        ]
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
         .split(frame.area());
 
     render_header(frame, app, chunks[0]);
     render_diff_content(frame, app, chunks[1]);
-    render_comment_preview(frame, app, chunks[2]);
+
+    if has_rally {
+        render_rally_status_bar(frame, chunks[2], app);
+        render_comment_preview(frame, app, chunks[3]);
+    } else {
+        render_comment_preview(frame, app, chunks[2]);
+    }
 }
 
 fn render_header(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
@@ -204,18 +242,36 @@ fn render_comment_preview(frame: &mut Frame, app: &App, area: ratatui::layout::R
 }
 
 pub fn render_with_suggestion_preview(frame: &mut Frame, app: &App) {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
+    let has_rally = app.has_background_rally();
+    let constraints = if has_rally {
+        vec![
+            Constraint::Length(3),      // Header
+            Constraint::Percentage(45), // Diff content (slightly reduced)
+            Constraint::Length(1),      // Rally status bar
+            Constraint::Percentage(50), // Suggestion preview
+        ]
+    } else {
+        vec![
             Constraint::Length(3),      // Header
             Constraint::Percentage(50), // Diff content
             Constraint::Percentage(50), // Suggestion preview
-        ])
+        ]
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
         .split(frame.area());
 
     render_header(frame, app, chunks[0]);
     render_diff_content(frame, app, chunks[1]);
-    render_suggestion_preview(frame, app, chunks[2]);
+
+    if has_rally {
+        render_rally_status_bar(frame, chunks[2], app);
+        render_suggestion_preview(frame, app, chunks[3]);
+    } else {
+        render_suggestion_preview(frame, app, chunks[2]);
+    }
 }
 
 fn render_suggestion_preview(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 mod ai_rally;
 mod comment_list;
+mod common;
 mod diff_view;
 mod file_list;
 mod help;


### PR DESCRIPTION
## Summary
- AI Rally実行中に`b`キーでバックグラウンド実行を維持しながら他の画面に移動できる機能を追加
- バックグラウンドRally存在時、全画面（FileList, DiffView, CommentList）にステータスバーを表示
- `A`キーで既存Rallyがあれば画面遷移のみ（Resume Rally）、なければ新規Rally開始

## Test plan
- [ ] AI Rally開始 → `b`キーでFileListに戻る → ステータスバー表示確認
- [ ] FileListで他の操作（ファイル閲覧など）を行い、`A`キーでAI Rally画面に戻る
- [ ] DiffView画面でもステータスバー表示確認
- [ ] CommentList画面でもステータスバー表示確認
- [ ] Rally完了後、ステータスバーが「Completed!」と表示されることを確認
- [ ] `q`キーでRally中止 → 完全に終了し、ステータスバーが消えることを確認
- [ ] `cargo test` - 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)