### PR TITLE
fix: add missing markdown_rich argument to benchmark calls

### DIFF
--- a/benches/ui_rendering.rs
+++ b/benches/ui_rendering.rs
@@ -49,6 +49,7 @@ fn bench_build_diff_cache(c: &mut Criterion) {
                             black_box("test.rs"),
                             black_box("base16-ocean.dark"),
                             black_box(&mut parser_pool),
+                            black_box(false),
                         ))
                     },
                     criterion::BatchSize::SmallInput,
@@ -84,6 +85,7 @@ fn bench_build_diff_cache_no_highlight(c: &mut Criterion) {
                             black_box("file.unknown_ext"),
                             black_box("base16-ocean.dark"),
                             black_box(&mut parser_pool),
+                            black_box(false),
                         ))
                     },
                     criterion::BatchSize::SmallInput,
@@ -105,7 +107,7 @@ fn bench_selected_line_rendering(c: &mut Criterion) {
     for line_count in [100, 500, 1000] {
         let patch = generate_diff_patch(line_count);
         let mut parser_pool = ParserPool::new();
-        let cache = build_diff_cache(&patch, "test.rs", "base16-ocean.dark", &mut parser_pool);
+        let cache = build_diff_cache(&patch, "test.rs", "base16-ocean.dark", &mut parser_pool, false);
         let empty_comments: HashSet<usize> = HashSet::new();
 
         // Benchmark current approach: resolve and clone each span, add REVERSED
@@ -182,7 +184,7 @@ fn bench_visible_range_processing(c: &mut Criterion) {
     for total_lines in [1000, 5000] {
         let patch = generate_diff_patch(total_lines);
         let mut parser_pool = ParserPool::new();
-        let cache = build_diff_cache(&patch, "test.rs", "base16-ocean.dark", &mut parser_pool);
+        let cache = build_diff_cache(&patch, "test.rs", "base16-ocean.dark", &mut parser_pool, false);
         let empty_comments: HashSet<usize> = HashSet::new();
 
         let visible_height = 50_usize;
@@ -270,6 +272,7 @@ fn bench_highlighter_tree_sitter_rust(c: &mut Criterion) {
                             black_box("test.rs"), // tree-sitter
                             black_box("Dracula"),
                             black_box(&mut parser_pool),
+                            black_box(false),
                         ))
                     },
                     criterion::BatchSize::SmallInput,
@@ -305,6 +308,7 @@ fn bench_highlighter_tree_sitter_haskell(c: &mut Criterion) {
                             black_box("test.hs"), // tree-sitter
                             black_box("Dracula"),
                             black_box(&mut parser_pool),
+                            black_box(false),
                         ))
                     },
                     criterion::BatchSize::SmallInput,
@@ -339,6 +343,7 @@ fn bench_highlighter_tree_sitter_vue(c: &mut Criterion) {
                             black_box("test.vue"), // tree-sitter with injection
                             black_box("Dracula"),
                             black_box(&mut parser_pool),
+                            black_box(false),
                         ))
                     },
                     criterion::BatchSize::SmallInput,
@@ -365,7 +370,7 @@ fn bench_archive_selected_line(c: &mut Criterion) {
     for line_count in [100, 500, 1000] {
         let patch = generate_diff_patch(line_count);
         let mut parser_pool = ParserPool::new();
-        let cache = build_diff_cache(&patch, "test.rs", "base16-ocean.dark", &mut parser_pool);
+        let cache = build_diff_cache(&patch, "test.rs", "base16-ocean.dark", &mut parser_pool, false);
 
         group.bench_with_input(
             BenchmarkId::new("line_style", line_count),
@@ -416,7 +421,7 @@ fn bench_archive_visible_range(c: &mut Criterion) {
     for total_lines in [1000, 5000] {
         let patch = generate_diff_patch(total_lines);
         let mut parser_pool = ParserPool::new();
-        let cache = build_diff_cache(&patch, "test.rs", "base16-ocean.dark", &mut parser_pool);
+        let cache = build_diff_cache(&patch, "test.rs", "base16-ocean.dark", &mut parser_pool, false);
 
         let visible_height = 50_usize;
         let scroll_offset = total_lines / 2;


### PR DESCRIPTION
## Summary
- `build_diff_cache` に追加された第5引数 `markdown_rich: bool` がベンチマークファイルで渡されておらずコンパイルエラーになっていた問題を修正
- `benches/ui_rendering.rs` の全9箇所の呼び出しに `false` を追加

## Test plan
- [x] `cargo build --release` 成功
- [x] `cargo bench --no-run` 成功
- [x] `cargo test` 全458テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)