### PR TITLE
feat: add post confirmation for AI Rally review/fix posting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,10 @@ pub struct AiConfig {
     /// Use Claude Code's --allowedTools format (e.g., "Skill", "Bash(git push:*)").
     #[serde(default)]
     pub reviewee_additional_tools: Vec<String>,
+    /// If true, AI Rally posts reviews/fix comments to PR without confirmation.
+    /// Default is false (confirmation prompt before posting).
+    #[serde(default)]
+    pub auto_post: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -110,6 +114,7 @@ impl Default for AiConfig {
             prompt_dir: None,
             reviewer_additional_tools: Vec::new(),
             reviewee_additional_tools: Vec::new(),
+            auto_post: false,
         }
     }
 }
@@ -434,7 +439,8 @@ mod tests {
           "timeout_secs": 600,
           "prompt_dir": null,
           "reviewer_additional_tools": [],
-          "reviewee_additional_tools": []
+          "reviewee_additional_tools": [],
+          "auto_post": false
         }
         "#);
     }
@@ -457,7 +463,8 @@ mod tests {
           "timeout_secs": 300,
           "prompt_dir": null,
           "reviewer_additional_tools": [],
-          "reviewee_additional_tools": []
+          "reviewee_additional_tools": [],
+          "auto_post": false
         }
         "#);
     }
@@ -483,8 +490,25 @@ mod tests {
           ],
           "reviewee_additional_tools": [
             "Bash(git push:*)"
-          ]
+          ],
+          "auto_post": false
         }
         "#);
+    }
+
+    #[test]
+    fn test_parse_ai_config_auto_post_true() {
+        let toml_str = r#"
+            [ai]
+            auto_post = true
+        "#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.ai.auto_post);
+    }
+
+    #[test]
+    fn test_parse_ai_config_auto_post_default() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(!config.ai.auto_post);
     }
 }

--- a/src/ui/common.rs
+++ b/src/ui/common.rs
@@ -38,6 +38,7 @@ pub fn render_rally_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         RallyState::RevieweeFix => ("Reviewee fixing...", Color::Cyan),
         RallyState::WaitingForClarification => ("Waiting for clarification", Color::Magenta),
         RallyState::WaitingForPermission => ("Waiting for permission", Color::Magenta),
+        RallyState::WaitingForPostConfirmation => ("Waiting for post confirmation", Color::Magenta),
         RallyState::Completed => ("Completed!", Color::Green),
         RallyState::Aborted => ("Aborted - Press A to view", Color::Yellow),
         RallyState::Error => ("Error - Press A to view", Color::Red),


### PR DESCRIPTION
## Summary
- AI Rally の Reviewer/Reviewee 結果を PR に投稿する前にユーザー確認を挟む Human-in-the-loop 方式を実装
- `config.toml` の `auto_post = true` で確認スキップ（従来動作）、デフォルトは `false`（確認あり）
- `local_mode = true` の場合は投稿自体がスキップされるため確認も出さない
- 既存の WaitingForPermission / WaitingForClarification の y/n フローと同じ UI パターンを踏襲

## Changes
- `src/config.rs`: `AiConfig` に `auto_post: bool` フィールド追加（デフォルト `false`）
- `src/ai/orchestrator.rs`: `RallyState::WaitingForPostConfirmation`、`ReviewPostInfo`/`FixPostInfo` DTO、`OrchestratorCommand::PostConfirmResponse`、`maybe_post_review_to_pr`/`maybe_post_fix_comment` ラッパー追加。無効コマンドの loop + re-wait 化
- `src/app.rs`: `AiRallyState` にフィールド追加、イベント受信・キー入力ハンドリング、abort 伝播
- `src/ui/ai_rally.rs`: 確認プロンプト表示、ステータスバー・ヘッダー更新
- `src/ui/common.rs`: バックグラウンドステータスバーに新 state 追加

Closes #81

## Test plan
- [x] `cargo test` — 全テスト通過（388 passed）
- [x] `cargo clippy` — warning なし
- [ ] 手動テスト: `A` キーで AI Rally 開始 → 投稿前に確認プロンプト表示
- [ ] `y` で投稿、`n` でスキップ、`q` で中止
- [ ] `config.toml` に `auto_post = true` → 確認なしで従来動作
- [ ] `--local` モード → 確認プロンプトなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)