### PR TITLE
docs: add bg_color setting to [diff] config example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Run `or init` to create default config files, or create `~/.config/octorus/confi
 theme = "base16-ocean.dark"
 # Number of spaces per tab character in diff view (minimum: 1)
 tab_width = 4
+# Show background color on added/removed lines (default: true)
+# bg_color = false
 
 [keybindings]
 # See "Configurable Keybindings" section below for all options


### PR DESCRIPTION
The DiffConfig struct has a bg_color field that controls background
colors on added/removed diff lines, but it was not documented in the
README configuration example.

https://claude.ai/code/session_01GveZcZZXXVvnSvv6Q91ScT