### PR TITLE
feat: replace static loading icon with braille spinner animation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,8 @@ use crate::loader::{CommentSubmitResult, DataLoadResult};
 use crate::ui;
 use std::time::Instant;
 
+const SPINNER_FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
 /// コメントのdiff内位置を表す構造体
 #[derive(Debug, Clone)]
 pub struct CommentPosition {
@@ -211,6 +213,8 @@ pub struct App {
     pub submission_result: Option<(bool, String)>,
     /// Timestamp when result was set (for auto-hide)
     submission_result_time: Option<Instant>,
+    /// Spinner animation frame counter (incremented each tick)
+    pub spinner_frame: usize,
 }
 
 impl App {
@@ -262,6 +266,7 @@ impl App {
             comment_submitting: false,
             submission_result: None,
             submission_result_time: None,
+            spinner_frame: 0,
         };
 
         (app, tx)
@@ -321,6 +326,7 @@ impl App {
             comment_submitting: false,
             submission_result: None,
             submission_result_time: None,
+            spinner_frame: 0,
         };
 
         (app, tx)
@@ -340,6 +346,7 @@ impl App {
         }
 
         while !self.should_quit {
+            self.spinner_frame = self.spinner_frame.wrapping_add(1);
             self.poll_data_updates();
             self.poll_comment_updates();
             self.poll_discussion_comment_updates();
@@ -356,6 +363,11 @@ impl App {
 
         ui::restore_terminal(&mut terminal)?;
         Ok(())
+    }
+
+    /// Get the current spinner character for loading animations
+    pub fn spinner_char(&self) -> &str {
+        SPINNER_FRAMES[self.spinner_frame % SPINNER_FRAMES.len()]
     }
 
     pub fn set_working_dir(&mut self, dir: Option<String>) {

--- a/src/ui/comment_list.rs
+++ b/src/ui/comment_list.rs
@@ -126,11 +126,11 @@ fn render_tab_header(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) 
         Style::default().fg(Color::DarkGray)
     };
 
-    let loading_indicator = |loading: bool| {
+    let loading_indicator = |loading: bool| -> String {
         if loading {
-            " ..."
+            format!(" {}", app.spinner_char())
         } else {
-            ""
+            String::new()
         }
     };
 

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -362,7 +362,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     if app.is_submitting_comment() {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
-            "⏳ Submitting...",
+            format!("{} Submitting...", app.spinner_char()),
             Style::default().fg(Color::Yellow),
         ));
     } else if let Some((success, message)) = &app.submission_result {
@@ -381,7 +381,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     } else if app.comments_loading {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
-            "⏳ Loading comments...",
+            format!("{} Loading comments...", app.spinner_char()),
             Style::default().fg(Color::Yellow),
         ));
     }

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -131,7 +131,7 @@ pub fn render_loading(frame: &mut Frame, app: &App) {
     frame.render_widget(header, chunks[0]);
 
     // Loading message
-    let loading = Paragraph::new("Loading PR data...")
+    let loading = Paragraph::new(format!("{} Loading PR data...", app.spinner_char()))
         .style(Style::default().fg(Color::Yellow))
         .alignment(Alignment::Center)
         .block(
@@ -142,8 +142,8 @@ pub fn render_loading(frame: &mut Frame, app: &App) {
     frame.render_widget(loading, chunks[1]);
 
     // Footer
-    let footer =
-        Paragraph::new("Please wait... (q: quit)").block(Block::default().borders(Borders::ALL));
+    let footer = Paragraph::new(format!("{} Please wait... (q: quit)", app.spinner_char()))
+        .block(Block::default().borders(Borders::ALL));
     frame.render_widget(footer, chunks[2]);
 }
 


### PR DESCRIPTION
## Summary
- ローディング/サブミット中の静的な `⏳` アイコンと `...` インジケータを braille スピナーアニメーション (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) に置換
- `App` 構造体に `spinner_frame` カウンタを追加し、100ms ポーリング間隔でフレームを切り替え
- DiffView フッター、CommentList ヘッダー、FileList ローディング画面の4箇所に適用

## Test plan
- [x] `cargo build` でコンパイル確認
- [x] `cargo test` で全68テストパス確認
- [ ] TUI を起動し、PR データローディング中にスピナーが回転することを目視確認
- [ ] DiffView でコメント送信中にスピナーが表示されることを確認
- [ ] CommentList でコメントロード中にタブヘッダーにスピナーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)