### PR TITLE
feat: ヘルプ画面にスクロール機能を追加

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3582,10 +3582,11 @@ impl App {
         let visible_lines = terminal_height.saturating_sub(Self::HELP_VIEWPORT_OVERHEAD) as usize;
         let half_page = (visible_lines / 2).max(1);
 
-        if matches!(
-            key.code,
-            KeyCode::Char('q') | KeyCode::Esc | KeyCode::Char('?')
-        ) {
+        let kb = &self.config.keybindings;
+        if self.matches_single_key(&key, &kb.quit)
+            || self.matches_single_key(&key, &kb.help)
+            || key.code == KeyCode::Esc
+        {
             self.state = self.previous_state;
         } else if Self::is_shift_char_shortcut(&key, 'j') {
             // Page down (J / Shift+j)

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -70,7 +70,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
     // Scrollbar
     if total_lines > content_height {
-        let mut scrollbar_state = ScrollbarState::new(max_scroll)
+        let mut scrollbar_state = ScrollbarState::new(max_scroll + 1)
             .position(app.help_scroll_offset);
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)


### PR DESCRIPTION
ヘルプ画面（?キー）のコンテンツが画面に収まらない場合に
見切れていた問題を修正。j/k, J/K, g/G, Ctrl-d/Ctrl-u で
スクロール可能に。スクロールバーとスクロール位置表示も追加。

https://claude.ai/code/session_01GctpNCmnuzpDfDcDFB2Ruh