### PR TITLE
Add --verbose to Claude adaptor calls

### DIFF
--- a/src/ai/adapters/claude.rs
+++ b/src/ai/adapters/claude.rs
@@ -104,6 +104,7 @@ impl ClaudeAdapter {
         let mut cmd = Command::new("claude");
         cmd.arg("-p").arg(prompt);
         cmd.arg("--output-format").arg("stream-json");
+        cmd.arg("--verbose");
         cmd.arg("--json-schema").arg(schema);
         cmd.arg("--allowedTools").arg(allowed_tools);
 
@@ -301,6 +302,7 @@ impl ClaudeAdapter {
         cmd.arg("-p").arg(message);
         cmd.arg("--resume").arg(session_id);
         cmd.arg("--output-format").arg("stream-json");
+        cmd.arg("--verbose");
         cmd.arg("--json-schema").arg(schema);
         if let Some(tools) = allowed_tools {
             cmd.arg("--allowedTools").arg(tools);


### PR DESCRIPTION
AI Rally mode was not working with claude code version 2.1.29 as it was not passing "--verbose" in the CLI args.

<img width="520" height="35" alt="image" src="https://github.com/user-attachments/assets/e2066a2c-e912-4683-b7c5-43230f8062fd" />
