### PR TITLE
fix: DiffViewでインラインコメントを常に表示する

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -712,6 +712,12 @@ impl App {
                     self.selected_line = 0;
                     self.scroll_offset = 0;
                     self.update_diff_line_count();
+
+                    // コメント未取得の場合、バックグラウンドでロード開始
+                    if self.review_comments.is_none() {
+                        self.load_review_comments();
+                    }
+
                     self.update_file_comment_positions();
                     self.ensure_diff_cache();
                 }


### PR DESCRIPTION
## Summary

- ファイル一覧から直接 DiffView に遷移した際にもレビューコメントをロードし、インラインコメント（`●` マーカー + コメントパネル）が表示されるように修正
- 従来はコメント一覧画面（`C`キー）を一度開かないとコメントが表示されなかった
- `review_comments` が未取得の場合のみ `load_review_comments()` を呼び出すため、既存フローへの影響なし

## Test plan

- [x] `cargo build` コンパイル確認
- [x] `cargo test` 全テスト通過確認（68 + 3）
- [ ] コメント付き PR に対して起動し、ファイル一覧から直接 Enter でファイルを開き `●` マーカーが表示されることを確認
- [ ] コメント行を選択するとコメントパネルが表示されることを確認
- [ ] `n`/`N` でコメント間ジャンプが動作することを確認
- [ ] `C` キーからの既存フローが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)