### PR TITLE
feat: accept GitHub URLs for `--pr` and `--issue`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ or init
 # 2. Open the Cockpit dashboard (default when no flags are given)
 or
 
-# 3. Open a specific PR directly
+# 3. Open a specific PR directly (number or full GitHub URL)
 or --pr 123
+or --pr https://github.com/owner/repo/pull/123
 
 # 4. Preview local changes
 or --local
@@ -56,8 +57,8 @@ or --local
 | Option | Description |
 |--------|-------------|
 | `-r, --repo <REPO>` | Repository name (e.g., `owner/repo`). Auto-detected from current directory if omitted |
-| `-p, --pr [<PR>]` | Open PR list (flag only), or open a specific PR directly if number is provided |
-| `-i, --issue [<ISSUE>]` | Open issue list (flag only), or open a specific issue directly if number is provided |
+| `-p, --pr [<PR>]` | Open PR list (flag only), or open a specific PR directly if number or full GitHub URL is provided |
+| `-i, --issue [<ISSUE>]` | Open issue list (flag only), or open a specific issue directly if number or full GitHub URL is provided |
 | `--local` | Show local git diff against current `HEAD` (no GitHub PR fetch) |
 | `--ai-rally` | Start AI Rally mode directly. Runs in headless mode when combined with `--pr <number>` or `--local` |
 | `--git-ops` | Open Git Ops view directly on startup |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@ pub mod ai;
 pub mod app;
 pub mod cache;
 pub mod config;
-pub mod diff_store;
 pub mod diff;
+pub mod diff_store;
 pub mod editor;
 pub mod filter;
 pub mod gitfilm;
@@ -19,6 +19,7 @@ pub mod loader;
 pub mod symbol;
 pub mod syntax;
 pub mod ui;
+pub mod url_parse;
 
 // Re-export commonly used types for benchmarks
 pub use app::{CachedDiffLine, DiffCache, InternedSpan};

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,9 +39,10 @@ struct Args {
     #[arg(short, long)]
     repo: Option<String>,
 
-    /// Pull request number. Shows PR list if flag only (no number).
+    /// Pull request number or full GitHub PR URL. Shows PR list if flag only (no value).
+    /// URLs like `https://github.com/owner/repo/pull/123` also set `--repo`.
     #[arg(short, long, conflicts_with = "local", num_args = 0..=1, default_missing_value = "0")]
-    pr: Option<u32>,
+    pr: Option<String>,
 
     /// Start AI Rally mode directly
     #[arg(long, default_value = "false")]
@@ -51,9 +52,10 @@ struct Args {
     #[arg(long, default_value = "false", conflicts_with = "pr")]
     local: bool,
 
-    /// Issue number. Shows issue detail directly if provided, issue list if flag only.
+    /// Issue number or full GitHub issue URL. Shows issue list if flag only (no value).
+    /// URLs like `https://github.com/owner/repo/issues/123` also set `--repo`.
     #[arg(short, long, conflicts_with_all = ["pr", "local"], num_args = 0..=1, default_missing_value = "0")]
-    issue: Option<u32>,
+    issue: Option<String>,
 
     /// Start in Git Ops view directly
     #[arg(long, default_value = "false")]
@@ -227,6 +229,72 @@ fn setup_panic_hook() {
     }));
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RefKind {
+    Pr,
+    Issue,
+}
+
+impl RefKind {
+    fn flag(self) -> &'static str {
+        match self {
+            RefKind::Pr => "--pr",
+            RefKind::Issue => "--issue",
+        }
+    }
+
+    fn other_flag(self) -> &'static str {
+        match self {
+            RefKind::Pr => "--issue",
+            RefKind::Issue => "--pr",
+        }
+    }
+}
+
+/// Resolve `--pr` or `--issue` into a numeric reference. Accepts a bare number
+/// or a GitHub URL; URLs of the matching kind also populate `--repo`.
+fn resolve_ref_arg(
+    raw: Option<String>,
+    repo: &mut Option<String>,
+    kind: RefKind,
+) -> Result<Option<u32>> {
+    use octorus::url_parse::{parse_github_url, GithubRef};
+
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+
+    if let Ok(n) = raw.parse::<u32>() {
+        return Ok(Some(n));
+    }
+
+    let parsed = parse_github_url(&raw).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{} value `{raw}` is neither a number nor a GitHub URL",
+            kind.flag()
+        )
+    })?;
+
+    let number = match (kind, &parsed) {
+        (RefKind::Pr, GithubRef::Pr { number, .. })
+        | (RefKind::Issue, GithubRef::Issue { number, .. }) => *number,
+        _ => anyhow::bail!(
+            "{} was given a URL of the wrong kind; use {} instead",
+            kind.flag(),
+            kind.other_flag()
+        ),
+    };
+
+    let slug = parsed.repo_slug();
+    if let Some(existing) = repo.as_ref() {
+        if existing != &slug {
+            anyhow::bail!("URL repo `{}` conflicts with --repo `{}`", slug, existing);
+        }
+    }
+    *repo = Some(slug);
+    Ok(Some(number))
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Set up panic hook before anything else
@@ -260,7 +328,9 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
-    let args = Args::parse();
+    let mut args = Args::parse();
+    let pr = resolve_ref_arg(args.pr.take(), &mut args.repo, RefKind::Pr)?;
+    let issue = resolve_ref_arg(args.issue.take(), &mut args.repo, RefKind::Issue)?;
 
     // Handle subcommands
     if let Some(command) = args.command {
@@ -323,7 +393,7 @@ async fn main() -> Result<()> {
         };
     }
 
-    let is_no_args = args.pr.is_none() && !args.local && args.issue.is_none() && !args.git_ops;
+    let is_no_args = pr.is_none() && !args.local && issue.is_none() && !args.git_ops;
 
     let (repo, repo_available) = match args.repo.clone() {
         Some(r) => (r, true),
@@ -367,8 +437,8 @@ async fn main() -> Result<()> {
     };
 
     // Headless mode: --ai-rally with --pr <number> or --local bypasses TUI entirely
-    if args.ai_rally && matches!(args.pr, Some(pr) if pr > 0) {
-        let pr = args.pr.unwrap();
+    if args.ai_rally && matches!(pr, Some(n) if n > 0) {
+        let pr = pr.unwrap();
         let working_dir = resolve_working_dir(&args);
         match headless::run_headless_rally(
             &repo,
@@ -410,10 +480,10 @@ async fn main() -> Result<()> {
 
     if args.local {
         run_with_local_diff(&repo, &config, &args).await
-    } else if let Some(pr) = args.pr.filter(|&n| n > 0) {
+    } else if let Some(pr) = pr.filter(|&n| n > 0) {
         run_with_pr(&repo, pr, &config, &args).await
     } else {
-        run_with_pr_list(&repo, config, &args, args.issue).await
+        run_with_pr_list(&repo, config, &args, issue).await
     }
 }
 

--- a/src/url_parse.rs
+++ b/src/url_parse.rs
@@ -1,0 +1,213 @@
+//! Parse GitHub PR / issue URLs into their components.
+//!
+//! Supports the common URL shapes that get pasted between people:
+//! `https://github.com/owner/repo/pull/123`, with optional scheme,
+//! trailing path segments (`/files`, `/commits`, ...), query strings,
+//! and URL fragments.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GithubRef {
+    Pr {
+        owner: String,
+        repo: String,
+        number: u32,
+    },
+    Issue {
+        owner: String,
+        repo: String,
+        number: u32,
+    },
+}
+
+impl GithubRef {
+    pub fn repo_slug(&self) -> String {
+        match self {
+            GithubRef::Pr { owner, repo, .. } | GithubRef::Issue { owner, repo, .. } => {
+                format!("{owner}/{repo}")
+            }
+        }
+    }
+
+    pub fn number(&self) -> u32 {
+        match self {
+            GithubRef::Pr { number, .. } | GithubRef::Issue { number, .. } => *number,
+        }
+    }
+}
+
+/// Parse a GitHub PR or issue URL. Returns `None` if the input doesn't look
+/// like a github.com PR/issue URL.
+pub fn parse_github_url(input: &str) -> Option<GithubRef> {
+    let s = input.trim();
+
+    // Strip query string and fragment.
+    let s = s.split(['?', '#']).next().unwrap_or(s);
+
+    // Strip scheme.
+    let s = s
+        .strip_prefix("https://")
+        .or_else(|| s.strip_prefix("http://"))
+        .unwrap_or(s);
+
+    // Require github.com host (allow optional `www.`).
+    let s = s.strip_prefix("www.").unwrap_or(s);
+    let s = s.strip_prefix("github.com/")?;
+
+    let parts: Vec<&str> = s.split('/').filter(|p| !p.is_empty()).collect();
+    if parts.len() < 4 {
+        return None;
+    }
+
+    let owner = parts[0];
+    let repo = parts[1];
+    let kind = parts[2];
+    let number: u32 = parts[3].parse().ok()?;
+
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+
+    match kind {
+        "pull" => Some(GithubRef::Pr {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            number,
+        }),
+        "issues" => Some(GithubRef::Issue {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            number,
+        }),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pr(owner: &str, repo: &str, number: u32) -> GithubRef {
+        GithubRef::Pr {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            number,
+        }
+    }
+
+    fn issue(owner: &str, repo: &str, number: u32) -> GithubRef {
+        GithubRef::Issue {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            number,
+        }
+    }
+
+    #[test]
+    fn parses_canonical_pr_url() {
+        assert_eq!(
+            parse_github_url("https://github.com/ushironoko/octorus/pull/123"),
+            Some(pr("ushironoko", "octorus", 123))
+        );
+    }
+
+    #[test]
+    fn parses_pr_url_with_files_suffix() {
+        assert_eq!(
+            parse_github_url("https://github.com/ushironoko/octorus/pull/123/files"),
+            Some(pr("ushironoko", "octorus", 123))
+        );
+    }
+
+    #[test]
+    fn parses_pr_url_with_fragment() {
+        assert_eq!(
+            parse_github_url(
+                "https://github.com/ushironoko/octorus/pull/123#discussion_r987654321"
+            ),
+            Some(pr("ushironoko", "octorus", 123))
+        );
+    }
+
+    #[test]
+    fn parses_pr_url_with_query_string() {
+        assert_eq!(
+            parse_github_url("https://github.com/ushironoko/octorus/pull/123?diff=split"),
+            Some(pr("ushironoko", "octorus", 123))
+        );
+    }
+
+    #[test]
+    fn parses_pr_url_without_scheme() {
+        assert_eq!(
+            parse_github_url("github.com/ushironoko/octorus/pull/123"),
+            Some(pr("ushironoko", "octorus", 123))
+        );
+    }
+
+    #[test]
+    fn parses_pr_url_with_http_scheme() {
+        assert_eq!(
+            parse_github_url("http://github.com/ushironoko/octorus/pull/123"),
+            Some(pr("ushironoko", "octorus", 123))
+        );
+    }
+
+    #[test]
+    fn parses_pr_url_with_trailing_slash() {
+        assert_eq!(
+            parse_github_url("https://github.com/ushironoko/octorus/pull/123/"),
+            Some(pr("ushironoko", "octorus", 123))
+        );
+    }
+
+    #[test]
+    fn parses_issue_url() {
+        assert_eq!(
+            parse_github_url("https://github.com/ushironoko/octorus/issues/161"),
+            Some(issue("ushironoko", "octorus", 161))
+        );
+    }
+
+    #[test]
+    fn rejects_plain_repo_url() {
+        assert_eq!(
+            parse_github_url("https://github.com/ushironoko/octorus"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_non_github_host() {
+        assert_eq!(
+            parse_github_url("https://gitlab.com/ushironoko/octorus/pull/123"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_kind() {
+        assert_eq!(
+            parse_github_url("https://github.com/ushironoko/octorus/wiki/123"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_non_numeric_number() {
+        assert_eq!(
+            parse_github_url("https://github.com/ushironoko/octorus/pull/abc"),
+            None
+        );
+    }
+
+    #[test]
+    fn rejects_repo_slug() {
+        assert_eq!(parse_github_url("ushironoko/octorus"), None);
+    }
+
+    #[test]
+    fn repo_slug_helper() {
+        assert_eq!(pr("a", "b", 1).repo_slug(), "a/b");
+        assert_eq!(issue("a", "b", 1).repo_slug(), "a/b");
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -59,6 +59,60 @@ fn invalid_repo_exits_with_error() {
 }
 
 #[test]
+fn pr_url_with_garbage_value_fails_with_clear_message() {
+    cargo_bin_cmd!("or")
+        .args(["--pr", "not-a-number-or-url"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "neither a number nor a GitHub URL",
+        ));
+}
+
+#[test]
+fn pr_issue_url_redirects_user_to_issue_flag() {
+    cargo_bin_cmd!("or")
+        .args(["--pr", "https://github.com/ushironoko/octorus/issues/161"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("use --issue instead"));
+}
+
+#[test]
+fn issue_url_pr_kind_redirects_user_to_pr_flag() {
+    cargo_bin_cmd!("or")
+        .args(["--issue", "https://github.com/ushironoko/octorus/pull/123"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("use --pr instead"));
+}
+
+#[test]
+fn issue_url_with_garbage_value_fails_with_clear_message() {
+    cargo_bin_cmd!("or")
+        .args(["--issue", "not-a-number-or-url"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "neither a number nor a GitHub URL",
+        ));
+}
+
+#[test]
+fn pr_url_conflicting_with_repo_flag_fails() {
+    cargo_bin_cmd!("or")
+        .args([
+            "--repo",
+            "someone/else",
+            "--pr",
+            "https://github.com/ushironoko/octorus/pull/123",
+        ])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("conflicts with --repo"));
+}
+
+#[test]
 fn pr_flag_only_enters_pr_list() {
     cargo_bin_cmd!("or")
         .args(["--repo", "invalid/nonexistent-repo-12345", "--pr"])


### PR DESCRIPTION
Closes #162.

## Summary

`--pr` and `--issue` now accept either a bare number or a full GitHub URL, so users can paste links directly:

```bash
or --pr https://github.com/owner/repo/pull/123
or --issue https://github.com/owner/repo/issues/161
```

When a URL is given, `--repo` is populated from it. Bare numbers continue to work unchanged.

## Behavior

- `https://github.com/...`, `http://...`, scheme-less, trailing `/files`, `?query`, `#fragment`, and trailing `/` all parse.
- If `--repo` is also passed and disagrees with the URL, the command errors out (no silent override).
- An issue URL passed to `--pr` (or PR URL to `--issue`) errors with a hint to use the other flag.
- A garbage value (neither number nor URL) errors with a clear message.

## Implementation

- New `src/url_parse.rs` with `parse_github_url()` returning `GithubRef::Pr` / `GithubRef::Issue`. 14 unit tests cover the URL shapes above and the rejection cases.
- `--pr` / `--issue` changed from `Option<u32>` to `Option<String>`; a single `resolve_ref_arg()` helper in `src/main.rs` normalizes both and updates `--repo`.
- 4 new CLI integration tests for the URL form, conflicts, and wrong-kind errors.

## Test plan

- [x] `cargo check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (1191 lib + 17 CLI tests pass; one pre-existing parallel-execution flake in `editor::test_command_found_in_path_basic`, unrelated)
- [x] Manually ran `or --pr https://github.com/ushironoko/octorus/pull/123` and verified `--repo` is set