### PR TITLE
test: improve diff test coverage and fix clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -958,6 +958,8 @@ checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
  "console",
  "once_cell",
+ "pest",
+ "pest_derive",
  "serde",
  "similar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ predicates = "3.1.3"
 criterion = { version = "0.5.1", features = ["html_reports"] }
 rand = "0.9.1"
 rand_chacha = "0.9.0"
-insta = { version = "1.46.3", features = ["json"] }
+insta = { version = "1.46.3", features = ["json", "redactions"] }
 
 [[bench]]
 name = "ui_rendering"

--- a/src/ai/prompts.rs
+++ b/src/ai/prompts.rs
@@ -71,3 +71,78 @@ If you're completely uncertain, make minimal changes and document your assumptio
         question = question,
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+
+    #[test]
+    fn test_build_clarification_prompt() {
+        let result = build_clarification_prompt("How should error handling work?");
+        assert_snapshot!(result, @r#"
+        The developer has a question about your review feedback:
+
+        ## Question
+        How should error handling work?
+
+        Please provide a clear answer to help them proceed with the fixes.
+        After answering, provide an updated review if needed.
+        "#);
+    }
+
+    #[test]
+    fn test_build_permission_granted_prompt() {
+        let result = build_permission_granted_prompt("run npm install");
+        assert_snapshot!(result, @r#"
+        Permission has been granted for the following action:
+
+        run npm install
+
+        Please proceed with the implementation.
+        "#);
+    }
+
+    #[test]
+    fn test_build_permission_denied_prompt() {
+        let result = build_permission_denied_prompt("git push --force", "Need to update remote");
+        assert_snapshot!(result, @r#"
+        The user has DENIED permission for the following action:
+
+        ## Denied Action
+        git push --force
+
+        ## Original Reason
+        Need to update remote
+
+        ## Your Task
+
+        You CANNOT perform this action. Instead:
+        1. Find an alternative approach that doesn't require this permission
+        2. If no alternative exists, document what cannot be done and proceed with other fixes
+        3. If the fix is completely blocked, set status to "completed" with a summary explaining what couldn't be done
+
+        Do NOT ask for this permission again. Work within your current constraints.
+        "#);
+    }
+
+    #[test]
+    fn test_build_clarification_skipped_prompt() {
+        let result = build_clarification_skipped_prompt("What database should we use?");
+        assert_snapshot!(result, @r#"
+        The user chose NOT to answer your clarification question:
+
+        ## Unanswered Question
+        What database should we use?
+
+        ## Your Task
+
+        Proceed WITHOUT this clarification. Use your best judgment based on:
+        1. Common patterns and best practices
+        2. The context from the review feedback
+        3. Conservative assumptions (prefer safe, non-breaking changes)
+
+        If you're completely uncertain, make minimal changes and document your assumptions in the summary.
+        "#);
+    }
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -197,6 +197,11 @@ impl SessionCache {
     pub fn len(&self) -> usize {
         self.pr_data.len()
     }
+
+    #[cfg(test)]
+    pub fn is_empty(&self) -> bool {
+        self.pr_data.is_empty()
+    }
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -359,6 +359,7 @@ impl Config {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use insta::assert_json_snapshot;
 
     #[test]
     fn test_default_keybindings() {
@@ -404,5 +405,70 @@ mod tests {
         let config: Config = toml::from_str("").unwrap();
         assert_eq!(config.keybindings.approve.display(), "a");
         assert_eq!(config.keybindings.request_changes.display(), "r");
+    }
+
+    #[test]
+    fn test_parse_ai_config_defaults() {
+        let config: Config = toml::from_str("").unwrap();
+        assert_json_snapshot!(config.ai, @r#"
+        {
+          "reviewer": "claude",
+          "reviewee": "claude",
+          "max_iterations": 10,
+          "timeout_secs": 600,
+          "prompt_dir": null,
+          "reviewer_additional_tools": [],
+          "reviewee_additional_tools": []
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_parse_ai_config_custom() {
+        let toml_str = r#"
+            [ai]
+            reviewer = "codex"
+            reviewee = "claude"
+            max_iterations = 5
+            timeout_secs = 300
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_json_snapshot!(config.ai, @r#"
+        {
+          "reviewer": "codex",
+          "reviewee": "claude",
+          "max_iterations": 5,
+          "timeout_secs": 300,
+          "prompt_dir": null,
+          "reviewer_additional_tools": [],
+          "reviewee_additional_tools": []
+        }
+        "#);
+    }
+
+    #[test]
+    fn test_parse_ai_config_with_additional_tools() {
+        let toml_str = r#"
+            [ai]
+            reviewer_additional_tools = ["Skill", "WebSearch"]
+            reviewee_additional_tools = ["Bash(git push:*)"]
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_json_snapshot!(config.ai, @r#"
+        {
+          "reviewer": "claude",
+          "reviewee": "claude",
+          "max_iterations": 10,
+          "timeout_secs": 600,
+          "prompt_dir": null,
+          "reviewer_additional_tools": [
+            "Skill",
+            "WebSearch"
+          ],
+          "reviewee_additional_tools": [
+            "Bash(git push:*)"
+          ]
+        }
+        "#);
     }
 }

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -202,3 +202,29 @@ pub async fn fetch_pr_list_with_offset(
 
     Ok(PrListPage { items, has_more })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_pr_state_filter_as_gh_arg() {
+        assert_eq!(PrStateFilter::Open.as_gh_arg(), "open");
+        assert_eq!(PrStateFilter::Closed.as_gh_arg(), "closed");
+        assert_eq!(PrStateFilter::All.as_gh_arg(), "all");
+    }
+
+    #[test]
+    fn test_pr_state_filter_display_name() {
+        assert_eq!(PrStateFilter::Open.display_name(), "open");
+        assert_eq!(PrStateFilter::Closed.display_name(), "closed");
+        assert_eq!(PrStateFilter::All.display_name(), "all");
+    }
+
+    #[test]
+    fn test_pr_state_filter_next_cycle() {
+        assert_eq!(PrStateFilter::Open.next(), PrStateFilter::Closed);
+        assert_eq!(PrStateFilter::Closed.next(), PrStateFilter::All);
+        assert_eq!(PrStateFilter::All.next(), PrStateFilter::Open);
+    }
+}


### PR DESCRIPTION
## Summary
- diff/mod.rs と ui/diff_view.rs のテストカバレッジを向上（diff/mod.rs: 96.73% → 99.31%, ui/diff_view.rs: 54.31% → 67.33%）
- clippy 警告を全て解消（`field_reassign_with_default`, `len_without_is_empty`）
- 既存テストを insta snapshot アサーションに移行（ai/prompts, ai/session, config, github/pr, ai/adapters/claude）
- diff/mod.rs の到達不能デッドコードを削除

## Changes
### テスト追加（15テスト）
- `diff/mod.rs`: classify_line フォールバック、hunk header no-comma パス、extract_filename no-separator パス
- `ui/diff_view.rs`: syntect フォールバック、plain cache スタイル検証、parse_patch_to_lines、render_cached_lines 境界条件、build_combined_source_for_highlight

### Clippy 修正
- `ai/adapters/claude.rs`: `field_reassign_with_default` → struct 初期化構文に変更
- `cache.rs`: `len()` に対応する `is_empty()` 追加

### Snapshot テスト移行
- `ai/adapters/claude.rs`, `ai/prompts.rs`, `ai/session.rs`, `config.rs`, `github/pr.rs`

## Test plan
- [x] `cargo test` — 352 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features` — 警告なし
- [x] `cargo llvm-cov --lib` — カバレッジ改善確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)