### PR TITLE
refactor: footer shows full-width status during submission

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3660,6 +3660,85 @@ impl App {
             self.state = AppState::PullRequestList;
         }
     }
+
+    /// Create a minimal App instance for unit tests outside of app.rs.
+    #[cfg(test)]
+    pub fn new_for_test() -> Self {
+        let config = Config::default();
+        Self {
+            repo: "test/repo".to_string(),
+            pr_number: Some(1),
+            data_state: DataState::Loading,
+            state: AppState::FileList,
+            pr_list: None,
+            selected_pr: 0,
+            pr_list_scroll_offset: 0,
+            pr_list_loading: false,
+            pr_list_has_more: false,
+            pr_list_state_filter: PrStateFilter::default(),
+            started_from_pr_list: false,
+            pr_list_receiver: None,
+            diff_view_return_state: AppState::FileList,
+            preview_return_state: AppState::DiffView,
+            previous_state: AppState::FileList,
+            selected_file: 0,
+            file_list_scroll_offset: 0,
+            selected_line: 0,
+            diff_line_count: 0,
+            scroll_offset: 0,
+            input_mode: None,
+            input_text_area: TextArea::with_submit_key(config.keybindings.submit.clone()),
+            config,
+            should_quit: false,
+            review_comments: None,
+            selected_comment: 0,
+            comment_list_scroll_offset: 0,
+            comments_loading: false,
+            file_comment_positions: vec![],
+            file_comment_lines: HashSet::new(),
+            comment_panel_open: false,
+            comment_panel_scroll: 0,
+            diff_cache: None,
+            highlighted_cache_store: HashMap::new(),
+            discussion_comments: None,
+            selected_discussion_comment: 0,
+            discussion_comment_list_scroll_offset: 0,
+            discussion_comments_loading: false,
+            discussion_comment_detail_mode: false,
+            discussion_comment_detail_scroll: 0,
+            comment_tab: CommentTab::default(),
+            ai_rally_state: None,
+            working_dir: None,
+            data_receiver: None,
+            retry_sender: None,
+            comment_receiver: None,
+            diff_cache_receiver: None,
+            prefetch_receiver: None,
+            discussion_comment_receiver: None,
+            rally_event_receiver: None,
+            rally_abort_handle: None,
+            rally_command_sender: None,
+            start_ai_rally_on_load: false,
+            pending_ai_rally: false,
+            comment_submit_receiver: None,
+            comment_submitting: false,
+            submission_result: None,
+            submission_result_time: None,
+            spinner_frame: 0,
+            selected_inline_comment: 0,
+            jump_stack: Vec::new(),
+            pending_keys: SmallVec::new(),
+            pending_since: None,
+            symbol_popup: None,
+            session_cache: SessionCache::new(),
+        }
+    }
+
+    /// Set the comment_submitting flag for testing.
+    #[cfg(test)]
+    pub fn set_submitting_for_test(&mut self, submitting: bool) {
+        self.comment_submitting = submitting;
+    }
 }
 
 #[cfg(test)]

--- a/src/ui/diff_view.rs
+++ b/src/ui/diff_view.rs
@@ -857,37 +857,8 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         "j/k/↑↓: move | n/N: next/prev comment | Enter: comments | Ctrl-d/u: page | ←/h/q: back"
     };
 
-    // Build footer content with submission status
-    let mut spans = vec![Span::raw(help_text)];
-
-    if app.is_submitting_comment() {
-        spans.push(Span::raw("  "));
-        spans.push(Span::styled(
-            format!("{} Submitting...", app.spinner_char()),
-            Style::default().fg(Color::Yellow),
-        ));
-    } else if let Some((success, message)) = &app.submission_result {
-        spans.push(Span::raw("  "));
-        if *success {
-            spans.push(Span::styled(
-                format!("✓ {}", message),
-                Style::default().fg(Color::Green),
-            ));
-        } else {
-            spans.push(Span::styled(
-                format!("✗ {}", message),
-                Style::default().fg(Color::Red),
-            ));
-        }
-    } else if app.comments_loading {
-        spans.push(Span::raw("  "));
-        spans.push(Span::styled(
-            format!("{} Loading comments...", app.spinner_char()),
-            Style::default().fg(Color::Yellow),
-        ));
-    }
-
-    let footer = Paragraph::new(Line::from(spans)).block(Block::default().borders(Borders::ALL));
+    let footer_line = super::footer::build_footer_line(app, help_text);
+    let footer = Paragraph::new(footer_line).block(Block::default().borders(Borders::ALL));
     frame.render_widget(footer, area);
 }
 

--- a/src/ui/footer.rs
+++ b/src/ui/footer.rs
@@ -1,0 +1,115 @@
+use ratatui::{
+    style::{Color, Style},
+    text::{Line, Span},
+};
+
+use crate::app::App;
+
+/// Build footer line content based on app state.
+///
+/// During submission or result display, the footer shows only the status
+/// (full-width override). Otherwise, it shows the normal help text with
+/// optional comments loading indicator appended.
+pub fn build_footer_line<'a>(app: &'a App, help_text: &'a str) -> Line<'a> {
+    if app.is_submitting_comment() {
+        Line::from(Span::styled(
+            format!("{} Submitting...", app.spinner_char()),
+            Style::default().fg(Color::Yellow),
+        ))
+    } else if let Some((success, message)) = &app.submission_result {
+        let (icon, color) = if *success {
+            ("\u{2713}", Color::Green)
+        } else {
+            ("\u{2717}", Color::Red)
+        };
+        Line::from(Span::styled(
+            format!("{} {}", icon, message),
+            Style::default().fg(color),
+        ))
+    } else {
+        let mut spans = vec![Span::raw(help_text)];
+        if app.comments_loading {
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(
+                format!("{} Loading comments...", app.spinner_char()),
+                Style::default().fg(Color::Yellow),
+            ));
+        }
+        Line::from(spans)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::App;
+
+    const HELP: &str = "j/k: move | q: quit";
+
+    fn line_to_string(line: &Line) -> String {
+        line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    #[test]
+    fn test_idle_shows_help_text_only() {
+        let app = App::new_for_test();
+        let line = build_footer_line(&app, HELP);
+        let text = line_to_string(&line);
+        assert_eq!(text, HELP);
+        assert_eq!(line.spans.len(), 1);
+    }
+
+    #[test]
+    fn test_comments_loading_appends_indicator() {
+        let mut app = App::new_for_test();
+        app.comments_loading = true;
+        let line = build_footer_line(&app, HELP);
+        let text = line_to_string(&line);
+        assert!(text.starts_with(HELP));
+        assert!(text.contains("Loading comments..."));
+        assert_eq!(line.spans.len(), 3); // help + "  " + loading
+    }
+
+    #[test]
+    fn test_submitting_shows_status_only() {
+        let mut app = App::new_for_test();
+        app.set_submitting_for_test(true);
+        let line = build_footer_line(&app, HELP);
+        let text = line_to_string(&line);
+        assert!(text.contains("Submitting..."));
+        assert!(!text.contains(HELP));
+        assert_eq!(line.spans.len(), 1);
+    }
+
+    #[test]
+    fn test_success_result_shows_checkmark_only() {
+        let mut app = App::new_for_test();
+        app.submission_result = Some((true, "Submitted".to_string()));
+        let line = build_footer_line(&app, HELP);
+        let text = line_to_string(&line);
+        assert!(text.contains("\u{2713}"));
+        assert!(text.contains("Submitted"));
+        assert!(!text.contains(HELP));
+        assert_eq!(line.spans.len(), 1);
+
+        // Check color is green
+        let style = line.spans[0].style;
+        assert_eq!(style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_error_result_shows_cross_only() {
+        let mut app = App::new_for_test();
+        app.submission_result = Some((false, "Failed: network error".to_string()));
+        let line = build_footer_line(&app, HELP);
+        let text = line_to_string(&line);
+        assert!(text.contains("\u{2717}"));
+        assert!(text.contains("Failed: network error"));
+        assert!(!text.contains(HELP));
+        assert_eq!(line.spans.len(), 1);
+
+        // Check color is red
+        let style = line.spans[0].style;
+        assert_eq!(style.fg, Some(Color::Red));
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@ mod comment_list;
 mod common;
 pub mod diff_view;
 mod file_list;
+mod footer;
 mod help;
 mod pr_list;
 mod split_view;

--- a/src/ui/split_view.rs
+++ b/src/ui/split_view.rs
@@ -203,36 +203,8 @@ fn render_diff_footer(
     help_text: &str,
     border_color: Color,
 ) {
-    let mut footer_spans = vec![Span::raw(help_text.to_string())];
-
-    if app.is_submitting_comment() {
-        footer_spans.push(Span::raw("  "));
-        footer_spans.push(Span::styled(
-            format!("{} Submitting...", app.spinner_char()),
-            Style::default().fg(Color::Yellow),
-        ));
-    } else if let Some((success, message)) = &app.submission_result {
-        footer_spans.push(Span::raw("  "));
-        if *success {
-            footer_spans.push(Span::styled(
-                format!("✓ {}", message),
-                Style::default().fg(Color::Green),
-            ));
-        } else {
-            footer_spans.push(Span::styled(
-                format!("✗ {}", message),
-                Style::default().fg(Color::Red),
-            ));
-        }
-    } else if app.comments_loading {
-        footer_spans.push(Span::raw("  "));
-        footer_spans.push(Span::styled(
-            format!("{} Loading comments...", app.spinner_char()),
-            Style::default().fg(Color::Yellow),
-        ));
-    }
-
-    let footer = Paragraph::new(Line::from(footer_spans)).block(
+    let footer_line = super::footer::build_footer_line(app, help_text);
+    let footer = Paragraph::new(footer_line).block(
         Block::default()
             .borders(Borders::ALL)
             .border_style(Style::default().fg(border_color)),


### PR DESCRIPTION
## Summary
- コメント送信中・結果表示中にフッター全域をステータス表示で上書きするよう変更
- `diff_view.rs` と `split_view.rs` で重複していたフッター構築ロジックを `footer.rs` の `build_footer_line()` に共通化
- 狭いターミナル幅でもステータス（特にエラー）が見切れなくなる

## Test plan
- [x] `cargo test` — 既存テスト + 新規ユニットテスト5件（submitting / success / error / idle+loading / idle）全パス
- [x] `cargo clippy` — 警告なし
- [ ] 狭いターミナル幅でコメント送信し、ステータスがフッター全域に表示されることを手動確認
- [ ] 3秒後にキーコンフィグ表示に戻ることを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)