### PR TITLE
fix: treat empty StatusContext state as pending + test cleanup

### DIFF
--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2159,7 +2159,6 @@ fn test_help_scroll_q_returns_to_previous_state() {
 fn test_open_help_from_diff_view_sets_previous_state() {
     let config = Config::default();
     let (mut app, _) = App::new_loading("owner/repo", 1, config);
-    app.state = AppState::DiffView;
     app.open_help(AppState::DiffView);
     assert_eq!(app.state, AppState::Help);
     assert_eq!(app.previous_state, AppState::DiffView);
@@ -2169,7 +2168,6 @@ fn test_open_help_from_diff_view_sets_previous_state() {
 fn test_open_help_from_split_view_diff_sets_previous_state() {
     let config = Config::default();
     let (mut app, _) = App::new_loading("owner/repo", 1, config);
-    app.state = AppState::SplitViewDiff;
     app.open_help(AppState::SplitViewDiff);
     assert_eq!(app.state, AppState::Help);
     assert_eq!(app.previous_state, AppState::SplitViewDiff);

--- a/src/github/pr.rs
+++ b/src/github/pr.rs
@@ -47,7 +47,8 @@ impl CiStatus {
                 },
                 "StatusContext" => match item.state.as_deref() {
                     Some("SUCCESS") => {}
-                    Some("PENDING") | Some("EXPECTED") => has_pending = true,
+                    // gh returns state: "" for in-progress StatusContext entries
+                    Some("PENDING") | Some("EXPECTED") | Some("") => has_pending = true,
                     Some(_) => return Self::Failure,
                     None => {}
                 },
@@ -534,6 +535,21 @@ mod tests {
                 state: None,
             },
         ];
+        assert_eq!(CiStatus::from_rollup(&items), CiStatus::Pending);
+    }
+
+    #[test]
+    fn test_ci_status_from_rollup_empty_state_is_pending() {
+        // gh may return state: "" for in-progress StatusContext entries,
+        // analogous to conclusion: "" for CheckRun.
+        let items = vec![StatusCheckRollupItem {
+            type_name: "StatusContext".to_string(),
+            name: None,
+            status: None,
+            conclusion: None,
+            context: Some("ci/in-progress".to_string()),
+            state: Some("".to_string()),
+        }];
         assert_eq!(CiStatus::from_rollup(&items), CiStatus::Pending);
     }
 


### PR DESCRIPTION
## Summary

Two follow-ups discovered while reviewing #158:

- **`StatusContext` empty state**: PR #158 fixed `CheckRun` `conclusion: ""` → Pending, but the symmetric `StatusContext` `state: ""` case still fell into `Some(_) => return Failure`. Apply the same treatment.
- **Test cleanup**: `test_open_help_from_diff_view_sets_previous_state` and `test_open_help_from_split_view_diff_sets_previous_state` set `app.state` before calling `open_help`, but `open_help` unconditionally overwrites it. Remove the dead assignments.

## Test plan

- [x] `cargo test --lib` — 1159 passed (was 1158 + 1 new regression test)
- [x] `cargo test --test cli` — 9 passed
- [x] `cargo check --all-targets` — clean
- [x] TDD: new test confirmed red before the fix, green after
- [x] `cargo clippy` — no new warnings introduced (the pre-existing `unnecessary_map_or` in `src/app/git_ops/mod.rs:2575` also fails on main; out of scope here)