### PR TITLE
fix: improve 422 error diagnostics for review comment creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,6 +1351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1408,6 +1426,7 @@ dependencies = [
  "tokio-util",
  "toml",
  "tracing",
+ "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
@@ -2154,6 +2173,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2481,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2604,6 +2641,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2902,6 +2969,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ syntect-tui = "3.0.4"
 two-face = { version = "0.5.1", default-features = false, features = ["syntect-default-fancy"] }
 async-trait = "0.1.88"
 tracing = "0.1.41"
+tracing-subscriber = { version = "0.3.22", features = ["fmt", "env-filter"] }
 chrono = "0.4.43"
 thiserror = "2.0.18"
 smallvec = "1.15.0"

--- a/src/github/comment.rs
+++ b/src/github/comment.rs
@@ -88,6 +88,7 @@ pub async fn create_review_comment(
             ("path", FieldValue::String(path)),
             ("line", FieldValue::Raw(&line_str)),
             ("side", FieldValue::String("RIGHT")),
+            ("subject_type", FieldValue::String("line")),
         ],
     )
     .await?;


### PR DESCRIPTION
## Summary

- `tracing-subscriber` を追加し、`OR_DEBUG=1` 環境変数でファイルログ (`~/.cache/octorus/debug.log`) を有効化。TUI の画面を壊さずにデバッグ可能に
- `gh_command` のエラーメッセージに stdout（API レスポンスボディ）を含めるよう改善。422 エラー時のバリデーション詳細がTUIフッターに表示される（最大200文字、ログには全文）
- `create_review_comment` に `subject_type: "line"` パラメータを追加（GitHub API ドキュメント推奨）
- `gh_api_post` にリクエスト引数のデバッグログを追加

## Test plan

- [x] `cargo check` pass
- [x] `cargo test` pass (381 tests)
- [x] `cargo clippy` pass (no warnings)
- [ ] `OR_DEBUG=1 or --repo owner/repo --pr 123` で `~/.cache/octorus/debug.log` にログ出力を確認
- [ ] コメント送信失敗時、フッターに API エラー詳細が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)