### PR TITLE
Improve mark-file-as-viewed: PrReceiver unification, root V fix, v toggle

### DIFF
--- a/src/github/mod.rs
+++ b/src/github/mod.rs
@@ -7,6 +7,6 @@ pub use client::{detect_repo, gh_command, DetectRepoError};
 pub use comment::{create_reply_comment, create_review_comment};
 pub use pr::{
     fetch_changed_files, fetch_files_viewed_state, fetch_pr, fetch_pr_diff, fetch_pr_list,
-    fetch_pr_list_with_offset, mark_file_as_viewed, submit_review, Branch, ChangedFile, Label,
-    PrListPage, PrStateFilter, PullRequest, PullRequestSummary, User,
+    fetch_pr_list_with_offset, mark_file_as_viewed, submit_review, unmark_file_as_viewed, Branch,
+    ChangedFile, Label, PrListPage, PrStateFilter, PullRequest, PullRequestSummary, User,
 };

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -268,6 +268,31 @@ mutation($pullRequestId: ID!, $path: String!) {
     Ok(())
 }
 
+pub async fn unmark_file_as_viewed(_repo: &str, pr_node_id: &str, path: &str) -> Result<()> {
+    let query = r#"
+mutation($pullRequestId: ID!, $path: String!) {
+  unmarkFileAsViewed(input: { pullRequestId: $pullRequestId, path: $path }) {
+    clientMutationId
+  }
+}
+"#;
+
+    let response = gh_api_graphql(
+        query,
+        &[
+            ("pullRequestId", FieldValue::String(pr_node_id)),
+            ("path", FieldValue::String(path)),
+        ],
+    )
+    .await?;
+
+    if let Some(errors) = response.get("errors") {
+        anyhow::bail!("GitHub GraphQL returned errors: {}", errors);
+    }
+
+    Ok(())
+}
+
 /// ページネーション結果
 pub struct PrListPage {
     pub items: Vec<PullRequestSummary>,


### PR DESCRIPTION
## Summary

- `mark_viewed_receiver` を `PrReceiver<T>` パターンに統一し、クロスPR汚染を防止
- ルートファイル選択時の `V` キーが全ファイルを対象にしてしまうバグを修正（ルートレベルのファイルのみに限定）
- `v` キーで viewed/unviewed のトグルに対応（`unmarkFileAsViewed` GraphQL mutation 追加）

## Test plan

- [x] `cargo test --lib` — 全 470 テスト通過
- [x] `cargo clippy` — 警告なし
- [x] `cargo build` — ビルド成功
- [ ] 実PRで `v` キーによる viewed→unviewed トグルを確認
- [ ] 実PRでルートファイル選択時の `V` キーがルートレベルのみ対象になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)