### PR TITLE
docs: add usage example for opening PR list

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -59,8 +59,8 @@ or
 # 3. 特定の PR を開く
 or --repo owner/repo --pr 123
 
-# 4. AI Rally を直接開始
-or --pr 123 --ai-rally
+# 4. AI Rally を開始（PR 選択後に自動開始）
+or --ai-rally
 ```
 
 ### オプション

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ or
 # 3. Open specific PR
 or --repo owner/repo --pr 123
 
-# 4. Start AI Rally directly on a PR
-or --pr 123 --ai-rally
+# 4. Start AI Rally (select PR from list, then auto-start)
+or --ai-rally
 ```
 
 ### Options


### PR DESCRIPTION
## Summary
- Document that `or` command without arguments opens the PR list for the current repository
- Repository is auto-detected from git remote

## Test plan
- [x] Verify README.md updated
- [x] Verify README-jp.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)