### PR TITLE
feat: output JSON summary to stdout on headless AI Rally completion

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,15 +148,25 @@ async fn main() -> Result<()> {
     if args.ai_rally && args.pr.is_some() {
         let pr = args.pr.unwrap();
         let working_dir = resolve_working_dir(&args);
-        let approved =
-            headless::run_headless_rally(&repo, pr, &config, working_dir.as_deref()).await?;
-        std::process::exit(if approved { 0 } else { 1 });
+        match headless::run_headless_rally(&repo, pr, &config, working_dir.as_deref()).await {
+            Ok(approved) => std::process::exit(if approved { 0 } else { 1 }),
+            Err(e) => {
+                headless::write_error_json(&e.to_string());
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
     }
     if args.local && args.ai_rally {
         let working_dir = resolve_working_dir(&args);
-        let approved =
-            headless::run_headless_rally_local(&repo, &config, working_dir.as_deref()).await?;
-        std::process::exit(if approved { 0 } else { 1 });
+        match headless::run_headless_rally_local(&repo, &config, working_dir.as_deref()).await {
+            Ok(approved) => std::process::exit(if approved { 0 } else { 1 }),
+            Err(e) => {
+                headless::write_error_json(&e.to_string());
+                eprintln!("Error: {}", e);
+                std::process::exit(1);
+            }
+        }
     }
 
     if args.local {


### PR DESCRIPTION
## Summary

- Headless AI Rally 完了時に最終結果を JSON で stdout に出力するようにした
- stderr の進捗ログは従来通り維持し、stdout に構造化 JSON を追加
- 早期エラー（PR取得失敗等）時も `write_error_json` でエラー JSON を出力

## Changes

- `HeadlessJsonOutput` / `HeadlessOutcome` 構造体を追加
- イベントループで `iterations`, `last_review`, `last_fix` を追跡
- `build_json_output` 純粋関数 + `write_json_stdout` ヘルパー
- `Approved` の summary にレビュワーの実際のメッセージを伝搬
- insta snapshot テスト 3 件（approved / not_approved / error）

## Output example

```json
{"result":"approved","iterations":2,"summary":"No blocking issues found.","last_review":{...},"last_fix":{...}}
```

```json
{"result":"error","iterations":0,"summary":"gh: Could not resolve to a PullRequest"}
```

## Test plan

- [x] `cargo test` — 全 528 テスト pass
- [x] `cargo clippy` — 新規 warning なし
- [x] `or --local --ai-rally` で実行確認済み（Approved, exit code 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)