### PR TITLE
feat: add local mode comments and AI Rally seed review support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ or --local
 | `or init --local` | Initialize project-local `.octorus/` config and prompts |
 | `or init --force` | Overwrite existing configuration files |
 | `or clean` | Remove AI Rally session data |
+| `or local-comments` | Show saved local comments for the current worktree |
+| `or update-local-comment` | Resolve or reopen local comments by ID |
 
 `or init` creates global config:
 - `~/.config/octorus/config.toml` - Main configuration file
@@ -146,11 +148,41 @@ Running `or` with no flags opens the Cockpit — a dashboard that serves as the 
 - Preview uncommitted changes (`git diff HEAD`) without creating a PR
 - Real-time file watching — diff refreshes automatically on save (ignoring `.git/` internals)
 - Auto-focus mode (`--auto-focus` or `F` key) — automatically selects the most recently changed file
+- **Local comments** — leave review comments on your own diff, persisted to disk across sessions
 - Header shows `[LOCAL]` or `[LOCAL AF]` when auto-focus is active
 
 ```bash
 or --local
 or --local --auto-focus
+```
+
+#### Local Comments
+
+In local mode, you can leave review comments on diff lines just like on a GitHub PR. Comments are saved to `~/.cache/octorus/local-comments/` and persist across sessions, scoped by repo and working directory.
+
+- Press `c` on a diff line to add a comment, `s` for a suggestion, `r` to reply
+- Press `C` to view all local comments in the comment list
+- Comments can be resolved and reopened
+
+Local comments can also seed AI Rally — when you start a rally in local mode, any open local comments are passed to the reviewer as a starting point, skipping the initial review step.
+
+**CLI subcommands** for managing local comments outside the TUI:
+
+```bash
+# Show open local comments (auto-detects repo)
+or local-comments
+
+# Show all comments including resolved
+or local-comments --all
+
+# Show as JSON
+or local-comments --json
+
+# Resolve a comment
+or update-local-comment --resolve 3
+
+# Reopen a comment
+or update-local-comment --reopen 3
 ```
 
 ### Git Ops

--- a/src/ai/orchestrator.rs
+++ b/src/ai/orchestrator.rs
@@ -246,8 +246,9 @@ impl Orchestrator {
                 }
             }
 
-            let (review_result, seeded_review) = if iteration == 1 {
-                if let Some(review) = self.seed_review.take() {
+            let (review_result, seeded_review) =
+                if iteration == 1 && self.seed_review.is_some() {
+                    let review = self.seed_review.take().unwrap();
                     self.send_event(RallyEvent::Log(format!(
                         "Using {} local comment{} as the initial review seed",
                         review.comments.len(),
@@ -256,61 +257,9 @@ impl Orchestrator {
                     .await;
                     (review, true)
                 } else {
-                    self.session.update_state(RallyState::ReviewerReviewing);
-                    self.send_event(RallyEvent::StateChanged(RallyState::ReviewerReviewing))
-                        .await;
-                    if let Err(e) = write_session(&self.session) {
-                        warn!("Failed to write session: {}", e);
-                        self.send_event(RallyEvent::Log(format!(
-                            "Warning: Failed to write session: {}",
-                            e
-                        )))
-                        .await;
-                    }
-
-                    let review = match self.run_reviewer_with_timeout(&context, iteration).await {
-                        Ok(result) => result,
-                        Err(e) => {
-                            self.session.update_state(RallyState::Error);
-                            let _ = write_session(&self.session);
-                            self.send_event(RallyEvent::Error(format!("Reviewer failed: {:#}", e)))
-                                .await;
-                            self.send_event(RallyEvent::StateChanged(RallyState::Error))
-                                .await;
-                            return Err(e);
-                        }
-                    };
-
+                    let review = self.run_reviewer_step(&context, iteration).await?;
                     (review, false)
-                }
-            } else {
-                self.session.update_state(RallyState::ReviewerReviewing);
-                self.send_event(RallyEvent::StateChanged(RallyState::ReviewerReviewing))
-                    .await;
-                if let Err(e) = write_session(&self.session) {
-                    warn!("Failed to write session: {}", e);
-                    self.send_event(RallyEvent::Log(format!(
-                        "Warning: Failed to write session: {}",
-                        e
-                    )))
-                    .await;
-                }
-
-                let review = match self.run_reviewer_with_timeout(&context, iteration).await {
-                    Ok(result) => result,
-                    Err(e) => {
-                        self.session.update_state(RallyState::Error);
-                        let _ = write_session(&self.session);
-                        self.send_event(RallyEvent::Error(format!("Reviewer failed: {:#}", e)))
-                            .await;
-                        self.send_event(RallyEvent::StateChanged(RallyState::Error))
-                            .await;
-                        return Err(e);
-                    }
                 };
-
-                (review, false)
-            };
 
             // Store the review for later use
             if let Err(e) = write_history_entry(
@@ -928,6 +877,37 @@ impl Orchestrator {
     #[allow(dead_code)]
     pub async fn continue_with_permission(&mut self, action: &str) -> Result<()> {
         self.handle_permission_granted(action).await
+    }
+
+    async fn run_reviewer_step(
+        &mut self,
+        context: &Context,
+        iteration: u32,
+    ) -> Result<ReviewerOutput> {
+        self.session.update_state(RallyState::ReviewerReviewing);
+        self.send_event(RallyEvent::StateChanged(RallyState::ReviewerReviewing))
+            .await;
+        if let Err(e) = write_session(&self.session) {
+            warn!("Failed to write session: {}", e);
+            self.send_event(RallyEvent::Log(format!(
+                "Warning: Failed to write session: {}",
+                e
+            )))
+            .await;
+        }
+
+        match self.run_reviewer_with_timeout(context, iteration).await {
+            Ok(result) => Ok(result),
+            Err(e) => {
+                self.session.update_state(RallyState::Error);
+                let _ = write_session(&self.session);
+                self.send_event(RallyEvent::Error(format!("Reviewer failed: {:#}", e)))
+                    .await;
+                self.send_event(RallyEvent::StateChanged(RallyState::Error))
+                    .await;
+                Err(e)
+            }
+        }
     }
 
     async fn run_reviewer_with_timeout(

--- a/src/ai/orchestrator.rs
+++ b/src/ai/orchestrator.rs
@@ -156,6 +156,7 @@ pub struct Orchestrator {
     reviewee_adapter: Box<dyn AgentAdapter>,
     session: RallySession,
     context: Option<Context>,
+    seed_review: Option<ReviewerOutput>,
     last_review: Option<ReviewerOutput>,
     last_fix: Option<RevieweeOutput>,
     event_sender: mpsc::Sender<RallyEvent>,
@@ -192,6 +193,7 @@ impl Orchestrator {
             reviewee_adapter,
             session,
             context: None,
+            seed_review: None,
             last_review: None,
             last_fix: None,
             event_sender,
@@ -208,6 +210,11 @@ impl Orchestrator {
         self.reviewer_adapter.set_local_mode(context.local_mode);
         self.reviewee_adapter.set_local_mode(context.local_mode);
         self.context = Some(context);
+    }
+
+    /// Seed the first review step with an existing review result.
+    pub fn set_seed_review(&mut self, review: ReviewerOutput) {
+        self.seed_review = Some(review);
     }
 
     /// Run the rally process
@@ -239,30 +246,70 @@ impl Orchestrator {
                 }
             }
 
-            // Run reviewer
-            self.session.update_state(RallyState::ReviewerReviewing);
-            self.send_event(RallyEvent::StateChanged(RallyState::ReviewerReviewing))
-                .await;
-            if let Err(e) = write_session(&self.session) {
-                warn!("Failed to write session: {}", e);
-                self.send_event(RallyEvent::Log(format!(
-                    "Warning: Failed to write session: {}",
-                    e
-                )))
-                .await;
-            }
+            let (review_result, seeded_review) = if iteration == 1 {
+                if let Some(review) = self.seed_review.take() {
+                    self.send_event(RallyEvent::Log(format!(
+                        "Using {} local comment{} as the initial review seed",
+                        review.comments.len(),
+                        if review.comments.len() == 1 { "" } else { "s" }
+                    )))
+                    .await;
+                    (review, true)
+                } else {
+                    self.session.update_state(RallyState::ReviewerReviewing);
+                    self.send_event(RallyEvent::StateChanged(RallyState::ReviewerReviewing))
+                        .await;
+                    if let Err(e) = write_session(&self.session) {
+                        warn!("Failed to write session: {}", e);
+                        self.send_event(RallyEvent::Log(format!(
+                            "Warning: Failed to write session: {}",
+                            e
+                        )))
+                        .await;
+                    }
 
-            let review_result = match self.run_reviewer_with_timeout(&context, iteration).await {
-                Ok(result) => result,
-                Err(e) => {
-                    self.session.update_state(RallyState::Error);
-                    let _ = write_session(&self.session);
-                    self.send_event(RallyEvent::Error(format!("Reviewer failed: {:#}", e)))
-                        .await;
-                    self.send_event(RallyEvent::StateChanged(RallyState::Error))
-                        .await;
-                    return Err(e);
+                    let review = match self.run_reviewer_with_timeout(&context, iteration).await {
+                        Ok(result) => result,
+                        Err(e) => {
+                            self.session.update_state(RallyState::Error);
+                            let _ = write_session(&self.session);
+                            self.send_event(RallyEvent::Error(format!("Reviewer failed: {:#}", e)))
+                                .await;
+                            self.send_event(RallyEvent::StateChanged(RallyState::Error))
+                                .await;
+                            return Err(e);
+                        }
+                    };
+
+                    (review, false)
                 }
+            } else {
+                self.session.update_state(RallyState::ReviewerReviewing);
+                self.send_event(RallyEvent::StateChanged(RallyState::ReviewerReviewing))
+                    .await;
+                if let Err(e) = write_session(&self.session) {
+                    warn!("Failed to write session: {}", e);
+                    self.send_event(RallyEvent::Log(format!(
+                        "Warning: Failed to write session: {}",
+                        e
+                    )))
+                    .await;
+                }
+
+                let review = match self.run_reviewer_with_timeout(&context, iteration).await {
+                    Ok(result) => result,
+                    Err(e) => {
+                        self.session.update_state(RallyState::Error);
+                        let _ = write_session(&self.session);
+                        self.send_event(RallyEvent::Error(format!("Reviewer failed: {:#}", e)))
+                            .await;
+                        self.send_event(RallyEvent::StateChanged(RallyState::Error))
+                            .await;
+                        return Err(e);
+                    }
+                };
+
+                (review, false)
             };
 
             // Store the review for later use
@@ -284,26 +331,28 @@ impl Orchestrator {
                 .await;
             self.last_review = Some(review_result.clone());
 
-            // Update head_sha before posting review (ensure we have the latest commit)
-            if let Err(e) = self.update_head_sha().await {
-                warn!("Failed to update head_sha before posting review: {}", e);
-            }
-
-            // Post review to PR (with confirmation if auto_post is false)
-            if let Err(e) = self.maybe_post_review_to_pr(&review_result).await {
-                // Check if abort was triggered during post confirmation
-                if self.session.state == RallyState::Aborted {
-                    return Ok(RallyResult::Aborted {
-                        iteration,
-                        reason: e.to_string(),
-                    });
+            if !seeded_review {
+                // Update head_sha before posting review (ensure we have the latest commit)
+                if let Err(e) = self.update_head_sha().await {
+                    warn!("Failed to update head_sha before posting review: {}", e);
                 }
-                warn!("Failed to post review to PR: {}", e);
-                self.send_event(RallyEvent::Log(format!(
-                    "Warning: Failed to post review to PR: {}",
-                    e
-                )))
-                .await;
+
+                // Post review to PR (with confirmation if auto_post is false)
+                if let Err(e) = self.maybe_post_review_to_pr(&review_result).await {
+                    // Check if abort was triggered during post confirmation
+                    if self.session.state == RallyState::Aborted {
+                        return Ok(RallyResult::Aborted {
+                            iteration,
+                            reason: e.to_string(),
+                        });
+                    }
+                    warn!("Failed to post review to PR: {}", e);
+                    self.send_event(RallyEvent::Log(format!(
+                        "Warning: Failed to post review to PR: {}",
+                        e
+                    )))
+                    .await;
+                }
             }
 
             // Check for approval

--- a/src/app/ai_rally.rs
+++ b/src/app/ai_rally.rs
@@ -4,9 +4,13 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use std::io::Stdout;
 use tokio::sync::mpsc;
 
+use crate::ai::adapter::{CommentSeverity, ReviewComment as AiReviewComment};
 use crate::ai::orchestrator::{OrchestratorCommand, RallyEvent};
 use crate::ai::prompt_loader::{PromptLoader, PromptSource};
-use crate::ai::{Context, Orchestrator, RallyState};
+use crate::ai::{
+    Context, Orchestrator, RallyState, ReviewAction as AiReviewAction, ReviewerOutput,
+};
+use crate::cache::load_local_review_comments;
 use crate::keybinding::{event_to_keybinding, SequenceMatch};
 use crate::ui;
 
@@ -107,7 +111,7 @@ impl App {
                 }
                 if let Some(context) = self.pending_rally_context.take() {
                     if let Some(prompt_loader) = self.pending_rally_prompt_loader.take() {
-                        self.spawn_rally_orchestrator(context, prompt_loader);
+                        self.spawn_rally_orchestrator(context, prompt_loader, None);
                     }
                 }
                 return Ok(());
@@ -375,6 +379,7 @@ impl App {
         self.rally_event_receiver = None;
         self.pending_rally_context = None;
         self.pending_rally_prompt_loader = None;
+        self.pending_rally_seed_review = None;
         if let Some(handle) = self.rally_abort_handle.take() {
             handle.abort();
         }
@@ -467,6 +472,18 @@ impl App {
             return;
         };
 
+        let seed_review = match self.build_seed_review_from_local_comments() {
+            Ok(seed_review) => seed_review,
+            Err(e) => {
+                self.cmt.submission_result = Some((
+                    false,
+                    format!("Failed to load local comments for AI Rally: {}", e),
+                ));
+                self.cmt.submission_result_time = Some(std::time::Instant::now());
+                return;
+            }
+        };
+
         let file_patches: Vec<(String, String)> = self
             .files()
             .iter()
@@ -553,10 +570,53 @@ impl App {
             // Save context and prompt_loader for later use after user confirmation
             self.pending_rally_context = Some(context);
             self.pending_rally_prompt_loader = Some(prompt_loader);
+            self.pending_rally_seed_review = seed_review;
             return;
         }
 
-        self.spawn_rally_orchestrator(context, prompt_loader);
+        self.spawn_rally_orchestrator(context, prompt_loader, seed_review);
+    }
+
+    pub(crate) fn build_seed_review_from_local_comments(
+        &self,
+    ) -> anyhow::Result<Option<ReviewerOutput>> {
+        if !self.local_mode {
+            return Ok(None);
+        }
+
+        let comments = load_local_review_comments(&self.repo, self.working_dir.as_deref())?;
+        let comments: Vec<AiReviewComment> = comments
+            .into_iter()
+            .filter_map(|comment| {
+                if comment.is_resolved {
+                    return None;
+                }
+                let line = comment.line?;
+                Some(AiReviewComment {
+                    path: comment.path,
+                    line,
+                    body: comment.body,
+                    severity: CommentSeverity::Major,
+                })
+            })
+            .collect();
+
+        if comments.is_empty() {
+            return Ok(None);
+        }
+
+        let summary = format!(
+            "Address {} local comment{} from the user before re-reviewing.",
+            comments.len(),
+            if comments.len() == 1 { "" } else { "s" }
+        );
+
+        Ok(Some(ReviewerOutput {
+            action: AiReviewAction::RequestChanges,
+            summary,
+            blocking_issues: vec!["Resolve the user-provided local comments.".to_string()],
+            comments,
+        }))
     }
 
     /// Spawn the orchestrator task. Called after user confirms config warnings
@@ -565,6 +625,7 @@ impl App {
         &mut self,
         context: Context,
         prompt_loader: PromptLoader,
+        seed_review: Option<ReviewerOutput>,
     ) {
         let (event_tx, event_rx) = mpsc::channel(100);
         let (cmd_tx, cmd_rx) = mpsc::channel(10);
@@ -590,6 +651,9 @@ impl App {
             match orchestrator_result {
                 Ok(mut orchestrator) => {
                     orchestrator.set_context(context);
+                    if let Some(seed_review) = seed_review {
+                        orchestrator.set_seed_review(seed_review);
+                    }
                     let _ = orchestrator.run().await;
                 }
                 Err(e) => {

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -5,18 +5,15 @@ use std::io::Stdout;
 use std::time::Instant;
 use tokio::sync::mpsc;
 
-use crate::cache::PrCacheKey;
+use crate::cache::{load_local_review_comments, PrCacheKey};
 use crate::github::{self, comment::ReviewComment};
 use crate::ui;
 
 use super::types::*;
-use super::{App, AppState};
+use super::{App, AppState, CommentTab};
 
 impl App {
     pub(crate) fn enter_comment_input(&mut self) {
-        if self.local_mode {
-            return;
-        }
         let Some(file) = self.files().get(self.selected_file) else {
             return;
         };
@@ -25,7 +22,8 @@ impl App {
         };
 
         // Get actual line number from diff
-        let Some(line_info) = crate::diff::get_line_info(patch, self.diff_scroll.selected_line) else {
+        let Some(line_info) = crate::diff::get_line_info(patch, self.diff_scroll.selected_line)
+        else {
             return;
         };
 
@@ -122,9 +120,6 @@ impl App {
         Ok(())
     }
     pub(crate) fn enter_suggestion_input(&mut self) {
-        if self.local_mode {
-            return;
-        }
         let Some(file) = self.files().get(self.selected_file) else {
             return;
         };
@@ -133,7 +128,8 @@ impl App {
         };
 
         // Check if this line can have a suggestion
-        let Some(line_info) = crate::diff::get_line_info(patch, self.diff_scroll.selected_line) else {
+        let Some(line_info) = crate::diff::get_line_info(patch, self.diff_scroll.selected_line)
+        else {
             return;
         };
 
@@ -172,9 +168,6 @@ impl App {
     }
     /// 複数行選択モードを開始する（Shift+Enter）
     pub(crate) fn enter_multiline_selection(&mut self) {
-        if self.local_mode {
-            return;
-        }
         // 現在の行がコメント可能な行であることを確認
         let Some(file) = self.files().get(self.selected_file) else {
             return;
@@ -182,7 +175,8 @@ impl App {
         let Some(patch) = file.patch.as_ref() else {
             return;
         };
-        let Some(line_info) = crate::diff::get_line_info(patch, self.diff_scroll.selected_line) else {
+        let Some(line_info) = crate::diff::get_line_info(patch, self.diff_scroll.selected_line)
+        else {
             return;
         };
         if !matches!(
@@ -197,9 +191,6 @@ impl App {
         });
     }
     pub(crate) fn enter_multiline_comment_input(&mut self) {
-        if self.local_mode {
-            return;
-        }
         let Some(ref selection) = self.multiline_selection else {
             return;
         };
@@ -265,9 +256,6 @@ impl App {
         self.state = AppState::TextInput;
     }
     pub(crate) fn enter_multiline_suggestion_input(&mut self) {
-        if self.local_mode {
-            return;
-        }
         let Some(ref selection) = self.multiline_selection else {
             return;
         };
@@ -348,17 +336,20 @@ impl App {
         self.state = AppState::TextInput;
     }
     pub(crate) fn open_comment_list(&mut self) {
-        if self.local_mode {
-            return;
-        }
         self.state = AppState::CommentList;
+        self.cmt.comment_tab = CommentTab::Review;
         self.cmt.discussion_comment_detail_mode = false;
         self.cmt.discussion_comment_detail_scroll = 0;
 
         // Load review comments
         self.load_review_comments();
-        // Load discussion comments
-        self.load_discussion_comments();
+        if self.local_mode {
+            self.cmt.discussion_comments = Some(vec![]);
+            self.cmt.discussion_comments_loading = false;
+        } else {
+            // Load discussion comments
+            self.load_discussion_comments();
+        }
     }
 
     pub(crate) fn load_review_comments(&mut self) {
@@ -372,6 +363,34 @@ impl App {
             self.cmt.selected_comment = 0;
             self.cmt.comment_list_scroll_offset = 0;
             self.cmt.comments_loading = false;
+            return;
+        }
+
+        if self.local_mode {
+            match load_local_review_comments(&self.repo, self.working_dir.as_deref()) {
+                Ok(comments) => {
+                    self.session_cache
+                        .put_review_comments(cache_key, comments.clone());
+                    self.cmt.review_comments = Some(comments);
+                    self.cmt.selected_comment = 0;
+                    self.cmt.comment_list_scroll_offset = 0;
+                    self.cmt.comments_loading = false;
+                    if matches!(
+                        self.state,
+                        AppState::DiffView | AppState::SplitViewDiff | AppState::SplitViewFileList
+                    ) {
+                        self.update_file_comment_positions();
+                        self.ensure_diff_cache();
+                    }
+                }
+                Err(e) => {
+                    self.cmt.review_comments = Some(vec![]);
+                    self.cmt.comments_loading = false;
+                    self.cmt.submission_result =
+                        Some((false, format!("Failed to load local comments: {}", e)));
+                    self.cmt.submission_result_time = Some(Instant::now());
+                }
+            }
             return;
         }
 
@@ -408,6 +427,8 @@ impl App {
                                 body,
                                 user: review.user,
                                 created_at: review.submitted_at.unwrap_or_default(),
+                                is_resolved: false,
+                                resolved_at: None,
                             });
                         }
                     }
@@ -457,6 +478,10 @@ impl App {
         key: event::KeyEvent,
         terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     ) -> Result<()> {
+        if self.local_mode {
+            return self.handle_local_comment_list_input(key, terminal).await;
+        }
+
         let visible_lines = terminal.size()?.height.saturating_sub(8) as usize;
 
         if self.cmt.discussion_comment_detail_mode {
@@ -476,12 +501,7 @@ impl App {
         } else if self.matches_single_key(&key, &kb.move_down) {
             match self.cmt.comment_tab {
                 CommentTab::Review => {
-                    if let Some(ref comments) = self.cmt.review_comments {
-                        if !comments.is_empty() {
-                            self.cmt.selected_comment =
-                                (self.cmt.selected_comment + 1).min(comments.len().saturating_sub(1));
-                        }
-                    }
+                    self.navigate_review_comments(&key, visible_lines);
                 }
                 CommentTab::Discussion => {
                     if let Some(ref comments) = self.cmt.discussion_comments {
@@ -496,7 +516,7 @@ impl App {
         } else if self.matches_single_key(&key, &kb.move_up) {
             match self.cmt.comment_tab {
                 CommentTab::Review => {
-                    self.cmt.selected_comment = self.cmt.selected_comment.saturating_sub(1);
+                    self.navigate_review_comments(&key, visible_lines);
                 }
                 CommentTab::Discussion => {
                     self.cmt.selected_discussion_comment =
@@ -506,17 +526,12 @@ impl App {
         } else if self.matches_single_key(&key, &kb.page_down)
             || Self::is_shift_char_shortcut(&key, 'j')
         {
-            let step = visible_lines.max(1);
             match self.cmt.comment_tab {
                 CommentTab::Review => {
-                    if let Some(ref comments) = self.cmt.review_comments {
-                        if !comments.is_empty() {
-                            self.cmt.selected_comment =
-                                (self.cmt.selected_comment + step).min(comments.len() - 1);
-                        }
-                    }
+                    self.navigate_review_comments(&key, visible_lines);
                 }
                 CommentTab::Discussion => {
+                    let step = visible_lines.max(1);
                     if let Some(ref comments) = self.cmt.discussion_comments {
                         if !comments.is_empty() {
                             self.cmt.selected_discussion_comment =
@@ -529,12 +544,12 @@ impl App {
         } else if self.matches_single_key(&key, &kb.page_up)
             || Self::is_shift_char_shortcut(&key, 'k')
         {
-            let step = visible_lines.max(1);
             match self.cmt.comment_tab {
                 CommentTab::Review => {
-                    self.cmt.selected_comment = self.cmt.selected_comment.saturating_sub(step);
+                    self.navigate_review_comments(&key, visible_lines);
                 }
                 CommentTab::Discussion => {
+                    let step = visible_lines.max(1);
                     self.cmt.selected_discussion_comment =
                         self.cmt.selected_discussion_comment.saturating_sub(step);
                 }
@@ -558,6 +573,68 @@ impl App {
             }
         }
         Ok(())
+    }
+
+    pub(crate) async fn handle_local_comment_list_input(
+        &mut self,
+        key: event::KeyEvent,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<()> {
+        let visible_lines = terminal.size()?.height.saturating_sub(8) as usize;
+
+        let kb = self.config.keybindings.clone();
+        if self.matches_single_key(&key, &kb.quit) {
+            self.state = self.previous_state;
+        } else if self.navigate_review_comments(&key, visible_lines) {
+            // handled by navigate_review_comments
+        } else if key.code == event::KeyCode::Char('g') {
+            self.cmt.selected_comment = 0;
+        } else if Self::is_shift_char_shortcut(&key, 'g') {
+            if let Some(ref comments) = self.cmt.review_comments {
+                if !comments.is_empty() {
+                    self.cmt.selected_comment = comments.len() - 1;
+                }
+            }
+        } else if self.matches_single_key(&key, &kb.open_panel) {
+            self.jump_to_comment();
+        }
+
+        Ok(())
+    }
+
+    fn navigate_review_comments(&mut self, key: &event::KeyEvent, visible_lines: usize) -> bool {
+        let kb = self.config.keybindings.clone();
+        if self.matches_single_key(key, &kb.move_down) {
+            if let Some(ref comments) = self.cmt.review_comments {
+                if !comments.is_empty() {
+                    self.cmt.selected_comment =
+                        (self.cmt.selected_comment + 1).min(comments.len().saturating_sub(1));
+                }
+            }
+            true
+        } else if self.matches_single_key(key, &kb.move_up) {
+            self.cmt.selected_comment = self.cmt.selected_comment.saturating_sub(1);
+            true
+        } else if self.matches_single_key(key, &kb.page_down)
+            || Self::is_shift_char_shortcut(key, 'j')
+        {
+            let step = visible_lines.max(1);
+            if let Some(ref comments) = self.cmt.review_comments {
+                if !comments.is_empty() {
+                    self.cmt.selected_comment =
+                        (self.cmt.selected_comment + step).min(comments.len() - 1);
+                }
+            }
+            true
+        } else if self.matches_single_key(key, &kb.page_up)
+            || Self::is_shift_char_shortcut(key, 'k')
+        {
+            let step = visible_lines.max(1);
+            self.cmt.selected_comment = self.cmt.selected_comment.saturating_sub(step);
+            true
+        } else {
+            false
+        }
     }
 
     pub(crate) fn handle_discussion_detail_input(

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -7,6 +7,7 @@ use tokio::sync::mpsc;
 
 use crate::cache::{load_local_review_comments, PrCacheKey};
 use crate::github::{self, comment::ReviewComment};
+use crate::keybinding::{event_to_keybinding, SequenceMatch};
 use crate::ui;
 
 use super::types::*;
@@ -337,7 +338,9 @@ impl App {
     }
     pub(crate) fn open_comment_list(&mut self) {
         self.state = AppState::CommentList;
-        self.cmt.comment_tab = CommentTab::Review;
+        if self.local_mode {
+            self.cmt.comment_tab = CommentTab::Review;
+        }
         self.cmt.discussion_comment_detail_mode = false;
         self.cmt.discussion_comment_detail_scroll = 0;
 
@@ -424,6 +427,7 @@ impl App {
                                 id: review.id,
                                 path: "[PR Review]".to_string(),
                                 line: None,
+                                start_line: None,
                                 body,
                                 user: review.user,
                                 created_at: review.submitted_at.unwrap_or_default(),
@@ -583,13 +587,35 @@ impl App {
         let visible_lines = terminal.size()?.height.saturating_sub(8) as usize;
 
         let kb = self.config.keybindings.clone();
+
+        if !self.pending_keys.is_empty() {
+            if let Some(kb_event) = event_to_keybinding(&key) {
+                self.push_pending_key(kb_event);
+
+                if self.try_match_sequence(&kb.jump_to_first) == SequenceMatch::Full {
+                    self.clear_pending_keys();
+                    self.cmt.selected_comment = 0;
+                    return Ok(());
+                }
+
+                self.clear_pending_keys();
+            } else {
+                self.clear_pending_keys();
+            }
+            return Ok(());
+        }
+
+        if self.key_could_match_sequence(&key, &kb.jump_to_first) {
+            if let Some(kb_event) = event_to_keybinding(&key) {
+                self.push_pending_key(kb_event);
+            }
+            return Ok(());
+        }
+
         if self.matches_single_key(&key, &kb.quit) {
             self.state = self.previous_state;
         } else if self.navigate_review_comments(&key, visible_lines) {
-            // handled by navigate_review_comments
-        } else if key.code == event::KeyCode::Char('g') {
-            self.cmt.selected_comment = 0;
-        } else if Self::is_shift_char_shortcut(&key, 'g') {
+        } else if self.matches_single_key(&key, &kb.jump_to_last) {
             if let Some(ref comments) = self.cmt.review_comments {
                 if !comments.is_empty() {
                     self.cmt.selected_comment = comments.len() - 1;

--- a/src/app/diff_cache.rs
+++ b/src/app/diff_cache.rs
@@ -43,7 +43,7 @@ impl App {
         self.clear_pending_keys();
         self.symbol_popup = None;
         self.update_diff_line_count();
-        if !self.local_mode && self.cmt.review_comments.is_none() {
+        if self.cmt.review_comments.is_none() {
             self.load_review_comments();
         }
         self.update_file_comment_positions();

--- a/src/app/input_text.rs
+++ b/src/app/input_text.rs
@@ -1,8 +1,12 @@
 use anyhow::Result;
+use chrono::Utc;
 use crossterm::event::{self, KeyEvent};
+use std::time::Instant;
 use tokio::sync::mpsc;
 
+use crate::cache::{load_local_review_comments, save_local_review_comments, PrCacheKey};
 use crate::github;
+use crate::github::comment::ReviewComment;
 use crate::loader::CommentSubmitResult;
 use crate::ui::text_area::TextAreaAction;
 
@@ -124,6 +128,11 @@ impl App {
     }
 
     fn submit_review_comment_inner(&mut self, ctx: LineInputContext, body: String) {
+        if self.local_mode {
+            self.submit_local_review_comment(ctx, body);
+            return;
+        }
+
         let Some(file) = self.files().get(ctx.file_index) else {
             return;
         };
@@ -165,7 +174,49 @@ impl App {
         });
     }
 
+    fn next_local_comment_id(comments: &[ReviewComment]) -> u64 {
+        comments.iter().map(|c| c.id).max().unwrap_or(0) + 1
+    }
+
+    fn submit_local_review_comment(&mut self, ctx: LineInputContext, body: String) {
+        let Some(file) = self.files().get(ctx.file_index) else {
+            return;
+        };
+
+        let mut comments = match load_local_review_comments(&self.repo, self.working_dir.as_deref())
+        {
+            Ok(comments) => comments,
+            Err(e) => {
+                self.cmt.submission_result =
+                    Some((false, format!("Failed to load local comments: {}", e)));
+                self.cmt.submission_result_time = Some(Instant::now());
+                return;
+            }
+        };
+
+        let next_id = Self::next_local_comment_id(&comments);
+        comments.push(ReviewComment {
+            id: next_id,
+            path: file.filename.clone(),
+            line: Some(ctx.line_number),
+            body,
+            user: github::User {
+                login: Self::local_comment_author(),
+            },
+            created_at: Utc::now().to_rfc3339(),
+            is_resolved: false,
+            resolved_at: None,
+        });
+
+        self.persist_local_review_comments(comments, "Saved local comment");
+    }
+
     pub(crate) fn submit_reply(&mut self, comment_id: u64, body: String) {
+        if self.local_mode {
+            self.submit_local_reply(comment_id, body);
+            return;
+        }
+
         let repo = self.repo.clone();
         let pr_number = self.pr_number();
 
@@ -184,6 +235,100 @@ impl App {
                 .await;
         });
     }
+
+    fn submit_local_reply(&mut self, comment_id: u64, body: String) {
+        let Some(parent) = self
+            .cmt.review_comments
+            .as_ref()
+            .and_then(|comments: &Vec<ReviewComment>| comments.iter().find(|comment| comment.id == comment_id))
+            .cloned()
+        else {
+            self.cmt.submission_result = Some((false, "Reply target not found".to_string()));
+            self.cmt.submission_result_time = Some(Instant::now());
+            return;
+        };
+
+        let Some(line_number) = parent.line else {
+            self.cmt.submission_result = Some((false, "Reply target has no line".to_string()));
+            self.cmt.submission_result_time = Some(Instant::now());
+            return;
+        };
+
+        let mut comments = match load_local_review_comments(&self.repo, self.working_dir.as_deref())
+        {
+            Ok(comments) => comments,
+            Err(e) => {
+                self.cmt.submission_result =
+                    Some((false, format!("Failed to load local comments: {}", e)));
+                self.cmt.submission_result_time = Some(Instant::now());
+                return;
+            }
+        };
+
+        let next_id = Self::next_local_comment_id(&comments);
+        comments.push(ReviewComment {
+            id: next_id,
+            path: parent.path,
+            line: Some(line_number),
+            body,
+            user: github::User {
+                login: Self::local_comment_author(),
+            },
+            created_at: Utc::now().to_rfc3339(),
+            is_resolved: false,
+            resolved_at: None,
+        });
+
+        self.persist_local_review_comments(comments, "Saved local reply");
+    }
+
+    fn persist_local_review_comments(
+        &mut self,
+        comments: Vec<ReviewComment>,
+        success_message: &str,
+    ) {
+        if let Err(e) =
+            save_local_review_comments(&self.repo, self.working_dir.as_deref(), &comments)
+        {
+            self.cmt.submission_result = Some((false, format!("Failed to save local comments: {}", e)));
+            self.cmt.submission_result_time = Some(Instant::now());
+            return;
+        }
+
+        let cache_key = PrCacheKey {
+            repo: self.repo.clone(),
+            pr_number: self.pr_number(),
+        };
+        self.session_cache
+            .put_review_comments(cache_key, comments.clone());
+        self.cmt.review_comments = Some(comments);
+        self.cmt.selected_comment = self
+            .cmt.review_comments
+            .as_ref()
+            .map(|comments: &Vec<ReviewComment>| comments.len().saturating_sub(1))
+            .unwrap_or(0);
+        self.cmt.comments_loading = false;
+        self.cmt.comment_submitting = false;
+        self.cmt.comment_submit_receiver = None;
+        self.update_file_comment_positions();
+        // ensure_diff_cache() requires a tokio runtime for spawn_blocking.
+        // In sync test contexts (e.g. #[test] without #[tokio::test]), no runtime
+        // is available, so we skip the call to avoid a panic.
+        if tokio::runtime::Handle::try_current().is_ok() {
+            self.ensure_diff_cache();
+        }
+        self.cmt.submission_result = Some((true, success_message.to_string()));
+        self.cmt.submission_result_time = Some(Instant::now());
+    }
+
+    fn local_comment_author() -> String {
+        std::env::var("USER")
+            .or_else(|_| std::env::var("USERNAME"))
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| "local".to_string())
+    }
+
     pub(crate) fn is_issue_comment_submitting(&self) -> bool {
         self.issue_state
             .as_ref()
@@ -212,8 +357,7 @@ impl App {
         }
         if self.matches_single_key(key, &self.config.keybindings.approve) {
             PendingApproveChoice::Submit
-        } else if self.matches_single_key(key, &self.config.keybindings.quit)
-                   {
+        } else if self.matches_single_key(key, &self.config.keybindings.quit) {
             self.cmt.pending_approve_body = None;
             self.cmt.submission_result = None;
             self.cmt.submission_result_time = None;

--- a/src/app/input_text.rs
+++ b/src/app/input_text.rs
@@ -199,6 +199,7 @@ impl App {
             id: next_id,
             path: file.filename.clone(),
             line: Some(ctx.line_number),
+            start_line: ctx.start_line_number,
             body,
             user: github::User {
                 login: Self::local_comment_author(),
@@ -270,6 +271,7 @@ impl App {
             id: next_id,
             path: parent.path,
             line: Some(line_number),
+            start_line: None,
             body,
             user: github::User {
                 login: Self::local_comment_author(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,28 +11,26 @@ use crate::ai::prompt_loader::PromptLoader;
 use crate::ai::Context as AiContext;
 use crate::cache::SessionCache;
 use crate::config::Config;
+use crate::diff_store::{DiffCacheStore, DiffScrollState, ScrollMode, MAX_STORE_ENTRIES};
 use crate::filter::ListFilter;
 use crate::github;
 use crate::keybinding::KeyBinding;
 use crate::loader::{DataLoadResult, SingleFileDiffResult};
 use crate::ui;
 use crate::ui::text_area::TextArea;
-use crate::diff_store::{DiffCacheStore, DiffScrollState, ScrollMode, MAX_STORE_ENTRIES};
 use std::time::Instant;
 
 mod types;
 pub use types::{
-    hash_string, AiRallyState, AppState, CachedDiffLine, CockpitMenuItem, CockpitState,
-    CommentPosition, CommentTab,
-    ChecksState, CommentState, CommitLogState, DataState, DiffCache, FileStatus, GitOpsState,
-    GitStatusEntry, HelpTab,
-    IndexEntry, InputMode, InternedSpan, IssueDetailFocus, IssueState, JumpLocation,
-    LeftPaneFocus, LineInputContext, LoadState, LogEntry, LogEventType, MultilineSelection,
-    PauseState, DestructiveOp, PendingGitOpsConfirm, SimulationPreview, SimulationResult,
-    PermissionInfo, PrListState, RefreshRequest,
-    RepoSymbolSearchResult, ReviewAction, CachedShellLine, ShellCommandResult, ShellPhase,
-    ShellState, SymbolPopupState, SpanVec, SymbolSearchState, SymbolSearchUpdate, TreeRow,
-    UndoAction, WatcherHandle,
+    hash_string, AiRallyState, AppState, CachedDiffLine, CachedShellLine, ChecksState,
+    CockpitMenuItem, CockpitState, CommentPosition, CommentState, CommentTab, CommitLogState,
+    DataState, DestructiveOp, DiffCache, FileStatus, GitOpsState, GitStatusEntry, HelpTab,
+    IndexEntry, InputMode, InternedSpan, IssueDetailFocus, IssueState, JumpLocation, LeftPaneFocus,
+    LineInputContext, LoadState, LogEntry, LogEventType, MultilineSelection, PauseState,
+    PendingGitOpsConfirm, PermissionInfo, PrListState, RefreshRequest, RepoSymbolSearchResult,
+    ReviewAction, ShellCommandResult, ShellPhase, ShellState, SimulationPreview, SimulationResult,
+    SpanVec, SymbolPopupState, SymbolSearchState, SymbolSearchUpdate, TreeRow, UndoAction,
+    WatcherHandle,
 };
 // Internal-only types (not re-exported from crate::app)
 use types::MarkViewedResult;
@@ -138,6 +136,8 @@ pub struct App {
     pending_rally_context: Option<AiContext>,
     // PromptLoader saved while waiting for config warning confirmation
     pending_rally_prompt_loader: Option<PromptLoader>,
+    // Seed review saved while waiting for config warning confirmation
+    pending_rally_seed_review: Option<crate::ai::ReviewerOutput>,
     // Flag to start AI Rally when data is loaded (set by --ai-rally CLI flag)
     start_ai_rally_on_load: bool,
     // Pending AI Rally flag (set when --ai-rally is passed with PR list mode)
@@ -241,6 +241,7 @@ impl App {
             rally_command_sender: None,
             pending_rally_context: None,
             pending_rally_prompt_loader: None,
+            pending_rally_seed_review: None,
             start_ai_rally_on_load: false,
             pending_ai_rally: false,
             mark_viewed_receiver: None,

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2,11 +2,34 @@ use super::types::{MarkViewedResult, PendingApproveChoice};
 use super::*;
 use crossterm::event::{self, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 use lasso::Rodeo;
+use serial_test::serial;
+use tempfile::tempdir;
 
 use crate::cache::{PrCacheKey, PrData};
 use crate::github::comment::ReviewComment;
 use crate::github::{ChangedFile, PrCommit, PullRequest};
 use crate::loader::DataLoadResult;
+
+struct ScopedCacheHome {
+    old: Option<std::ffi::OsString>,
+}
+
+impl ScopedCacheHome {
+    fn new(dir: &std::path::Path) -> Self {
+        let old = std::env::var_os("XDG_CACHE_HOME");
+        unsafe { std::env::set_var("XDG_CACHE_HOME", dir) };
+        Self { old }
+    }
+}
+
+impl Drop for ScopedCacheHome {
+    fn drop(&mut self) {
+        match self.old.take() {
+            Some(v) => unsafe { std::env::set_var("XDG_CACHE_HOME", v) },
+            None => unsafe { std::env::remove_var("XDG_CACHE_HOME") },
+        }
+    }
+}
 
 #[test]
 fn test_find_diff_line_index_basic() {
@@ -618,8 +641,14 @@ async fn test_handle_data_result_resyncs_diff_state_when_selected_file_changes()
         "diff_cache should be rebuilt for the new selected file"
     );
     // selected_line and scroll_offset must be reset
-    assert_eq!(app.diff_scroll.selected_line, 0, "selected_line should be reset to 0");
-    assert_eq!(app.diff_scroll.scroll_offset, 0, "scroll_offset should be reset to 0");
+    assert_eq!(
+        app.diff_scroll.selected_line, 0,
+        "selected_line should be reset to 0"
+    );
+    assert_eq!(
+        app.diff_scroll.scroll_offset, 0,
+        "scroll_offset should be reset to 0"
+    );
 }
 
 #[tokio::test]
@@ -677,6 +706,8 @@ async fn test_handle_data_result_resyncs_comment_positions_when_selected_file_ch
             login: "reviewer".to_string(),
         },
         created_at: "2024-01-01T00:00:00Z".to_string(),
+        is_resolved: false,
+        resolved_at: None,
     }]);
 
     // Pre-populate stale comment positions for the old file
@@ -3445,8 +3476,11 @@ fn test_adjust_scroll_invariant_all_positions() {
         for visible_lines in [1usize, 5, 10, 20, 40] {
             for selected_line in 0..diff_line_count {
                 // scroll_offset が selected_line より手前にあるケース
-                for initial_scroll in [0, selected_line.saturating_sub(visible_lines), selected_line]
-                {
+                for initial_scroll in [
+                    0,
+                    selected_line.saturating_sub(visible_lines),
+                    selected_line,
+                ] {
                     let mut app = App::new_for_test();
                     app.diff_scroll.line_count = diff_line_count;
                     app.diff_scroll.selected_line = selected_line;
@@ -3465,7 +3499,8 @@ fn test_adjust_scroll_invariant_all_positions() {
                         initial_scroll,
                     );
                     assert!(
-                        app.diff_scroll.selected_line < app.diff_scroll.scroll_offset + visible_lines,
+                        app.diff_scroll.selected_line
+                            < app.diff_scroll.scroll_offset + visible_lines,
                         "cursor below viewport: selected_line={}, scroll_offset={}, \
                          visible_lines={}, diff_line_count={}, initial_scroll={}",
                         app.diff_scroll.selected_line,
@@ -3611,12 +3646,185 @@ fn test_cleanup_rally_state() {
     app.rally_command_sender = Some(cmd_tx);
     let (_, event_rx) = mpsc::channel(100);
     app.rally_event_receiver = Some(event_rx);
+    app.pending_rally_seed_review = Some(crate::ai::ReviewerOutput {
+        action: crate::ai::ReviewAction::RequestChanges,
+        summary: "seeded".to_string(),
+        comments: vec![],
+        blocking_issues: vec![],
+    });
 
     app.cleanup_rally_state();
 
     assert!(app.ai_rally_state.is_none());
     assert!(app.rally_command_sender.is_none());
     assert!(app.rally_event_receiver.is_none());
+    assert!(app.pending_rally_seed_review.is_none());
+}
+
+#[test]
+#[serial]
+fn test_build_seed_review_from_local_comments_returns_none_without_comments() {
+    let tempdir = tempdir().unwrap();
+    let workdir = tempdir.path().join("worktree");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let mut app = App::new_for_test();
+    app.local_mode = true;
+    app.repo = "owner/repo".to_string();
+    app.working_dir = Some(workdir.to_string_lossy().to_string());
+
+    let _cache_home = ScopedCacheHome::new(tempdir.path());
+
+    let seed = app.build_seed_review_from_local_comments().unwrap();
+
+    assert!(seed.is_none());
+}
+
+#[test]
+#[serial]
+fn test_build_seed_review_from_local_comments_uses_persisted_comments() {
+    let tempdir = tempdir().unwrap();
+    let workdir = tempdir.path().join("worktree");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let _cache_home = ScopedCacheHome::new(tempdir.path());
+
+    crate::cache::save_local_review_comments(
+        "owner/repo",
+        Some(workdir.to_string_lossy().as_ref()),
+        &[crate::github::comment::ReviewComment {
+            id: 1,
+            path: "src/main.rs".to_string(),
+            line: Some(12),
+            body: "Please simplify this branch.".to_string(),
+            user: crate::github::User {
+                login: "local".to_string(),
+            },
+            created_at: "2026-03-24T00:00:00Z".to_string(),
+            is_resolved: false,
+            resolved_at: None,
+        }],
+    )
+    .unwrap();
+
+    let mut app = App::new_for_test();
+    app.local_mode = true;
+    app.repo = "owner/repo".to_string();
+    app.working_dir = Some(workdir.to_string_lossy().to_string());
+
+    let seed = app
+        .build_seed_review_from_local_comments()
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(seed.action, crate::ai::ReviewAction::RequestChanges);
+    assert_eq!(seed.comments.len(), 1);
+    assert_eq!(seed.comments[0].path, "src/main.rs");
+    assert_eq!(seed.comments[0].line, 12);
+    assert_eq!(seed.comments[0].body, "Please simplify this branch.");
+    assert_eq!(
+        seed.comments[0].severity,
+        crate::ai::adapter::CommentSeverity::Major
+    );
+    assert!(seed.summary.contains("1 local comment"));
+}
+
+#[test]
+#[serial]
+fn test_build_seed_review_from_local_comments_skips_resolved_comments() {
+    let tempdir = tempdir().unwrap();
+    let workdir = tempdir.path().join("worktree");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let _cache_home = ScopedCacheHome::new(tempdir.path());
+
+    crate::cache::save_local_review_comments(
+        "owner/repo",
+        Some(workdir.to_string_lossy().as_ref()),
+        &[crate::github::comment::ReviewComment {
+            id: 1,
+            path: "src/main.rs".to_string(),
+            line: Some(12),
+            body: "Already handled.".to_string(),
+            user: crate::github::User {
+                login: "local".to_string(),
+            },
+            created_at: "2026-03-24T00:00:00Z".to_string(),
+            is_resolved: true,
+            resolved_at: Some("2026-03-24T01:00:00Z".to_string()),
+        }],
+    )
+    .unwrap();
+
+    let mut app = App::new_for_test();
+    app.local_mode = true;
+    app.repo = "owner/repo".to_string();
+    app.working_dir = Some(workdir.to_string_lossy().to_string());
+
+    let seed = app.build_seed_review_from_local_comments().unwrap();
+
+    assert!(seed.is_none());
+}
+
+#[test]
+#[serial]
+fn test_start_ai_rally_stashes_seed_review_while_waiting_for_confirmation() {
+    let tempdir = tempdir().unwrap();
+    let workdir = tempdir.path().join("worktree");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let _cache_home = ScopedCacheHome::new(tempdir.path());
+
+    crate::cache::save_local_review_comments(
+        "owner/repo",
+        Some(workdir.to_string_lossy().as_ref()),
+        &[crate::github::comment::ReviewComment {
+            id: 1,
+            path: "src/main.rs".to_string(),
+            line: Some(7),
+            body: "Handle the error explicitly.".to_string(),
+            user: crate::github::User {
+                login: "local".to_string(),
+            },
+            created_at: "2026-03-24T00:00:00Z".to_string(),
+            is_resolved: false,
+            resolved_at: None,
+        }],
+    )
+    .unwrap();
+
+    let mut app = App::new_for_test();
+    app.local_mode = true;
+    app.repo = "owner/repo".to_string();
+    app.pr_number = Some(0);
+    app.working_dir = Some(workdir.to_string_lossy().to_string());
+    app.config.local_overrides.insert("ai.reviewer".to_string());
+    app.data_state = DataState::Loaded {
+        pr: Box::new(make_local_pr()),
+        files: vec![ChangedFile {
+            filename: "src/main.rs".to_string(),
+            status: "modified".to_string(),
+            additions: 1,
+            deletions: 0,
+            patch: Some("@@ -1 +1 @@\n+fn main() {}".to_string()),
+            viewed: false,
+        }],
+    };
+
+    app.start_ai_rally();
+
+    assert_eq!(app.state, AppState::AiRally);
+    assert!(app.pending_rally_context.is_some());
+    assert!(app.pending_rally_prompt_loader.is_some());
+    assert!(app.pending_rally_seed_review.is_some());
+    assert_eq!(
+        app.pending_rally_seed_review
+            .as_ref()
+            .unwrap()
+            .comments
+            .len(),
+        1
+    );
 }
 
 #[test]
@@ -4148,7 +4356,9 @@ async fn test_jump_back_restores_position() {
                 status: "modified".to_string(),
                 additions: 1,
                 deletions: 0,
-                patch: Some("@@ -1,6 +1,6 @@\n line1\n line2\n line3\n line4\n line5\n+line6".to_string()),
+                patch: Some(
+                    "@@ -1,6 +1,6 @@\n line1\n line2\n line3\n line4\n line5\n+line6".to_string(),
+                ),
                 viewed: false,
             },
             ChangedFile {
@@ -4156,7 +4366,10 @@ async fn test_jump_back_restores_position() {
                 status: "modified".to_string(),
                 additions: 1,
                 deletions: 0,
-                patch: Some("@@ -1,11 +1,11 @@\n l1\n l2\n l3\n l4\n l5\n l6\n l7\n l8\n l9\n l10\n+l11".to_string()),
+                patch: Some(
+                    "@@ -1,11 +1,11 @@\n l1\n l2\n l3\n l4\n l5\n l6\n l7\n l8\n l9\n l10\n+l11"
+                        .to_string(),
+                ),
                 viewed: false,
             },
         ],
@@ -4246,6 +4459,32 @@ fn test_enter_suggestion_input_sets_mode() {
     assert_eq!(app.state, AppState::TextInput);
 }
 
+#[test]
+fn test_enter_comment_input_works_in_local_mode() {
+    let patch = "@@ -1,3 +1,4 @@\n context\n+added\n more context";
+    let mut app = make_app_with_patch(patch);
+    app.local_mode = true;
+    app.pr_number = Some(0);
+    app.data_state = DataState::Loaded {
+        pr: Box::new(make_local_pr()),
+        files: vec![ChangedFile {
+            filename: "test.rs".to_string(),
+            status: "modified".to_string(),
+            additions: 1,
+            deletions: 0,
+            patch: Some(patch.to_string()),
+            viewed: false,
+        }],
+    };
+    app.diff_scroll.selected_line = 2;
+    app.state = AppState::DiffView;
+
+    app.enter_comment_input();
+
+    assert!(matches!(app.input_mode, Some(InputMode::Comment(_))));
+    assert_eq!(app.state, AppState::TextInput);
+}
+
 #[tokio::test]
 async fn test_open_comment_list_transitions_state() {
     let mut app = App::new_for_test();
@@ -4296,6 +4535,112 @@ async fn test_open_comment_list_sets_previous_state() {
 }
 
 #[test]
+fn test_open_comment_list_transitions_state_in_local_mode() {
+    let mut app = App::new_for_test();
+    app.local_mode = true;
+    app.pr_number = Some(0);
+    app.data_state = DataState::Loaded {
+        pr: Box::new(make_local_pr()),
+        files: vec![],
+    };
+    app.state = AppState::FileList;
+    app.previous_state = AppState::FileList;
+
+    app.open_comment_list();
+
+    assert_eq!(app.state, AppState::CommentList);
+    assert_eq!(app.cmt.comment_tab, CommentTab::Review);
+}
+
+#[test]
+#[serial]
+fn test_submit_local_comment_persists_and_loads() {
+    let tempdir = tempdir().unwrap();
+    let workdir = tempdir.path().join("worktree");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let _cache_home = ScopedCacheHome::new(tempdir.path());
+
+    let patch = "@@ -1,3 +1,4 @@\n context\n+added\n more context";
+    let mut app = App::new_for_test();
+    app.repo = "owner/repo".to_string();
+    app.local_mode = true;
+    app.pr_number = Some(0);
+    app.working_dir = Some(workdir.to_string_lossy().to_string());
+    app.data_state = DataState::Loaded {
+        pr: Box::new(make_local_pr()),
+        files: vec![ChangedFile {
+            filename: "src/test.rs".to_string(),
+            status: "modified".to_string(),
+            additions: 1,
+            deletions: 0,
+            patch: Some(patch.to_string()),
+            viewed: false,
+        }],
+    };
+    app.diff_scroll.selected_line = 2;
+    app.state = AppState::DiffView;
+
+    let cache_key = PrCacheKey {
+        repo: app.repo.clone(),
+        pr_number: 0,
+    };
+    app.session_cache.put_pr_data(
+        cache_key,
+        PrData {
+            pr: Box::new(make_local_pr()),
+            files: app.files().to_vec(),
+            pr_updated_at: "".to_string(),
+        },
+    );
+
+    app.enter_comment_input();
+    let ctx = match app.input_mode.clone() {
+        Some(InputMode::Comment(ctx)) => ctx,
+        other => panic!("expected comment input mode, got {:?}", other),
+    };
+
+    app.submit_comment(ctx, "local note".to_string());
+
+    assert_eq!(app.cmt.review_comments.as_ref().map(|c: &Vec<crate::github::comment::ReviewComment>| c.len()), Some(1));
+    assert_eq!(
+        app.cmt.review_comments.as_ref().unwrap()[0].body,
+        "local note".to_string()
+    );
+
+    let mut reloaded = App::new_for_test();
+    reloaded.repo = "owner/repo".to_string();
+    reloaded.local_mode = true;
+    reloaded.pr_number = Some(0);
+    reloaded.working_dir = Some(workdir.to_string_lossy().to_string());
+    reloaded.data_state = DataState::Loaded {
+        pr: Box::new(make_local_pr()),
+        files: vec![ChangedFile {
+            filename: "src/test.rs".to_string(),
+            status: "modified".to_string(),
+            additions: 1,
+            deletions: 0,
+            patch: Some(patch.to_string()),
+            viewed: false,
+        }],
+    };
+    reloaded.load_review_comments();
+
+    let stored = reloaded.cmt.review_comments.unwrap();
+    assert_eq!(stored.len(), 1);
+    assert_eq!(stored[0].path, "src/test.rs");
+    assert_eq!(stored[0].line, Some(2));
+    assert_eq!(stored[0].body, "local note");
+
+    let path = crate::cache::local_review_comments_path(
+        "owner/repo",
+        Some(workdir.to_string_lossy().as_ref()),
+    )
+    .unwrap();
+    let _ = std::fs::remove_file(path);
+}
+
+#[test]
 fn test_update_file_comment_positions_empty_comments() {
     let mut app = make_app_with_patch("@@ -1,3 +1,4 @@\n context\n+added\n more context");
     app.cmt.review_comments = Some(vec![]);
@@ -4316,6 +4661,8 @@ fn test_update_file_comment_positions_with_comments() {
             login: "reviewer".to_string(),
         },
         created_at: "2024-01-01T00:00:00Z".to_string(),
+        is_resolved: false,
+        resolved_at: None,
     }]);
     app.update_file_comment_positions();
     assert_eq!(app.cmt.file_comment_positions.len(), 1);
@@ -4334,6 +4681,8 @@ fn test_update_file_comment_positions_stale_comment() {
             login: "reviewer".to_string(),
         },
         created_at: "2024-01-01T00:00:00Z".to_string(),
+        is_resolved: false,
+        resolved_at: None,
     }]);
     app.update_file_comment_positions();
     assert!(app.cmt.file_comment_positions.is_empty());
@@ -4401,6 +4750,8 @@ fn test_enter_reply_input_sets_mode() {
             login: "reviewer".to_string(),
         },
         created_at: "2024-01-01T00:00:00Z".to_string(),
+        is_resolved: false,
+        resolved_at: None,
     }]);
     app.cmt.file_comment_positions = vec![CommentPosition {
         diff_line_index: 1,
@@ -4487,6 +4838,8 @@ async fn test_jump_to_comment_sets_file_and_line() {
             login: "r".to_string(),
         },
         created_at: "2024-01-01T00:00:00Z".to_string(),
+        is_resolved: false,
+        resolved_at: None,
     }]);
     app.cmt.selected_comment = 0;
 
@@ -5361,7 +5714,10 @@ async fn test_ensure_diff_cache_non_md_ignores_markdown_rich_mismatch() {
     // ensure_diff_cache は非markdown なので markdown_rich 不一致を無視してキャッシュを維持
     app.ensure_diff_cache();
     assert!(
-        app.diff_store.current.as_ref().is_some_and(|c| c.highlighted),
+        app.diff_store
+            .current
+            .as_ref()
+            .is_some_and(|c| c.highlighted),
         "non-md file: highlighted cache should be preserved despite markdown_rich mismatch"
     );
 }
@@ -5397,7 +5753,10 @@ fn test_ensure_diff_cache_store_non_md_ignores_markdown_rich_mismatch() {
 
     // ストアから復元されるはず（markdown_rich 不一致は無視）
     assert!(
-        app.diff_store.current.as_ref().is_some_and(|c| c.highlighted),
+        app.diff_store
+            .current
+            .as_ref()
+            .is_some_and(|c| c.highlighted),
         "non-md file: store cache should be restored despite markdown_rich mismatch"
     );
 }
@@ -5431,7 +5790,10 @@ async fn test_ensure_diff_cache_md_invalidates_on_markdown_rich_mismatch() {
 
     // markdown ファイルなので markdown_rich 不一致 → 再構築（plain に戻る）
     assert!(
-        app.diff_store.current.as_ref().is_some_and(|c| !c.highlighted),
+        app.diff_store
+            .current
+            .as_ref()
+            .is_some_and(|c| !c.highlighted),
         "md file: cache should be rebuilt (plain) on markdown_rich mismatch"
     );
 }
@@ -6092,11 +6454,7 @@ fn make_app_with_files(filenames: &[&str]) -> App {
 
 #[test]
 fn test_toggle_file_tree_on() {
-    let mut app = make_app_with_files(&[
-        "src/app/mod.rs",
-        "src/lib.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/app/mod.rs", "src/lib.rs", "README.md"]);
 
     assert!(!app.tree_mode_active);
     assert!(app.file_tree_state.is_none());
@@ -6114,10 +6472,7 @@ fn test_toggle_file_tree_on() {
 
 #[test]
 fn test_toggle_file_tree_off_preserves_state() {
-    let mut app = make_app_with_files(&[
-        "src/app/mod.rs",
-        "src/lib.rs",
-    ]);
+    let mut app = make_app_with_files(&["src/app/mod.rs", "src/lib.rs"]);
 
     app.toggle_file_tree(); // ON
     assert!(app.tree_mode_active);
@@ -6144,11 +6499,7 @@ fn test_toggle_file_tree_off_preserves_state() {
 
 #[test]
 fn test_toggle_preserves_selection() {
-    let mut app = make_app_with_files(&[
-        "src/app/mod.rs",
-        "src/lib.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/app/mod.rs", "src/lib.rs", "README.md"]);
     app.selected_file = 1; // src/lib.rs
 
     app.toggle_file_tree(); // ON
@@ -6165,10 +6516,7 @@ fn test_toggle_preserves_selection() {
 
 #[test]
 fn test_retoggle_restores_expanded_dirs() {
-    let mut app = make_app_with_files(&[
-        "src/app/mod.rs",
-        "src/lib.rs",
-    ]);
+    let mut app = make_app_with_files(&["src/app/mod.rs", "src/lib.rs"]);
 
     app.toggle_file_tree(); // ON
 
@@ -6190,10 +6538,7 @@ fn test_retoggle_restores_expanded_dirs() {
 
 #[test]
 fn test_tree_nav_down_updates_selected_file() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "README.md"]);
 
     app.toggle_file_tree();
 
@@ -6215,11 +6560,7 @@ fn test_tree_nav_down_updates_selected_file() {
 
 #[test]
 fn test_tree_nav_on_dir_keeps_selected_file() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "tests/test.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "tests/test.rs", "README.md"]);
     app.selected_file = 2; // README.md
 
     app.toggle_file_tree();
@@ -6231,7 +6572,12 @@ fn test_tree_nav_on_dir_keeps_selected_file() {
     // Dir 行に移動しても selected_file は変わらない
     let old_selected = app.selected_file;
     // Dir 行にカーソルを強制配置
-    if let Some(dir_row) = app.file_tree_state.as_ref().unwrap().find_row_for_dir("src") {
+    if let Some(dir_row) = app
+        .file_tree_state
+        .as_ref()
+        .unwrap()
+        .find_row_for_dir("src")
+    {
         app.file_tree_state.as_mut().unwrap().selected_row = dir_row;
     }
     // file_tree_move_down で Dir 行を通過
@@ -6247,10 +6593,7 @@ fn test_tree_nav_on_dir_keeps_selected_file() {
 
 #[test]
 fn test_tree_enter_dir_toggles_expand() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "README.md"]);
 
     app.toggle_file_tree();
 
@@ -6275,10 +6618,7 @@ fn test_tree_enter_dir_toggles_expand() {
 
 #[test]
 fn test_tree_enter_file_opens_split() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "README.md"]);
 
     app.toggle_file_tree();
 
@@ -6294,10 +6634,7 @@ fn test_tree_enter_file_opens_split() {
 
 #[test]
 fn test_tree_dir_row_blocks_mark_viewed() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "README.md"]);
 
     app.toggle_file_tree();
 
@@ -6312,10 +6649,7 @@ fn test_tree_dir_row_blocks_mark_viewed() {
 
 #[test]
 fn test_tree_filter_shows_flat() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "README.md"]);
 
     app.toggle_file_tree();
     assert!(app.is_file_tree_active());
@@ -6329,10 +6663,7 @@ fn test_tree_filter_shows_flat() {
 
 #[test]
 fn test_tree_survives_filter_clear() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "README.md"]);
 
     app.toggle_file_tree();
     let _tree_row_count = app.file_tree_state.as_ref().unwrap().row_count();
@@ -6353,33 +6684,34 @@ fn test_tree_survives_filter_clear() {
 
 #[test]
 fn test_selected_file_always_valid_index() {
-    let mut app = make_app_with_files(&[
-        "src/app/mod.rs",
-        "src/lib.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/app/mod.rs", "src/lib.rs", "README.md"]);
 
     app.toggle_file_tree();
 
     // 様々なナビゲーション操作後も selected_file は有効
     for _ in 0..10 {
         app.file_tree_move_down();
-        assert!(app.selected_file < app.files().len(),
-            "selected_file {} >= files().len() {}", app.selected_file, app.files().len());
+        assert!(
+            app.selected_file < app.files().len(),
+            "selected_file {} >= files().len() {}",
+            app.selected_file,
+            app.files().len()
+        );
     }
     for _ in 0..10 {
         app.file_tree_move_up();
-        assert!(app.selected_file < app.files().len(),
-            "selected_file {} >= files().len() {}", app.selected_file, app.files().len());
+        assert!(
+            app.selected_file < app.files().len(),
+            "selected_file {} >= files().len() {}",
+            app.selected_file,
+            app.files().len()
+        );
     }
 }
 
 #[test]
 fn test_rebuild_on_data_reload() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "README.md"]);
 
     app.toggle_file_tree();
 
@@ -6429,11 +6761,7 @@ fn test_tree_page_down_up() {
 
 #[test]
 fn test_tree_jump_to_first_last() {
-    let mut app = make_app_with_files(&[
-        "src/a.rs",
-        "src/b.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/a.rs", "src/b.rs", "README.md"]);
 
     app.toggle_file_tree();
 
@@ -6477,16 +6805,21 @@ fn test_deep_nested_collapse_hides_descendants() {
     use crate::app::file_tree::FileTreeState;
 
     let mut tree = FileTreeState::new();
-    tree.rebuild(&[
-        (0, "a/b/c/file.rs"),
-        (1, "a/b/other.rs"),
-        (2, "a/top.rs"),
-    ]);
+    tree.rebuild(&[(0, "a/b/c/file.rs"), (1, "a/b/other.rs"), (2, "a/top.rs")]);
 
     // 初回: 全ディレクトリ展開、全ファイル表示
-    assert!(tree.find_row_for_file(0).is_some(), "file.rs should be visible");
-    assert!(tree.find_row_for_file(1).is_some(), "other.rs should be visible");
-    assert!(tree.find_row_for_file(2).is_some(), "top.rs should be visible");
+    assert!(
+        tree.find_row_for_file(0).is_some(),
+        "file.rs should be visible"
+    );
+    assert!(
+        tree.find_row_for_file(1).is_some(),
+        "other.rs should be visible"
+    );
+    assert!(
+        tree.find_row_for_file(2).is_some(),
+        "top.rs should be visible"
+    );
 
     // "a" を折り畳む → 全子孫が非表示
     let a_row = tree.find_row_for_dir("a").unwrap();
@@ -6494,26 +6827,52 @@ fn test_deep_nested_collapse_hides_descendants() {
     tree.toggle_expand();
 
     // "a" 行のみ残る
-    assert_eq!(tree.row_count(), 1, "only 'a' dir should remain, dump:\n{}", tree.dump_tree());
-    assert!(tree.find_row_for_dir("a/b").is_none(), "a/b should be hidden");
-    assert!(tree.find_row_for_dir("a/b/c").is_none(), "a/b/c should be hidden");
-    assert!(tree.find_row_for_file(0).is_none(), "file.rs should be hidden");
-    assert!(tree.find_row_for_file(1).is_none(), "other.rs should be hidden");
-    assert!(tree.find_row_for_file(2).is_none(), "top.rs should be hidden");
+    assert_eq!(
+        tree.row_count(),
+        1,
+        "only 'a' dir should remain, dump:\n{}",
+        tree.dump_tree()
+    );
+    assert!(
+        tree.find_row_for_dir("a/b").is_none(),
+        "a/b should be hidden"
+    );
+    assert!(
+        tree.find_row_for_dir("a/b/c").is_none(),
+        "a/b/c should be hidden"
+    );
+    assert!(
+        tree.find_row_for_file(0).is_none(),
+        "file.rs should be hidden"
+    );
+    assert!(
+        tree.find_row_for_file(1).is_none(),
+        "other.rs should be hidden"
+    );
+    assert!(
+        tree.find_row_for_file(2).is_none(),
+        "top.rs should be hidden"
+    );
 
     // "a" を再展開 → "a/b" は expanded のまま、"a/b/c" も
     tree.toggle_expand();
-    assert!(tree.find_row_for_file(0).is_some(), "file.rs should be visible again");
-    assert!(tree.find_row_for_file(1).is_some(), "other.rs should be visible again");
-    assert!(tree.find_row_for_file(2).is_some(), "top.rs should be visible again");
+    assert!(
+        tree.find_row_for_file(0).is_some(),
+        "file.rs should be visible again"
+    );
+    assert!(
+        tree.find_row_for_file(1).is_some(),
+        "other.rs should be visible again"
+    );
+    assert!(
+        tree.find_row_for_file(2).is_some(),
+        "top.rs should be visible again"
+    );
 }
 
 #[test]
 fn test_select_pr_resets_tree_state() {
-    let mut app = make_app_with_files(&[
-        "src/main.rs",
-        "README.md",
-    ]);
+    let mut app = make_app_with_files(&["src/main.rs", "README.md"]);
     app.started_from_pr_list = true;
 
     app.toggle_file_tree();

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -701,6 +701,7 @@ async fn test_handle_data_result_resyncs_comment_positions_when_selected_file_ch
         id: 1,
         path: "file_4.rs".to_string(),
         line: Some(1),
+        start_line: None,
         body: "comment on old file".to_string(),
         user: crate::github::User {
             login: "reviewer".to_string(),
@@ -3696,6 +3697,7 @@ fn test_build_seed_review_from_local_comments_uses_persisted_comments() {
             id: 1,
             path: "src/main.rs".to_string(),
             line: Some(12),
+            start_line: None,
             body: "Please simplify this branch.".to_string(),
             user: crate::github::User {
                 login: "local".to_string(),
@@ -3745,6 +3747,7 @@ fn test_build_seed_review_from_local_comments_skips_resolved_comments() {
             id: 1,
             path: "src/main.rs".to_string(),
             line: Some(12),
+            start_line: None,
             body: "Already handled.".to_string(),
             user: crate::github::User {
                 login: "local".to_string(),
@@ -3782,6 +3785,7 @@ fn test_start_ai_rally_stashes_seed_review_while_waiting_for_confirmation() {
             id: 1,
             path: "src/main.rs".to_string(),
             line: Some(7),
+            start_line: None,
             body: "Handle the error explicitly.".to_string(),
             user: crate::github::User {
                 login: "local".to_string(),
@@ -4656,6 +4660,7 @@ fn test_update_file_comment_positions_with_comments() {
         id: 1,
         path: "test.rs".to_string(),
         line: Some(1),
+        start_line: None,
         body: "comment at line 1".to_string(),
         user: crate::github::User {
             login: "reviewer".to_string(),
@@ -4676,6 +4681,7 @@ fn test_update_file_comment_positions_stale_comment() {
         id: 1,
         path: "other_file.rs".to_string(), // different file
         line: Some(1),
+        start_line: None,
         body: "wrong file".to_string(),
         user: crate::github::User {
             login: "reviewer".to_string(),
@@ -4745,6 +4751,7 @@ fn test_enter_reply_input_sets_mode() {
         id: 42,
         path: "test.rs".to_string(),
         line: Some(1),
+        start_line: None,
         body: "original comment".to_string(),
         user: crate::github::User {
             login: "reviewer".to_string(),
@@ -4833,6 +4840,7 @@ async fn test_jump_to_comment_sets_file_and_line() {
         id: 1,
         path: "second.rs".to_string(),
         line: Some(2),
+        start_line: None,
         body: "check this".to_string(),
         user: crate::github::User {
             login: "r".to_string(),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -90,7 +90,7 @@ fn hash_path_for_filename(path: &str) -> u64 {
     hasher.finish()
 }
 
-fn effective_working_dir(working_dir: Option<&str>) -> Result<String> {
+pub fn effective_working_dir(working_dir: Option<&str>) -> Result<String> {
     if let Some(dir) = working_dir {
         return Ok(dir.to_owned());
     }
@@ -477,6 +477,7 @@ mod tests {
             id: 1,
             path: "src/main.rs".to_string(),
             line: Some(42),
+            start_line: None,
             body: "hello".to_string(),
             user: User {
                 login: "local".to_string(),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,7 +1,11 @@
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
+use std::fs;
+use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use xdg::BaseDirectories;
 
 use crate::github::comment::{DiscussionComment, ReviewComment};
@@ -70,6 +74,118 @@ pub fn cleanup_rally_sessions() {
             let _ = std::fs::remove_dir_all(path);
         }
     }
+}
+
+const LOCAL_REVIEW_COMMENTS_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct LocalReviewCommentsFile {
+    version: u32,
+    comments: Vec<ReviewComment>,
+}
+
+fn hash_path_for_filename(path: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn effective_working_dir(working_dir: Option<&str>) -> Result<String> {
+    if let Some(dir) = working_dir {
+        return Ok(dir.to_owned());
+    }
+    std::env::current_dir()
+        .map(|path| path.to_string_lossy().to_string())
+        .map_err(|e| anyhow::anyhow!("Failed to determine working directory: {}", e))
+}
+
+pub fn local_review_comments_path(repo: &str, working_dir: Option<&str>) -> Result<PathBuf> {
+    local_review_comments_path_with_base(repo, working_dir, &cache_dir())
+}
+
+fn local_review_comments_path_with_base(
+    repo: &str,
+    working_dir: Option<&str>,
+    base: &std::path::Path,
+) -> Result<PathBuf> {
+    let repo = sanitize_repo_name(repo)?;
+    let workdir = effective_working_dir(working_dir)?;
+    let workdir_hash = hash_path_for_filename(&workdir);
+    Ok(base
+        .join("local-comments")
+        .join(format!("{}-{:016x}.json", repo, workdir_hash)))
+}
+
+pub fn load_local_review_comments(
+    repo: &str,
+    working_dir: Option<&str>,
+) -> Result<Vec<ReviewComment>> {
+    load_local_review_comments_with_base(repo, working_dir, &cache_dir())
+}
+
+fn load_local_review_comments_with_base(
+    repo: &str,
+    working_dir: Option<&str>,
+    base: &std::path::Path,
+) -> Result<Vec<ReviewComment>> {
+    let path = local_review_comments_path_with_base(repo, working_dir, base)?;
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let content = fs::read_to_string(&path)
+        .map_err(|e| anyhow::anyhow!("Failed to read {}: {}", path.display(), e))?;
+    let file: LocalReviewCommentsFile = serde_json::from_str(&content)
+        .map_err(|e| anyhow::anyhow!("Failed to parse {}: {}", path.display(), e))?;
+
+    if file.version != LOCAL_REVIEW_COMMENTS_VERSION {
+        return Err(anyhow::anyhow!(
+            "Unsupported local comments version: {}",
+            file.version
+        ));
+    }
+
+    Ok(file.comments)
+}
+
+pub fn save_local_review_comments(
+    repo: &str,
+    working_dir: Option<&str>,
+    comments: &[ReviewComment],
+) -> Result<()> {
+    save_local_review_comments_with_base(repo, working_dir, comments, &cache_dir())
+}
+
+fn save_local_review_comments_with_base(
+    repo: &str,
+    working_dir: Option<&str>,
+    comments: &[ReviewComment],
+    base: &std::path::Path,
+) -> Result<()> {
+    let path = local_review_comments_path_with_base(repo, working_dir, base)?;
+
+    if comments.is_empty() {
+        if path.exists() {
+            fs::remove_file(&path)
+                .map_err(|e| anyhow::anyhow!("Failed to remove {}: {}", path.display(), e))?;
+        }
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("Failed to create {}: {}", parent.display(), e))?;
+    }
+
+    let payload = LocalReviewCommentsFile {
+        version: LOCAL_REVIEW_COMMENTS_VERSION,
+        comments: comments.to_vec(),
+    };
+    let json = serde_json::to_string_pretty(&payload)
+        .map_err(|e| anyhow::anyhow!("Failed to serialize local review comments: {}", e))?;
+    fs::write(&path, json)
+        .map_err(|e| anyhow::anyhow!("Failed to write {}: {}", path.display(), e))?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -217,6 +333,8 @@ impl SessionCache {
 mod tests {
     use super::*;
     use crate::github::{Branch, User};
+    use serial_test::serial;
+    use tempfile::tempdir;
 
     fn make_test_pr(title: &str, updated_at: &str) -> PullRequest {
         PullRequest {
@@ -345,6 +463,61 @@ mod tests {
             sanitize_repo_name("simple-repo").unwrap(),
             "simple-repo".to_string()
         );
+    }
+
+    #[test]
+    #[serial]
+    fn test_local_review_comments_roundtrip() {
+        let tempdir = tempdir().unwrap();
+        let base = tempdir.path().join("cache");
+        let workdir = tempdir.path().join("worktree");
+        fs::create_dir_all(&workdir).unwrap();
+
+        let comments = vec![ReviewComment {
+            id: 1,
+            path: "src/main.rs".to_string(),
+            line: Some(42),
+            body: "hello".to_string(),
+            user: User {
+                login: "local".to_string(),
+            },
+            created_at: "2026-03-24T00:00:00Z".to_string(),
+            is_resolved: false,
+            resolved_at: None,
+        }];
+
+        save_local_review_comments_with_base(
+            "owner/repo",
+            Some(workdir.to_string_lossy().as_ref()),
+            &comments,
+            &base,
+        )
+        .unwrap();
+
+        let loaded = load_local_review_comments_with_base(
+            "owner/repo",
+            Some(workdir.to_string_lossy().as_ref()),
+            &base,
+        )
+        .unwrap();
+
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].body, "hello");
+        assert_eq!(loaded[0].line, Some(42));
+    }
+
+    #[test]
+    #[serial]
+    fn test_local_review_comments_path_changes_with_workdir() {
+        let tempdir = tempdir().unwrap();
+        let base = tempdir.path();
+
+        let path_a =
+            local_review_comments_path_with_base("owner/repo", Some("/tmp/a"), base).unwrap();
+        let path_b =
+            local_review_comments_path_with_base("owner/repo", Some("/tmp/b"), base).unwrap();
+
+        assert_ne!(path_a, path_b);
     }
 
     #[test]

--- a/src/github/comment.rs
+++ b/src/github/comment.rs
@@ -14,16 +14,27 @@ async fn fetch_and_parse<T: DeserializeOwned>(
     serde_json::from_value(json).context(error_context)
 }
 
+/// Unified review comment used for both GitHub API responses and local-mode comments.
+///
+/// Fields marked "local-only" (`is_resolved`, `resolved_at`, `start_line`) are only
+/// meaningful for local comments. They default to zero-values via `#[serde(default)]`
+/// and are omitted from serialization when empty (`skip_serializing_if`), so GitHub API
+/// deserialization is unaffected.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReviewComment {
     pub id: u64,
     pub path: String,
     pub line: Option<u32>,
+    /// Start line for multiline comments (local-only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_line: Option<u32>,
     pub body: String,
     pub user: User,
     pub created_at: String,
+    /// Whether this comment has been resolved (local-only).
     #[serde(default)]
     pub is_resolved: bool,
+    /// Timestamp when resolved (local-only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_at: Option<String>,
 }
@@ -197,6 +208,7 @@ mod tests {
             id: 1,
             path: "lib.rs".to_string(),
             line: Some(10),
+            start_line: None,
             body: "LGTM".to_string(),
             user: User { login: "dev".to_string() },
             created_at: "2025-03-01T12:00:00Z".to_string(),
@@ -310,6 +322,22 @@ mod tests {
             "created_at": "2025-01-01T00:00:00Z"
         });
         let comment: ReviewComment = serde_json::from_value(json).unwrap();
-        assert_snapshot!(format!("{:?}", comment), @r#"ReviewComment { id: 555, path: "src/app.rs", line: Some(100), body: "Snapshot test body", user: User { login: "snapshot_user" }, created_at: "2025-01-01T00:00:00Z", is_resolved: false, resolved_at: None }"#);
+        assert_snapshot!(format!("{:?}", comment), @r#"ReviewComment { id: 555, path: "src/app.rs", line: Some(100), start_line: None, body: "Snapshot test body", user: User { login: "snapshot_user" }, created_at: "2025-01-01T00:00:00Z", is_resolved: false, resolved_at: None }"#);
+    }
+
+    #[test]
+    fn test_review_comment_snapshot_resolved() {
+        let comment = ReviewComment {
+            id: 10,
+            path: "src/app.rs".to_string(),
+            line: Some(50),
+            start_line: Some(45),
+            body: "Resolved comment".to_string(),
+            user: User { login: "dacuna".to_string() },
+            created_at: "2026-03-25T00:00:00Z".to_string(),
+            is_resolved: true,
+            resolved_at: Some("2026-03-25T01:00:00Z".to_string()),
+        };
+        assert_snapshot!(format!("{:?}", comment), @r#"ReviewComment { id: 10, path: "src/app.rs", line: Some(50), start_line: Some(45), body: "Resolved comment", user: User { login: "dacuna" }, created_at: "2026-03-25T00:00:00Z", is_resolved: true, resolved_at: Some("2026-03-25T01:00:00Z") }"#);
     }
 }

--- a/src/github/comment.rs
+++ b/src/github/comment.rs
@@ -22,6 +22,10 @@ pub struct ReviewComment {
     pub body: String,
     pub user: User,
     pub created_at: String,
+    #[serde(default)]
+    pub is_resolved: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_at: Option<String>,
 }
 
 pub async fn fetch_review_comments(repo: &str, pr_number: u32) -> Result<Vec<ReviewComment>> {
@@ -196,6 +200,8 @@ mod tests {
             body: "LGTM".to_string(),
             user: User { login: "dev".to_string() },
             created_at: "2025-03-01T12:00:00Z".to_string(),
+            is_resolved: false,
+            resolved_at: None,
         };
         let serialized = serde_json::to_string(&original).unwrap();
         let deserialized: ReviewComment = serde_json::from_str(&serialized).unwrap();
@@ -304,6 +310,6 @@ mod tests {
             "created_at": "2025-01-01T00:00:00Z"
         });
         let comment: ReviewComment = serde_json::from_value(json).unwrap();
-        assert_snapshot!(format!("{:?}", comment), @r#"ReviewComment { id: 555, path: "src/app.rs", line: Some(100), body: "Snapshot test body", user: User { login: "snapshot_user" }, created_at: "2025-01-01T00:00:00Z" }"#);
+        assert_snapshot!(format!("{:?}", comment), @r#"ReviewComment { id: 555, path: "src/app.rs", line: Some(100), body: "Snapshot test body", user: User { login: "snapshot_user" }, created_at: "2025-01-01T00:00:00Z", is_resolved: false, resolved_at: None }"#);
     }
 }

--- a/src/local_comments.rs
+++ b/src/local_comments.rs
@@ -58,7 +58,7 @@ pub async fn show_local_comments_command(
     resolved: bool,
 ) -> Result<()> {
     let repo = resolve_repo(repo).await;
-    let working_dir = resolve_working_dir_arg(working_dir)?;
+    let working_dir = cache::effective_working_dir(working_dir.as_deref())?;
     let filter = local_comments_filter(all, resolved);
 
     let comments = cache::load_local_review_comments(&repo, Some(&working_dir))?;
@@ -113,7 +113,7 @@ pub async fn update_local_comments_command(
     };
 
     let repo = resolve_repo(repo).await;
-    let working_dir = resolve_working_dir_arg(working_dir)?;
+    let working_dir = cache::effective_working_dir(working_dir.as_deref())?;
 
     let mut comments = cache::load_local_review_comments(&repo, Some(&working_dir))?;
     let result = update_local_comments(&mut comments, &ids, action);
@@ -136,15 +136,6 @@ async fn resolve_repo(repo: Option<String>) -> String {
         None => github::detect_repo()
             .await
             .unwrap_or_else(|_| "local".to_string()),
-    }
-}
-
-fn resolve_working_dir_arg(working_dir: Option<String>) -> Result<String> {
-    match working_dir {
-        Some(dir) => Ok(dir),
-        None => std::env::current_dir()
-            .map(|path| path.to_string_lossy().to_string())
-            .map_err(|e| anyhow::anyhow!("Failed to determine working directory: {}", e)),
     }
 }
 
@@ -334,6 +325,7 @@ fn join_ids(ids: &[u64]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use insta::assert_snapshot;
     use octorus::github::comment::ReviewComment;
     use octorus::github::User;
 
@@ -344,6 +336,7 @@ mod tests {
                 id: 1,
                 path: "src/a.rs".to_string(),
                 line: Some(10),
+                start_line: None,
                 body: "older".to_string(),
                 user: User {
                     login: "alice".to_string(),
@@ -356,6 +349,7 @@ mod tests {
                 id: 2,
                 path: "src/b.rs".to_string(),
                 line: Some(20),
+                start_line: None,
                 body: "newer".to_string(),
                 user: User {
                     login: "bob".to_string(),
@@ -380,6 +374,7 @@ mod tests {
                 id: 1,
                 path: "src/a.rs".to_string(),
                 line: Some(10),
+                start_line: None,
                 body: "first".to_string(),
                 user: User {
                     login: "alice".to_string(),
@@ -392,6 +387,7 @@ mod tests {
                 id: 2,
                 path: "src/b.rs".to_string(),
                 line: Some(20),
+                start_line: None,
                 body: "second".to_string(),
                 user: User {
                     login: "bob".to_string(),
@@ -414,6 +410,7 @@ mod tests {
             id: 7,
             path: "src/main.rs".to_string(),
             line: Some(42),
+            start_line: None,
             body: "why is this here?".to_string(),
             user: User {
                 login: "dacuna".to_string(),
@@ -479,6 +476,7 @@ mod tests {
             id: 7,
             path: "src/main.rs".to_string(),
             line: Some(42),
+            start_line: None,
             body: "why is this here?".to_string(),
             user: User {
                 login: "dacuna".to_string(),
@@ -507,6 +505,7 @@ mod tests {
             id: 1,
             path: "src/main.rs".to_string(),
             line: Some(1),
+            start_line: None,
             body: "hello".to_string(),
             user: User {
                 login: "dacuna".to_string(),
@@ -529,6 +528,7 @@ mod tests {
                 id: 1,
                 path: "src/main.rs".to_string(),
                 line: Some(1),
+                start_line: None,
                 body: "open".to_string(),
                 user: User {
                     login: "dacuna".to_string(),
@@ -541,6 +541,7 @@ mod tests {
                 id: 2,
                 path: "src/main.rs".to_string(),
                 line: Some(2),
+                start_line: None,
                 body: "resolved".to_string(),
                 user: User {
                     login: "dacuna".to_string(),
@@ -564,6 +565,7 @@ mod tests {
                 id: 1,
                 path: "src/main.rs".to_string(),
                 line: Some(1),
+                start_line: None,
                 body: "open".to_string(),
                 user: User {
                     login: "dacuna".to_string(),
@@ -576,6 +578,7 @@ mod tests {
                 id: 2,
                 path: "src/main.rs".to_string(),
                 line: Some(2),
+                start_line: None,
                 body: "resolved".to_string(),
                 user: User {
                     login: "dacuna".to_string(),
@@ -590,5 +593,56 @@ mod tests {
 
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].id, 2);
+    }
+
+    #[test]
+    fn test_snapshot_format_local_comments_text_with_comments() {
+        let comments = vec![ReviewComment {
+            id: 7,
+            path: "src/main.rs".to_string(),
+            line: Some(42),
+            start_line: None,
+            body: "why is this here?".to_string(),
+            user: User {
+                login: "dacuna".to_string(),
+            },
+            created_at: "2026-03-25T02:00:00+00:00".to_string(),
+            is_resolved: false,
+            resolved_at: None,
+        }];
+
+        assert_snapshot!(
+            format_local_comments_text(
+                "owner/repo",
+                "/tmp/worktree",
+                1,
+                1,
+                LocalCommentsFilter::Open,
+                &comments,
+            ),
+            @"
+        Showing 1 comment (open) for owner/repo (/tmp/worktree) [open: 1, resolved: 0, total: 1]
+
+        #7 [open] 2026-03-25T02:00:00+00:00 src/main.rs:42 dacuna
+          why is this here?
+        "
+        );
+    }
+
+    #[test]
+    fn test_snapshot_format_update_local_comments_text() {
+        let payload = UpdateLocalCommentsOutput {
+            repo: "owner/repo".to_string(),
+            working_dir: "/tmp/worktree".to_string(),
+            action: LocalCommentAction::Resolve,
+            updated_ids: vec![3, 7],
+            missing_ids: vec![99],
+        };
+
+        assert_snapshot!(format_update_local_comments_text(&payload), @"
+        Resolved 2 local comments for owner/repo (/tmp/worktree)
+        Updated IDs: 3, 7
+        Missing IDs: 99
+        ");
     }
 }

--- a/src/local_comments.rs
+++ b/src/local_comments.rs
@@ -1,0 +1,594 @@
+use anyhow::Result;
+use chrono::DateTime;
+use serde::Serialize;
+
+use octorus::{cache, github};
+
+#[derive(Debug, Clone, Serialize)]
+struct LocalCommentsOutput {
+    repo: String,
+    working_dir: String,
+    total_comments: usize,
+    open_comments: usize,
+    resolved_comments: usize,
+    shown_comments: usize,
+    filter: LocalCommentsFilter,
+    comments: Vec<github::comment::ReviewComment>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct UpdateLocalCommentsOutput {
+    repo: String,
+    working_dir: String,
+    action: LocalCommentAction,
+    updated_ids: Vec<u64>,
+    missing_ids: Vec<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum LocalCommentAction {
+    Resolve,
+    Reopen,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum LocalCommentsFilter {
+    Open,
+    Resolved,
+    All,
+}
+
+impl LocalCommentAction {
+    fn past_tense(self) -> &'static str {
+        match self {
+            Self::Resolve => "Resolved",
+            Self::Reopen => "Reopened",
+        }
+    }
+}
+
+pub async fn show_local_comments_command(
+    repo: Option<String>,
+    working_dir: Option<String>,
+    limit: usize,
+    json: bool,
+    all: bool,
+    resolved: bool,
+) -> Result<()> {
+    let repo = resolve_repo(repo).await;
+    let working_dir = resolve_working_dir_arg(working_dir)?;
+    let filter = local_comments_filter(all, resolved);
+
+    let comments = cache::load_local_review_comments(&repo, Some(&working_dir))?;
+    let total_comments = comments.len();
+    let open_comments = comments
+        .iter()
+        .filter(|comment| !comment.is_resolved)
+        .count();
+    let resolved_comments = total_comments.saturating_sub(open_comments);
+    let comments = select_latest_local_comments(filter_local_comments(comments, filter), limit);
+
+    if json {
+        let payload = LocalCommentsOutput {
+            repo,
+            working_dir,
+            total_comments,
+            open_comments,
+            resolved_comments,
+            shown_comments: comments.len(),
+            filter,
+            comments,
+        };
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    print!(
+        "{}",
+        format_local_comments_text(
+            &repo,
+            &working_dir,
+            total_comments,
+            open_comments,
+            filter,
+            &comments,
+        )
+    );
+    Ok(())
+}
+
+pub async fn update_local_comments_command(
+    repo: Option<String>,
+    working_dir: Option<String>,
+    resolve: bool,
+    reopen: bool,
+    ids: Vec<u64>,
+) -> Result<()> {
+    let action = match (resolve, reopen) {
+        (true, false) => LocalCommentAction::Resolve,
+        (false, true) => LocalCommentAction::Reopen,
+        _ => anyhow::bail!("Specify exactly one action: --resolve or --reopen"),
+    };
+
+    let repo = resolve_repo(repo).await;
+    let working_dir = resolve_working_dir_arg(working_dir)?;
+
+    let mut comments = cache::load_local_review_comments(&repo, Some(&working_dir))?;
+    let result = update_local_comments(&mut comments, &ids, action);
+    cache::save_local_review_comments(&repo, Some(&working_dir), &comments)?;
+
+    let payload = UpdateLocalCommentsOutput {
+        repo,
+        working_dir,
+        action,
+        updated_ids: result.updated_ids,
+        missing_ids: result.missing_ids,
+    };
+    print!("{}", format_update_local_comments_text(&payload));
+    Ok(())
+}
+
+async fn resolve_repo(repo: Option<String>) -> String {
+    match repo {
+        Some(repo) => repo,
+        None => github::detect_repo()
+            .await
+            .unwrap_or_else(|_| "local".to_string()),
+    }
+}
+
+fn resolve_working_dir_arg(working_dir: Option<String>) -> Result<String> {
+    match working_dir {
+        Some(dir) => Ok(dir),
+        None => std::env::current_dir()
+            .map(|path| path.to_string_lossy().to_string())
+            .map_err(|e| anyhow::anyhow!("Failed to determine working directory: {}", e)),
+    }
+}
+
+fn local_comments_filter(all: bool, resolved: bool) -> LocalCommentsFilter {
+    if all {
+        LocalCommentsFilter::All
+    } else if resolved {
+        LocalCommentsFilter::Resolved
+    } else {
+        LocalCommentsFilter::Open
+    }
+}
+
+fn filter_local_comments(
+    comments: Vec<github::comment::ReviewComment>,
+    filter: LocalCommentsFilter,
+) -> Vec<github::comment::ReviewComment> {
+    comments
+        .into_iter()
+        .filter(|comment| match filter {
+            LocalCommentsFilter::Open => !comment.is_resolved,
+            LocalCommentsFilter::Resolved => comment.is_resolved,
+            LocalCommentsFilter::All => true,
+        })
+        .collect()
+}
+
+fn select_latest_local_comments(
+    mut comments: Vec<github::comment::ReviewComment>,
+    limit: usize,
+) -> Vec<github::comment::ReviewComment> {
+    comments.sort_by(|a, b| {
+        parse_comment_timestamp(&b.created_at)
+            .cmp(&parse_comment_timestamp(&a.created_at))
+            .then_with(|| b.id.cmp(&a.id))
+    });
+    comments.truncate(limit);
+    comments
+}
+
+fn parse_comment_timestamp(created_at: &str) -> Option<DateTime<chrono::FixedOffset>> {
+    DateTime::parse_from_rfc3339(created_at).ok()
+}
+
+fn format_local_comments_text(
+    repo: &str,
+    working_dir: &str,
+    total_comments: usize,
+    open_comments: usize,
+    filter: LocalCommentsFilter,
+    comments: &[github::comment::ReviewComment],
+) -> String {
+    if total_comments == 0 {
+        return format!("No local comments found for {} ({})\n", repo, working_dir);
+    }
+
+    let resolved_comments = total_comments.saturating_sub(open_comments);
+    let filter_label = match filter {
+        LocalCommentsFilter::Open => "open",
+        LocalCommentsFilter::Resolved => "resolved",
+        LocalCommentsFilter::All => "all",
+    };
+
+    if comments.is_empty() {
+        return format!(
+            "No {} local comments for {} ({}) [open: {}, resolved: {}, total: {}]\n",
+            filter_label, repo, working_dir, open_comments, resolved_comments, total_comments,
+        );
+    }
+
+    let mut out = format!(
+        "Showing {} comment{} ({}) for {} ({}) [open: {}, resolved: {}, total: {}]\n\n",
+        comments.len(),
+        if comments.len() == 1 { "" } else { "s" },
+        filter_label,
+        repo,
+        working_dir,
+        open_comments,
+        resolved_comments,
+        total_comments,
+    );
+
+    for comment in comments {
+        let line = comment
+            .line
+            .map(|line| line.to_string())
+            .unwrap_or_else(|| "-".to_string());
+        let status = if comment.is_resolved {
+            "resolved"
+        } else {
+            "open"
+        };
+        out.push_str(&format!(
+            "#{} [{}] {} {}:{} {}\n",
+            comment.id, status, comment.created_at, comment.path, line, comment.user.login
+        ));
+        for body_line in comment.body.lines() {
+            out.push_str("  ");
+            out.push_str(body_line);
+            out.push('\n');
+        }
+        if comment.body.is_empty() {
+            out.push_str("  \n");
+        }
+        out.push('\n');
+    }
+
+    out
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LocalCommentUpdateResult {
+    updated_ids: Vec<u64>,
+    missing_ids: Vec<u64>,
+}
+
+fn update_local_comments(
+    comments: &mut [github::comment::ReviewComment],
+    ids: &[u64],
+    action: LocalCommentAction,
+) -> LocalCommentUpdateResult {
+    let mut updated_ids = Vec::new();
+    let mut missing_ids = Vec::new();
+
+    for id in ids {
+        let Some(comment) = comments.iter_mut().find(|comment| comment.id == *id) else {
+            missing_ids.push(*id);
+            continue;
+        };
+
+        match action {
+            LocalCommentAction::Resolve => {
+                comment.is_resolved = true;
+                comment.resolved_at = Some(chrono::Utc::now().to_rfc3339());
+            }
+            LocalCommentAction::Reopen => {
+                comment.is_resolved = false;
+                comment.resolved_at = None;
+            }
+        }
+        updated_ids.push(*id);
+    }
+
+    LocalCommentUpdateResult {
+        updated_ids,
+        missing_ids,
+    }
+}
+
+fn format_update_local_comments_text(payload: &UpdateLocalCommentsOutput) -> String {
+    let mut out = format!(
+        "{} {} local comment{} for {} ({})\n",
+        payload.action.past_tense(),
+        payload.updated_ids.len(),
+        if payload.updated_ids.len() == 1 {
+            ""
+        } else {
+            "s"
+        },
+        payload.repo,
+        payload.working_dir
+    );
+
+    if !payload.updated_ids.is_empty() {
+        out.push_str(&format!(
+            "Updated IDs: {}\n",
+            join_ids(&payload.updated_ids)
+        ));
+    }
+    if !payload.missing_ids.is_empty() {
+        out.push_str(&format!(
+            "Missing IDs: {}\n",
+            join_ids(&payload.missing_ids)
+        ));
+    }
+
+    out
+}
+
+fn join_ids(ids: &[u64]) -> String {
+    ids.iter()
+        .map(u64::to_string)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use octorus::github::comment::ReviewComment;
+    use octorus::github::User;
+
+    #[test]
+    fn test_select_latest_local_comments_orders_newest_first() {
+        let comments = vec![
+            ReviewComment {
+                id: 1,
+                path: "src/a.rs".to_string(),
+                line: Some(10),
+                body: "older".to_string(),
+                user: User {
+                    login: "alice".to_string(),
+                },
+                created_at: "2026-03-25T01:00:00+00:00".to_string(),
+                is_resolved: false,
+                resolved_at: None,
+            },
+            ReviewComment {
+                id: 2,
+                path: "src/b.rs".to_string(),
+                line: Some(20),
+                body: "newer".to_string(),
+                user: User {
+                    login: "bob".to_string(),
+                },
+                created_at: "2026-03-25T02:00:00+00:00".to_string(),
+                is_resolved: false,
+                resolved_at: None,
+            },
+        ];
+
+        let selected = select_latest_local_comments(comments, 10);
+
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected[0].id, 2);
+        assert_eq!(selected[1].id, 1);
+    }
+
+    #[test]
+    fn test_select_latest_local_comments_applies_limit() {
+        let comments = vec![
+            ReviewComment {
+                id: 1,
+                path: "src/a.rs".to_string(),
+                line: Some(10),
+                body: "first".to_string(),
+                user: User {
+                    login: "alice".to_string(),
+                },
+                created_at: "2026-03-25T01:00:00+00:00".to_string(),
+                is_resolved: false,
+                resolved_at: None,
+            },
+            ReviewComment {
+                id: 2,
+                path: "src/b.rs".to_string(),
+                line: Some(20),
+                body: "second".to_string(),
+                user: User {
+                    login: "bob".to_string(),
+                },
+                created_at: "2026-03-25T02:00:00+00:00".to_string(),
+                is_resolved: false,
+                resolved_at: None,
+            },
+        ];
+
+        let selected = select_latest_local_comments(comments, 1);
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].id, 2);
+    }
+
+    #[test]
+    fn test_format_local_comments_text_includes_comment_details() {
+        let comments = vec![ReviewComment {
+            id: 7,
+            path: "src/main.rs".to_string(),
+            line: Some(42),
+            body: "why is this here?".to_string(),
+            user: User {
+                login: "dacuna".to_string(),
+            },
+            created_at: "2026-03-25T02:00:00+00:00".to_string(),
+            is_resolved: false,
+            resolved_at: None,
+        }];
+
+        let output = format_local_comments_text(
+            "owner/repo",
+            "/tmp/worktree",
+            1,
+            1,
+            LocalCommentsFilter::Open,
+            &comments,
+        );
+
+        assert!(output.contains(
+            "Showing 1 comment (open) for owner/repo (/tmp/worktree) [open: 1, resolved: 0, total: 1]"
+        ));
+        assert!(output.contains("#7 [open] 2026-03-25T02:00:00+00:00 src/main.rs:42 dacuna"));
+        assert!(output.contains("  why is this here?"));
+    }
+
+    #[test]
+    fn test_format_local_comments_text_handles_empty_state() {
+        let output = format_local_comments_text(
+            "owner/repo",
+            "/tmp/worktree",
+            0,
+            0,
+            LocalCommentsFilter::Open,
+            &[],
+        );
+
+        assert_eq!(
+            output,
+            "No local comments found for owner/repo (/tmp/worktree)\n"
+        );
+    }
+
+    #[test]
+    fn test_format_local_comments_text_handles_empty_filtered_state() {
+        let output = format_local_comments_text(
+            "owner/repo",
+            "/tmp/worktree",
+            3,
+            0,
+            LocalCommentsFilter::Open,
+            &[],
+        );
+
+        assert_eq!(
+            output,
+            "No open local comments for owner/repo (/tmp/worktree) [open: 0, resolved: 3, total: 3]\n"
+        );
+    }
+
+    #[test]
+    fn test_update_local_comments_resolves_and_reopens() {
+        let mut comments = vec![ReviewComment {
+            id: 7,
+            path: "src/main.rs".to_string(),
+            line: Some(42),
+            body: "why is this here?".to_string(),
+            user: User {
+                login: "dacuna".to_string(),
+            },
+            created_at: "2026-03-25T02:00:00+00:00".to_string(),
+            is_resolved: false,
+            resolved_at: None,
+        }];
+
+        let resolved = update_local_comments(&mut comments, &[7], LocalCommentAction::Resolve);
+        assert_eq!(resolved.updated_ids, vec![7]);
+        assert!(resolved.missing_ids.is_empty());
+        assert!(comments[0].is_resolved);
+        assert!(comments[0].resolved_at.is_some());
+
+        let reopened = update_local_comments(&mut comments, &[7], LocalCommentAction::Reopen);
+        assert_eq!(reopened.updated_ids, vec![7]);
+        assert!(reopened.missing_ids.is_empty());
+        assert!(!comments[0].is_resolved);
+        assert!(comments[0].resolved_at.is_none());
+    }
+
+    #[test]
+    fn test_update_local_comments_reports_missing_ids() {
+        let mut comments = vec![ReviewComment {
+            id: 1,
+            path: "src/main.rs".to_string(),
+            line: Some(1),
+            body: "hello".to_string(),
+            user: User {
+                login: "dacuna".to_string(),
+            },
+            created_at: "2026-03-25T02:00:00+00:00".to_string(),
+            is_resolved: false,
+            resolved_at: None,
+        }];
+
+        let result = update_local_comments(&mut comments, &[1, 2], LocalCommentAction::Resolve);
+
+        assert_eq!(result.updated_ids, vec![1]);
+        assert_eq!(result.missing_ids, vec![2]);
+    }
+
+    #[test]
+    fn test_filter_local_comments_defaults_to_open() {
+        let comments = vec![
+            ReviewComment {
+                id: 1,
+                path: "src/main.rs".to_string(),
+                line: Some(1),
+                body: "open".to_string(),
+                user: User {
+                    login: "dacuna".to_string(),
+                },
+                created_at: "2026-03-25T01:00:00+00:00".to_string(),
+                is_resolved: false,
+                resolved_at: None,
+            },
+            ReviewComment {
+                id: 2,
+                path: "src/main.rs".to_string(),
+                line: Some(2),
+                body: "resolved".to_string(),
+                user: User {
+                    login: "dacuna".to_string(),
+                },
+                created_at: "2026-03-25T02:00:00+00:00".to_string(),
+                is_resolved: true,
+                resolved_at: Some("2026-03-25T03:00:00+00:00".to_string()),
+            },
+        ];
+
+        let filtered = filter_local_comments(comments, LocalCommentsFilter::Open);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, 1);
+    }
+
+    #[test]
+    fn test_filter_local_comments_resolved_only() {
+        let comments = vec![
+            ReviewComment {
+                id: 1,
+                path: "src/main.rs".to_string(),
+                line: Some(1),
+                body: "open".to_string(),
+                user: User {
+                    login: "dacuna".to_string(),
+                },
+                created_at: "2026-03-25T01:00:00+00:00".to_string(),
+                is_resolved: false,
+                resolved_at: None,
+            },
+            ReviewComment {
+                id: 2,
+                path: "src/main.rs".to_string(),
+                line: Some(2),
+                body: "resolved".to_string(),
+                user: User {
+                    login: "dacuna".to_string(),
+                },
+                created_at: "2026-03-25T02:00:00+00:00".to_string(),
+                is_resolved: true,
+                resolved_at: Some("2026-03-25T03:00:00+00:00".to_string()),
+            },
+        ];
+
+        let filtered = filter_local_comments(comments, LocalCommentsFilter::Resolved);
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, 2);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,7 @@ use octorus::{app, cache, config, github, headless, loader, syntax};
 
 // init/update/migrate are only used by the binary, not needed for benchmarks
 mod init;
+mod local_comments;
 mod migrate;
 mod update;
 
@@ -90,6 +91,54 @@ enum Commands {
     },
     /// Remove AI Rally session data
     Clean,
+    /// Show saved local comments for the current worktree
+    LocalComments {
+        /// Repository name (e.g., "owner/repo"). Auto-detected if omitted.
+        #[arg(short, long)]
+        repo: Option<String>,
+
+        /// Working directory used to scope local comments (defaults to current directory)
+        #[arg(long)]
+        working_dir: Option<String>,
+
+        /// Maximum number of newest comments to show
+        #[arg(short, long, default_value_t = 20)]
+        limit: usize,
+
+        /// Print JSON instead of plain text
+        #[arg(long, default_value = "false")]
+        json: bool,
+
+        /// Show all comments, including resolved ones
+        #[arg(long, conflicts_with = "resolved")]
+        all: bool,
+
+        /// Show only resolved comments
+        #[arg(long, conflicts_with = "all")]
+        resolved: bool,
+    },
+    /// Update saved local comments for the current worktree
+    UpdateLocalComment {
+        /// Repository name (e.g., "owner/repo"). Auto-detected if omitted.
+        #[arg(short, long)]
+        repo: Option<String>,
+
+        /// Working directory used to scope local comments (defaults to current directory)
+        #[arg(long)]
+        working_dir: Option<String>,
+
+        /// Mark the specified comments as resolved
+        #[arg(long, conflicts_with = "reopen")]
+        resolve: bool,
+
+        /// Reopen the specified comments
+        #[arg(long, conflicts_with = "resolve")]
+        reopen: bool,
+
+        /// One or more local comment IDs to update
+        #[arg(required = true, num_args = 1.., value_name = "ID")]
+        ids: Vec<u64>,
+    },
     /// Update to the latest version from GitHub Releases
     Update,
     /// Migrate configuration files and prompts after an update
@@ -214,6 +263,21 @@ async fn main() -> Result<()> {
                 println!("Rally sessions cleaned: {}", rally_dir.display());
                 Ok(())
             }
+            Commands::LocalComments {
+                repo,
+                working_dir,
+                limit,
+                json,
+                all,
+                resolved,
+            } => local_comments::show_local_comments_command(repo, working_dir, limit, json, all, resolved).await,
+            Commands::UpdateLocalComment {
+                repo,
+                working_dir,
+                resolve,
+                reopen,
+                ids,
+            } => local_comments::update_local_comments_command(repo, working_dir, resolve, reopen, ids).await,
             Commands::Update => {
                 update::run_update()?;
                 Ok(())

--- a/src/ui/comment_list.rs
+++ b/src/ui/comment_list.rs
@@ -107,8 +107,10 @@ fn render_local_comment_list(frame: &mut Frame, app: &mut App) {
     }
 
     let footer_chunk_idx = if has_rally { 3 } else { 2 };
-    let footer = Paragraph::new("j/k/↑↓: move | Enter: jump to file | q: back")
-        .block(Block::default().borders(Borders::ALL));
+    let help_text = super::footer::footer_hint_back(&app.config.keybindings);
+    let footer_line = super::footer::build_footer_line(app, &help_text);
+    let footer =
+        Paragraph::new(footer_line).block(super::footer::build_footer_block(app));
     frame.render_widget(footer, chunks[footer_chunk_idx]);
 }
 
@@ -568,6 +570,7 @@ mod tests {
                 id: 1,
                 path: "src/main.rs".to_string(),
                 line: Some(10),
+                start_line: None,
                 body: "This looks good.".to_string(),
                 user: User { login: "reviewer1".to_string() },
                 created_at: "2025-01-01T00:00:00Z".to_string(),
@@ -660,6 +663,101 @@ mod tests {
         ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
         │> @commenter  2025-03-01                                                                          │
         │    Thanks for the fix!                                                                           │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        │                                                                                                  │
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+        │? Help | ! Shell | q/Esc Back                                                                     │
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ");
+    }
+
+    #[test]
+    fn test_local_comment_list_rendering() {
+        let mut app = App::new_for_test();
+        app.state = crate::app::AppState::CommentList;
+        app.set_local_mode(true);
+        app.cmt.comment_tab = CommentTab::Review;
+        app.cmt.review_comments = Some(vec![
+            ReviewComment {
+                id: 1,
+                path: "src/main.rs".to_string(),
+                line: Some(10),
+                start_line: None,
+                body: "Fix this variable naming".to_string(),
+                user: User { login: "dacuna".to_string() },
+                created_at: "2026-03-25T02:00:00+00:00".to_string(),
+                is_resolved: false,
+                resolved_at: None,
+            },
+            ReviewComment {
+                id: 2,
+                path: "src/lib.rs".to_string(),
+                line: Some(42),
+                start_line: None,
+                body: "Consider error handling".to_string(),
+                user: User { login: "dacuna".to_string() },
+                created_at: "2026-03-25T03:00:00+00:00".to_string(),
+                is_resolved: true,
+                resolved_at: Some("2026-03-25T04:00:00+00:00".to_string()),
+            },
+        ]);
+
+        assert_snapshot!(render_full(&mut app), @"
+        ┌octorus───────────────────────────────────────────────────────────────────────────────────────────┐
+        │ [Local Comments (2)]                                                                             │
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+        │> @dacuna on src/main.rs:10                                                                       ▲
+        │    Fix this variable naming                                                                      █
+        │                                                                                                  █
+        │  @dacuna [resolved] on src/lib.rs:42                                                             █
+        │    Consider error handling                                                                       █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  █
+        │                                                                                                  ▼
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+        │? Help | ! Shell | q/Esc Back                                                                     │
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ");
+    }
+
+    #[test]
+    fn test_local_comment_list_empty() {
+        let mut app = App::new_for_test();
+        app.state = crate::app::AppState::CommentList;
+        app.set_local_mode(true);
+        app.cmt.comment_tab = CommentTab::Review;
+        app.cmt.review_comments = Some(vec![]);
+
+        assert_snapshot!(render_full(&mut app), @"
+        ┌octorus───────────────────────────────────────────────────────────────────────────────────────────┐
+        │ [Local Comments (0)]                                                                             │
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+        │No review comments found                                                                          │
+        │                                                                                                  │
         │                                                                                                  │
         │                                                                                                  │
         │                                                                                                  │

--- a/src/ui/comment_list.rs
+++ b/src/ui/comment_list.rs
@@ -1,3 +1,5 @@
+use super::common::{render_rally_status_bar, wrap_text};
+use crate::app::{App, CommentTab};
 use ratatui::{
     layout::{Constraint, Direction, Layout, Margin},
     style::{Color, Modifier, Style},
@@ -8,10 +10,13 @@ use ratatui::{
     },
     Frame,
 };
-use super::common::{render_rally_status_bar, wrap_text};
-use crate::app::{App, CommentTab};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
+    if app.is_local_mode() {
+        render_local_comment_list(frame, app);
+        return;
+    }
+
     if app.cmt.discussion_comment_detail_mode {
         render_discussion_detail(frame, app);
         return;
@@ -52,6 +57,58 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     let footer_chunk_idx = if has_rally { 3 } else { 2 };
     let help_text = super::footer::footer_hint_back(&app.config.keybindings);
     let footer = Paragraph::new(help_text).block(Block::default().borders(Borders::ALL));
+    frame.render_widget(footer, chunks[footer_chunk_idx]);
+}
+
+fn render_local_comment_list(frame: &mut Frame, app: &mut App) {
+    let has_rally = app.has_background_rally();
+    let constraints = if has_rally {
+        vec![
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(1),
+            Constraint::Length(3),
+        ]
+    } else {
+        vec![
+            Constraint::Length(3),
+            Constraint::Min(0),
+            Constraint::Length(3),
+        ]
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(frame.area());
+
+    let count = app.cmt.review_comments.as_ref().map(|c| c.len()).unwrap_or(0);
+    let loading = if app.cmt.comments_loading {
+        format!(" {}", app.spinner_char())
+    } else {
+        String::new()
+    };
+    let header = Paragraph::new(Line::from(vec![
+        Span::raw(" "),
+        Span::styled(
+            format!("[Local Comments ({})]{}", count, loading),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]))
+    .block(Block::default().borders(Borders::ALL).title("octorus"));
+    frame.render_widget(header, chunks[0]);
+
+    render_review_comments(frame, app, chunks[1]);
+
+    if has_rally {
+        render_rally_status_bar(frame, chunks[2], app);
+    }
+
+    let footer_chunk_idx = if has_rally { 3 } else { 2 };
+    let footer = Paragraph::new("j/k/↑↓: move | Enter: jump to file | q: back")
+        .block(Block::default().borders(Borders::ALL));
     frame.render_widget(footer, chunks[footer_chunk_idx]);
 }
 
@@ -227,6 +284,16 @@ fn render_review_comments(frame: &mut Frame, app: &mut App, area: ratatui::layou
                     format!("@{}", comment.user.login),
                     Style::default().fg(Color::Cyan),
                 ),
+                if comment.is_resolved {
+                    Span::raw(" ")
+                } else {
+                    Span::raw("")
+                },
+                if comment.is_resolved {
+                    Span::styled("[resolved]", Style::default().fg(Color::DarkGray))
+                } else {
+                    Span::raw("")
+                },
                 Span::raw(" on "),
                 Span::styled(
                     format!("{}{}", comment.path, line_info),
@@ -504,6 +571,8 @@ mod tests {
                 body: "This looks good.".to_string(),
                 user: User { login: "reviewer1".to_string() },
                 created_at: "2025-01-01T00:00:00Z".to_string(),
+                is_resolved: false,
+                resolved_at: None,
             },
         ]);
 

--- a/src/ui/diff_view/mod.rs
+++ b/src/ui/diff_view/mod.rs
@@ -1435,6 +1435,8 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         "j/k/↑↓: extend selection | c: comment | s: suggest | Esc: cancel".to_string()
     } else if app.cmt.comment_panel_open {
         "r: reply | Esc: close".to_string()
+    } else if app.is_local_mode() {
+        "j/k/↑↓: move | n/N: next/prev comment | Enter: comments | M: markdown rich | Ctrl-d/u: page | ←/h/q: back".to_string()
     } else {
         super::footer::footer_hint_back(&app.config.keybindings)
     };

--- a/src/ui/diff_view/mod.rs
+++ b/src/ui/diff_view/mod.rs
@@ -1435,8 +1435,6 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         "j/k/↑↓: extend selection | c: comment | s: suggest | Esc: cancel".to_string()
     } else if app.cmt.comment_panel_open {
         "r: reply | Esc: close".to_string()
-    } else if app.is_local_mode() {
-        "j/k/↑↓: move | n/N: next/prev comment | Enter: comments | M: markdown rich | Ctrl-d/u: page | ←/h/q: back".to_string()
     } else {
         super::footer::footer_hint_back(&app.config.keybindings)
     };

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -490,7 +490,7 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
             fmt_key(&kb.ci_checks.display(), key_width)
         )),
         Line::from(format!(
-            "{}  Start AI Rally",
+            "{}  Start AI Rally (local mode seeds from local comments)",
             fmt_key(&kb.ai_rally.display(), key_width)
         )),
         Line::from(format!(
@@ -595,7 +595,11 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Jump to first/last line",
             fmt_key(
-                &format!("{}/{}", kb.jump_to_first.display(), kb.jump_to_last.display()),
+                &format!(
+                    "{}/{}",
+                    kb.jump_to_first.display(),
+                    kb.jump_to_last.display()
+                ),
                 key_width
             )
         )),
@@ -606,7 +610,11 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Next/prev comment",
             fmt_key(
-                &format!("{}/{}", kb.next_comment.display(), kb.prev_comment.display()),
+                &format!(
+                    "{}/{}",
+                    kb.next_comment.display(),
+                    kb.prev_comment.display()
+                ),
                 key_width
             )
         )),
@@ -655,7 +663,11 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Jump to first/last line",
             fmt_key(
-                &format!("{}/{}", kb.jump_to_first.display(), kb.jump_to_last.display()),
+                &format!(
+                    "{}/{}",
+                    kb.jump_to_first.display(),
+                    kb.jump_to_last.display()
+                ),
                 key_width
             )
         )),
@@ -756,7 +768,11 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Jump to next/prev comment",
             fmt_key(
-                &format!("{}/{}", kb.next_comment.display(), kb.prev_comment.display()),
+                &format!(
+                    "{}/{}",
+                    kb.next_comment.display(),
+                    kb.prev_comment.display()
+                ),
                 key_width
             )
         )),
@@ -916,10 +932,7 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
             "{}  Move commit selection",
             fmt_key("j/k, Down/Up", key_width)
         )),
-        Line::from(format!(
-            "{}  Jump to first/last",
-            fmt_key("g/G", key_width)
-        )),
+        Line::from(format!("{}  Jump to first/last", fmt_key("g/G", key_width))),
         Line::from(format!(
             "{}  Undo last operation",
             fmt_key(&kb.git_ops_undo.display(), key_width)
@@ -961,7 +974,11 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Jump to first/last",
             fmt_key(
-                &format!("{}/{}", kb.jump_to_first.display(), kb.jump_to_last.display()),
+                &format!(
+                    "{}/{}",
+                    kb.jump_to_first.display(),
+                    kb.jump_to_last.display()
+                ),
                 key_width
             )
         )),
@@ -1053,7 +1070,11 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Jump to first/last",
             fmt_key(
-                &format!("{}/{}", kb.jump_to_first.display(), kb.jump_to_last.display()),
+                &format!(
+                    "{}/{}",
+                    kb.jump_to_first.display(),
+                    kb.jump_to_last.display()
+                ),
                 key_width
             )
         )),

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -809,6 +809,45 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         )),
         Line::from(""),
         Line::from(vec![Span::styled(
+            "Local Mode",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )]),
+        Line::from(vec![Span::styled(
+            "  In local mode, you can leave review comments on your own diff.",
+            Style::default().fg(Color::DarkGray),
+        )]),
+        Line::from(vec![Span::styled(
+            "  Comments persist to disk across sessions.",
+            Style::default().fg(Color::DarkGray),
+        )]),
+        Line::from(format!(
+            "{}  Add comment on diff line",
+            fmt_key(&kb.comment.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Add suggestion on diff line",
+            fmt_key(&kb.suggestion.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Reply to comment",
+            fmt_key(&kb.reply.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  View local comments (no Discussion tab)",
+            fmt_key(&kb.comment_list.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Start AI Rally (seeds from open local comments)",
+            fmt_key(&kb.ai_rally.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Toggle auto-focus on changed files",
+            fmt_key(&kb.toggle_auto_focus.display(), key_width)
+        )),
+        Line::from(""),
+        Line::from(vec![Span::styled(
             "Input Mode (Comment/Suggestion/Reply)",
             Style::default()
                 .fg(Color::Yellow)


### PR DESCRIPTION
## TLDR
Enables a local review workflow. 

1. You review code via `or --local`
2. You add comments, locally
3. Use rally mode OR tell whichever model you may be using to address the comments via `or local-comments` to address/discuss them
4. Models use `or update-local-comment --resolve <ids>` to mark them as resolved
5. ???
6. profit!

## Summary

- Enable review commenting in local mode with disk persistence (`~/.cache/octorus/local_comments/`)
- Add `LocalComments` and `UpdateLocalComment` CLI subcommands for managing local comments outside the TUI
- Allow local comments to seed AI Rally reviews, skipping the initial reviewer step when seed comments exist
- Add `is_resolved` / `resolved_at` fields to `ReviewComment` for resolved status tracking

## Test plan

- [x] All 1244 existing tests pass (1164 lib + 71 integration + 9 CLI)
- [ ] Manual test: create local comments in local mode TUI, verify persistence across restarts
- [ ] Manual test: run `or local-comments --repo owner/repo` to list local comments
- [ ] Manual test: start AI Rally with local comments present, verify seed review is used
- [ ] Manual test: verify resolved badge renders in comment list


Made with [Cursor](https://cursor.com)