### PR TITLE
fix: unify keybinding display format to j/k/↑↓

### DIFF
--- a/src/ui/ai_rally.rs
+++ b/src/ui/ai_rally.rs
@@ -289,7 +289,7 @@ fn render_logs(frame: &mut Frame, area: Rect, state: &mut AiRallyState) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(format!(
-            " Logs ({}/{}) [↑↓ select, Enter: detail] ",
+            " Logs ({}/{}) [j/k/↑↓: select, Enter: detail] ",
             scroll_offset.saturating_add(visible_height).min(total_logs),
             total_logs
         ))
@@ -435,15 +435,15 @@ fn render_status_bar(frame: &mut Frame, area: Rect, state: &AiRallyState) {
     } else {
         match state.state {
             RallyState::WaitingForClarification => {
-                "y: Open editor | n: Skip | ↑↓: Select | Enter: Detail | q: Abort"
+                "y: Open editor | n: Skip | j/k/↑↓: select | Enter: detail | q: Abort"
             }
             RallyState::WaitingForPermission => {
-                "y: Approve | n: Deny | ↑↓: Select | Enter: Detail | q: Abort"
+                "y: Approve | n: Deny | j/k/↑↓: select | Enter: detail | q: Abort"
             }
-            RallyState::Completed => "↑↓: Select | Enter: Detail | b: Background | q: Close",
-            RallyState::Aborted => "↑↓: Select | Enter: Detail | b: Background | q: Close",
-            RallyState::Error => "r: Retry | ↑↓: Select | Enter: Detail | b: Background | q: Close",
-            _ => "↑↓: Select | Enter: Detail | b: Background | q: Abort",
+            RallyState::Completed => "j/k/↑↓: select | Enter: detail | b: Background | q: Close",
+            RallyState::Aborted => "j/k/↑↓: select | Enter: detail | b: Background | q: Close",
+            RallyState::Error => "r: Retry | j/k/↑↓: select | Enter: detail | b: Background | q: Close",
+            _ => "j/k/↑↓: select | Enter: detail | b: Background | q: Abort",
         }
     };
 

--- a/src/ui/comment_list.rs
+++ b/src/ui/comment_list.rs
@@ -95,8 +95,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     // Footer
     let footer_chunk_idx = if has_rally { 3 } else { 2 };
     let footer_text = match app.comment_tab {
-        CommentTab::Review => "j/k: move | Enter: jump to file | [/]: switch tab | q: back",
-        CommentTab::Discussion => "j/k: move | Enter: view detail | [/]: switch tab | q: back",
+        CommentTab::Review => "j/k/↑↓: move | Enter: jump to file | [/]: switch tab | q: back",
+        CommentTab::Discussion => "j/k/↑↓: move | Enter: view detail | [/]: switch tab | q: back",
     };
     let footer = Paragraph::new(footer_text).block(Block::default().borders(Borders::ALL));
     frame.render_widget(footer, chunks[footer_chunk_idx]);
@@ -416,7 +416,7 @@ fn render_discussion_detail(frame: &mut Frame, app: &App) {
 
     // Footer
     let footer_chunk_idx = if has_rally { 3 } else { 2 };
-    let footer = Paragraph::new("j/k: scroll | Ctrl+d/u: page | Enter/Esc: back to list")
+    let footer = Paragraph::new("j/k/↑↓: scroll | Ctrl+d/u: page | Enter/Esc: back to list")
         .block(Block::default().borders(Borders::ALL));
     frame.render_widget(footer, chunks[footer_chunk_idx]);
 }

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -359,9 +359,9 @@ fn highlight_or_fallback(
 
 fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     let help_text = if app.comment_panel_open {
-        "j/k: scroll | n/N: jump | Tab: switch | r: reply | c: comment | s: suggest | ←/h: back | Esc/q: close"
+        "j/k/↑↓: scroll | n/N: jump | Tab: switch | r: reply | c: comment | s: suggest | ←/h: back | Esc/q: close"
     } else {
-        "j/k: move | n/N: next/prev comment | Enter: comments | Ctrl-d/u: page | ←/h/q: back"
+        "j/k/↑↓: move | n/N: next/prev comment | Enter: comments | Ctrl-d/u: page | ←/h/q: back"
     };
 
     // Build footer content with submission status
@@ -579,7 +579,7 @@ fn render_inline_comments(frame: &mut Frame, app: &App, area: ratatui::layout::R
         }
     }
 
-    let title = "Comments (j/k: scroll, c: comment, s: suggest, r: reply)";
+    let title = "Comments (j/k/↑↓: scroll, c: comment, s: suggest, r: reply)";
 
     let paragraph = Paragraph::new(lines)
         .block(

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -70,7 +70,7 @@ pub fn render(frame: &mut Frame, app: &App) {
         "A: AI Rally"
     };
     let footer_text = format!(
-        "j/k: move | Enter/→/l: split view | a: approve | r: request changes | c: comment | C: comments | {} | R: refresh | q: quit | ?: help",
+        "j/k/↑↓: move | Enter/→/l: split view | a: approve | r: request changes | c: comment | C: comments | {} | R: refresh | q: quit | ?: help",
         ai_rally_text
     );
     let footer = Paragraph::new(footer_text).block(Block::default().borders(Borders::ALL));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -117,7 +117,7 @@ fn render_symbol_popup(frame: &mut Frame, popup: &crate::app::SymbolPopupState) 
     let list = List::new(items).block(
         Block::default()
             .borders(Borders::ALL)
-            .title("Select symbol (j/k: move, Enter: jump, Esc: cancel)")
+            .title("Select symbol (j/k/↑↓: move, Enter: jump, Esc: cancel)")
             .border_style(Style::default().fg(Color::Cyan)),
     );
 

--- a/src/ui/split_view.rs
+++ b/src/ui/split_view.rs
@@ -100,7 +100,7 @@ fn render_file_list_pane(
 
     // Footer
     let footer_text = if is_focused {
-        "j/k: move | Enter/→/l: diff | ←/h/q: back"
+        "j/k/↑↓: move | Enter/→/l: diff | ←/h/q: back"
     } else {
         "←/h: focus files"
     };
@@ -150,7 +150,7 @@ fn render_diff_pane_normal(
 
     // Footer
     let footer_text = if is_focused {
-        "j/k: scroll | n/N: next/prev comment | Enter: comments | →/l: fullscreen | ←/h: files | q: back"
+        "j/k/↑↓: scroll | n/N: next/prev comment | Enter: comments | →/l: fullscreen | ←/h: files | q: back"
     } else {
         "Enter/→: focus diff"
     };
@@ -261,7 +261,7 @@ fn render_diff_pane_with_comments(
         }
     }
 
-    let title = "Comments (j/k: scroll, c: comment, s: suggest, r: reply)";
+    let title = "Comments (j/k/↑↓: scroll, c: comment, s: suggest, r: reply)";
 
     let paragraph = Paragraph::new(lines)
         .block(
@@ -275,7 +275,7 @@ fn render_diff_pane_with_comments(
     frame.render_widget(paragraph, chunks[2]);
 
     // Footer
-    let footer_text = "j/k: scroll | n/N: jump | Tab: switch | r: reply | c: comment | s: suggest | →/l: fullscreen | ←/h/q: close";
+    let footer_text = "j/k/↑↓: scroll | n/N: jump | Tab: switch | r: reply | c: comment | s: suggest | →/l: fullscreen | ←/h/q: close";
     render_diff_footer(frame, app, chunks[3], footer_text, border_color);
 }
 


### PR DESCRIPTION
## Summary
- キーバインド表示を `j/k/↑↓` 形式に統一
- 一部の画面で `↑↓: Select`、他の画面で `j/k: move` と表示が混在していた問題を修正
- 対象: ai_rally, comment_list, diff_view, file_list, mod, split_view

## Test plan
- [x] `cargo build` 成功
- [x] `cargo test` 全テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)