### PR TITLE
fix: pipe prompts via stdin to avoid OS ARG_MAX limit

### DIFF
--- a/src/ai/orchestrator.rs
+++ b/src/ai/orchestrator.rs
@@ -211,7 +211,7 @@ impl Orchestrator {
                 Err(e) => {
                     self.session.update_state(RallyState::Error);
                     let _ = write_session(&self.session);
-                    self.send_event(RallyEvent::Error(format!("Reviewer failed: {}", e)))
+                    self.send_event(RallyEvent::Error(format!("Reviewer failed: {:#}", e)))
                         .await;
                     self.send_event(RallyEvent::StateChanged(RallyState::Error))
                         .await;
@@ -312,7 +312,7 @@ impl Orchestrator {
                 Err(e) => {
                     self.session.update_state(RallyState::Error);
                     let _ = write_session(&self.session);
-                    self.send_event(RallyEvent::Error(format!("Reviewee failed: {}", e)))
+                    self.send_event(RallyEvent::Error(format!("Reviewee failed: {:#}", e)))
                         .await;
                     self.send_event(RallyEvent::StateChanged(RallyState::Error))
                         .await;


### PR DESCRIPTION
## Summary

- Switch Claude/Codex adapters to pipe prompts via stdin instead of command-line arguments, avoiding OS `ARG_MAX` limit (~256KB on macOS) that caused `E2BIG` spawn failures on large PR diffs
- Improve error diagnostics: use anyhow alternate display (`{:#}`) for full error chain, include command details in spawn error context

Closes partially #68 (spawn failure fixed; context window limit is a separate issue)

## Test plan

- [ ] Run AI Rally on a normal-sized PR with both Claude and Codex adapters
- [ ] Run AI Rally on a large PR (confirm spawn succeeds, API may reject due to context window)
- [ ] Verify error messages show full error chain on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)