### PR TITLE
fix: resolve race condition in cli test, stale CI status upon refresh, and misleading CI status when gh returns conclusion with empty string

### DIFF
--- a/src/app/cockpit.rs
+++ b/src/app/cockpit.rs
@@ -17,10 +17,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.help) {
-            self.previous_state = AppState::Cockpit;
-            self.state = AppState::Help;
-            self.help_scroll_offset = 0;
-            self.config_scroll_offset = 0;
+            self.open_help(AppState::Cockpit);
             return Ok(());
         }
 

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -464,6 +464,12 @@ impl App {
         }
 
         let kb = self.config.keybindings.clone();
+
+        if self.matches_single_key(&key, &kb.help) {
+            self.open_help(AppState::CommentList);
+            return Ok(());
+        }
+
         if self.matches_single_key(&key, &kb.quit) {
             self.state = self.previous_state;
         } else if self.matches_single_key(&key, &kb.tab_prev)

--- a/src/app/git_ops/mod.rs
+++ b/src/app/git_ops/mod.rs
@@ -1173,6 +1173,11 @@ impl App {
             return;
         }
 
+        if self.matches_single_key(&key, &kb.help) {
+            self.open_help(AppState::GitOpsSplitTree);
+            return;
+        }
+
         if self.matches_single_key(&key, &kb.quit) {
             self.close_git_ops();
             return;
@@ -1693,6 +1698,11 @@ impl App {
             if let Some(scroll) = self.active_git_ops_diff_scroll() {
                 scroll.jump_to_last();
             }
+            return;
+        }
+
+        if self.matches_single_key(&key, &kb.help) {
+            self.open_help(AppState::GitOpsSplitDiff);
             return;
         }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -434,10 +434,7 @@ AppState::IssueList => self.handle_issue_list_input(key).await?,
         }
 
         if self.matches_single_key(&key, &kb.help) {
-            self.previous_state = AppState::FileList;
-            self.state = AppState::Help;
-            self.help_scroll_offset = 0;
-            self.config_scroll_offset = 0;
+            self.open_help(AppState::FileList);
             return Ok(());
         }
 
@@ -675,6 +672,13 @@ AppState::IssueList => self.handle_issue_list_input(key).await?,
         });
     }
 
+    pub(crate) fn open_help(&mut self, from: AppState) {
+        self.previous_state = from;
+        self.state = AppState::Help;
+        self.help_scroll_offset = 0;
+        self.config_scroll_offset = 0;
+    }
+
     pub(crate) fn open_checks_list(&mut self, pr_number: u32) {
         if self.state != AppState::ChecksList {
             self.chk.checks_return_state = self.state;
@@ -768,10 +772,7 @@ AppState::IssueList => self.handle_issue_list_input(key).await?,
         }
 
         if self.matches_single_key(&key, &kb.help) {
-            self.previous_state = AppState::ChecksList;
-            self.state = AppState::Help;
-            self.help_scroll_offset = 0;
-            self.config_scroll_offset = 0;
+            self.open_help(AppState::ChecksList);
             return Ok(());
         }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -658,6 +658,8 @@ AppState::IssueList => self.handle_issue_list_input(key).await?,
         self.cmt.discussion_comments = None;
         self.cmt.comments_loading = false;
         self.cmt.discussion_comments_loading = false;
+        self.chk.ci_status = None;
+        self.chk.ci_status_receiver = None;
         self.file_list_filter = None;
         self.data_state = DataState::Loading;
         self.retry_load();

--- a/src/app/input_diff.rs
+++ b/src/app/input_diff.rs
@@ -187,10 +187,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.help) {
-            self.previous_state = AppState::SplitViewFileList;
-            self.state = AppState::Help;
-            self.help_scroll_offset = 0;
-            self.config_scroll_offset = 0;
+            self.open_help(AppState::SplitViewFileList);
             return Ok(());
         }
 
@@ -206,6 +203,15 @@ impl App {
     ) -> Result<()> {
         if self.symbol_popup.is_some() {
             self.handle_symbol_popup_input(key, terminal).await?;
+            return Ok(());
+        }
+
+        if self.matches_single_key(&key, &self.config.keybindings.help) {
+            let from = match variant {
+                DiffViewVariant::SplitPane => AppState::SplitViewDiff,
+                DiffViewVariant::Fullscreen => AppState::DiffView,
+            };
+            self.open_help(from);
             return Ok(());
         }
 

--- a/src/app/input_text.rs
+++ b/src/app/input_text.rs
@@ -10,6 +10,8 @@ use super::types::*;
 use super::{App, SuggestionHighlightCache};
 
 impl App {
+    /// Note: the help keybinding (?) is intentionally not handled here
+    /// because this is a free-form text input and ? is a literal character.
     pub(crate) fn handle_text_input(&mut self, key: event::KeyEvent) -> Result<()> {
         // 送信中は入力を無視（各送信種別に対応するInputModeのみブロック）
         if self.cmt.comment_submitting {

--- a/src/app/issue_detail.rs
+++ b/src/app/issue_detail.rs
@@ -198,10 +198,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.help) {
-            self.previous_state = AppState::IssueDetail;
-            self.state = AppState::Help;
-            self.help_scroll_offset = 0;
-            self.config_scroll_offset = 0;
+            self.open_help(AppState::IssueDetail);
             return Ok(());
         }
 
@@ -360,10 +357,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.help) {
-            self.previous_state = AppState::IssueCommentList;
-            self.state = AppState::Help;
-            self.help_scroll_offset = 0;
-            self.config_scroll_offset = 0;
+            self.open_help(AppState::IssueCommentList);
             return Ok(());
         }
 

--- a/src/app/issue_list.rs
+++ b/src/app/issue_list.rs
@@ -348,10 +348,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.help) {
-            self.previous_state = AppState::IssueList;
-            self.state = AppState::Help;
-            self.help_scroll_offset = 0;
-            self.config_scroll_offset = 0;
+            self.open_help(AppState::IssueList);
             return Ok(());
         }
 

--- a/src/app/pr_list.rs
+++ b/src/app/pr_list.rs
@@ -213,10 +213,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.help) {
-            self.previous_state = AppState::PullRequestList;
-            self.state = AppState::Help;
-            self.help_scroll_offset = 0;
-            self.config_scroll_offset = 0;
+            self.open_help(AppState::PullRequestList);
             return Ok(());
         }
 

--- a/src/app/symbol.rs
+++ b/src/app/symbol.rs
@@ -251,9 +251,12 @@ impl App {
 
         let kb = self.config.keybindings.clone();
 
-        if self.matches_single_key(&key, &kb.quit)
-            || self.matches_single_key(&key, &kb.help)
-        {
+        if self.matches_single_key(&key, &kb.help) {
+            self.open_help(AppState::PrDescription);
+            return Ok(());
+        }
+
+        if self.matches_single_key(&key, &kb.quit) {
             self.state = self.previous_state;
             return Ok(());
         }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2156,6 +2156,26 @@ fn test_help_scroll_q_returns_to_previous_state() {
 }
 
 #[test]
+fn test_open_help_from_diff_view_sets_previous_state() {
+    let config = Config::default();
+    let (mut app, _) = App::new_loading("owner/repo", 1, config);
+    app.state = AppState::DiffView;
+    app.open_help(AppState::DiffView);
+    assert_eq!(app.state, AppState::Help);
+    assert_eq!(app.previous_state, AppState::DiffView);
+}
+
+#[test]
+fn test_open_help_from_split_view_diff_sets_previous_state() {
+    let config = Config::default();
+    let (mut app, _) = App::new_loading("owner/repo", 1, config);
+    app.state = AppState::SplitViewDiff;
+    app.open_help(AppState::SplitViewDiff);
+    assert_eq!(app.state, AppState::Help);
+    assert_eq!(app.previous_state, AppState::SplitViewDiff);
+}
+
+#[test]
 fn test_help_viewport_overhead_matches_render_layout() {
     // The render layout uses:
     //   Constraint::Length(3) for tab header + Constraint::Min(0) for content

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -3211,6 +3211,7 @@ fn test_refresh_all_resets_state() {
     app.cmt.discussion_comments = Some(vec![]);
     app.cmt.comments_loading = true;
     app.cmt.discussion_comments_loading = true;
+    app.chk.ci_status = Some(crate::github::CiStatus::Failure);
     let filter = crate::filter::ListFilter::new();
     app.file_list_filter = Some(filter);
 
@@ -3221,6 +3222,8 @@ fn test_refresh_all_resets_state() {
     assert!(app.cmt.discussion_comments.is_none());
     assert!(!app.cmt.comments_loading);
     assert!(!app.cmt.discussion_comments_loading);
+    assert!(app.chk.ci_status.is_none());
+    assert!(app.chk.ci_status_receiver.is_none());
     assert!(app.file_list_filter.is_none());
 }
 

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -39,10 +39,11 @@ impl CiStatus {
             match item.type_name.as_str() {
                 "CheckRun" => match item.conclusion.as_deref() {
                     Some("SUCCESS") | Some("NEUTRAL") | Some("SKIPPED") => {}
-                    Some(_) => return Self::Failure,
-                    None => {
+                    // gh returns conclusion: "" for in-progress/queued checks
+                    None | Some("") => {
                         has_pending = true;
                     }
+                    Some(_) => return Self::Failure,
                 },
                 "StatusContext" => match item.state.as_deref() {
                     Some("SUCCESS") => {}
@@ -510,6 +511,30 @@ mod tests {
             state: None,
         }];
         assert_eq!(CiStatus::from_rollup(&items), CiStatus::Success);
+    }
+
+    #[test]
+    fn test_ci_status_from_rollup_empty_conclusion_is_pending() {
+        // gh returns conclusion: "" (not null) for in-progress/queued checks
+        let items = vec![
+            StatusCheckRollupItem {
+                type_name: "CheckRun".to_string(),
+                name: Some("build".to_string()),
+                status: Some("COMPLETED".to_string()),
+                conclusion: Some("SUCCESS".to_string()),
+                context: None,
+                state: None,
+            },
+            StatusCheckRollupItem {
+                type_name: "CheckRun".to_string(),
+                name: Some("test".to_string()),
+                status: Some("IN_PROGRESS".to_string()),
+                conclusion: Some("".to_string()),
+                context: None,
+                state: None,
+            },
+        ];
+        assert_eq!(CiStatus::from_rollup(&items), CiStatus::Pending);
     }
 
     #[test]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -34,6 +34,8 @@ fn init_help_exits_successfully() {
 // the full flow via assert_cmd. But we CAN verify that the binary does NOT
 // fall back to printing help — it should attempt to enter TUI mode and
 // eventually fail or hang (timeout), never printing "Usage:" to stdout.
+// The ASCII-art banner check is omitted because crossterm may render it
+// via escape sequences during TUI init, causing false positives.
 #[test]
 fn no_args_does_not_print_help() {
     let output = cargo_bin_cmd!("or")
@@ -45,10 +47,6 @@ fn no_args_does_not_print_help() {
     assert!(
         !stdout.contains("Usage"),
         "no-args should enter Cockpit, not print help"
-    );
-    assert!(
-        !stdout.contains(HELP_BANNER_LINE),
-        "no-args should enter Cockpit, not print help banner"
     );
 }
 


### PR DESCRIPTION
## Summary
I've been trying out octorus for my own github PR review workflow and ran into a couple places where the UX was a little awkward, so I figured I'd offer a PR to address these along with fixes for a few issues I found along the way.  Full disclosure, I am a software engineer working primarily in Rust, but am not familiar with this codebase so I used claude code to help find/fix these issues and implement the new features.  I didn't see any contributor guides so I hope that use of an AI tool is okay.

I split the UX fixes from #157 into their own PR to make it easier to review.

### Fixes
- **Help screen from diff views**: `?` keybinding now works in DiffView and SplitViewDiff (was missing from `handle_diff_input_common`)
- **CI status for in-progress checks**: `gh` returns `conclusion: ""` (not null) for queued/in-progress CheckRuns, which was misclassified as failure. Also clears stale CI status on manual refresh
- **Flaky test assertion**: Removed racy `HELP_BANNER_LINE` check from `no_args_does_not_print_help` test

## Testing
- All changes pass `cargo clippy -- -D warnings` and `cargo test`
- Added tests for CI status parsing (empty conclusion → pending) and `refresh_all` state clearing
- Manually verified in-progress CI shows pending rather than failed
- Manually verified threaded comments expand/collapse with Enter/Esc
- Manually verified `?` opens the help screen from diff views