### PR TITLE
feat: add fallback for large diff files using gh pr diff

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,6 +1,8 @@
 use tokio::sync::mpsc;
+use tracing::warn;
 
 use crate::cache;
+use crate::diff;
 use crate::github::{self, ChangedFile, PullRequest};
 
 pub enum DataLoadResult {
@@ -51,7 +53,32 @@ async fn fetch_and_send(repo: &str, pr_number: u32, tx: mpsc::Sender<DataLoadRes
         github::fetch_pr(repo, pr_number),
         github::fetch_changed_files(repo, pr_number)
     ) {
-        Ok((pr, files)) => {
+        Ok((pr, mut files)) => {
+            // Check if any files have missing patches (large file limitation)
+            let has_missing_patches = files.iter().any(|f| f.patch.is_none());
+
+            if has_missing_patches {
+                // Fetch full diff using gh pr diff as fallback
+                match github::fetch_pr_diff(repo, pr_number).await {
+                    Ok(full_diff) => {
+                        let mut patch_map = diff::parse_unified_diff(&full_diff);
+
+                        // Apply patches only to files that are missing them
+                        for file in files.iter_mut() {
+                            if file.patch.is_none() {
+                                if let Some(patch) = patch_map.remove(&file.filename) {
+                                    file.patch = Some(patch);
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // Fallback failed, log warning and continue with "No diff available"
+                        warn!("Failed to fetch full diff for fallback: {}", e);
+                    }
+                }
+            }
+
             if let Err(e) = cache::write_cache(repo, pr_number, &pr, &files) {
                 eprintln!("Warning: Failed to write cache: {}", e);
             }


### PR DESCRIPTION
## Summary

- GitHub APIが大きなファイル（約10000行以上）で`patch`フィールドを返さない問題に対応
- `gh pr diff`でフルdiffを取得するフォールバック機構を実装
- unified diff形式のパーサーを追加し、ファイル名→patchのマッピングを生成

## Changes

### `src/diff/mod.rs`
- `parse_unified_diff()`: unified diff出力をファイル名→patchのHashMapに分割
- `extract_filename()`: `diff --git`行からファイル名を抽出（`a/`プレフィックス除去）
- 18件のテスト追加（単一/複数ファイル、新規/削除/リネーム/バイナリファイル対応）

### `src/loader.rs`
- `fetch_and_send()`を修正し、`patch`が空のファイルがある場合にフォールバック処理を実行
- フォールバック失敗時は警告ログを出力し、既存動作（"No diff available"）を維持

## Test plan

- [ ] 大きなファイルを含むPRで`--refresh`付きで起動し、diffが表示されることを確認
- [ ] 通常サイズのPRでregressionがないことを確認
- [ ] `cargo test diff::`でユニットテストが全てpassすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)