### PR TITLE
fix: word-wrap reply text area

### DIFF
--- a/src/ui/text_area.rs
+++ b/src/ui/text_area.rs
@@ -1,16 +1,93 @@
+//! Multi-line text input widget used for reply / comment composition.
+//!
+//! ## Wrapping
+//!
+//! Cursor placement under wrap requires knowing exactly where the renderer
+//! breaks each logical line. ratatui's `Wrap` is word-aware (textwrap-style)
+//! and its break positions are not part of the public API, so cursor math
+//! layered on top of it would either drift out of sync with what's rendered
+//! or have to re-derive the same breaks via a direct `textwrap` dependency.
+//!
+//! Instead we pre-wrap at character boundaries with `wrap_line_to_rows` and
+//! pass the already-wrapped lines to `Paragraph` with no `Wrap` set. The
+//! same algorithm drives `display_rows_for_line`, so the cursor cell and
+//! the rendered glyph cell are computed from a single source of truth.
+//!
+//! Char-boundary wrap is also a closer match to editing intuition:
+//! characters flow past the right edge the way a raw terminal does, and
+//! inserting a character can never re-flow the wrap point of an earlier
+//! row the way word-aware wrap can.
+//!
+//! If word-aware wrap is ever wanted here, the right move is to depend on
+//! `textwrap` directly and keep the "Paragraph receives pre-wrapped lines"
+//! contract — re-enabling `ratatui::widgets::Wrap` would reintroduce the
+//! cursor-vs-render divergence.
+
 use std::cell::Cell;
 
 use crossterm::event::{self, KeyCode, KeyModifiers};
 use ratatui::{
     layout::Rect,
     style::{Color, Style},
-    text::Line,
+    text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
     Frame,
 };
 use unicode_width::UnicodeWidthChar;
 
 use crate::keybinding::{event_to_keybinding, KeySequence, SequenceMatch, SequenceState};
+
+/// Display rows occupied by `line` when wrapped at character boundaries to
+/// `inner_width` display columns. Empty lines still take one row.
+///
+/// This must agree with [`wrap_line_to_rows`] — they encode the same
+/// wrapping algorithm, one as a count and one as the actual split.
+fn display_rows_for_line(line: &str, inner_width: usize) -> usize {
+    let inner_width = inner_width.max(1);
+    let width: usize = line
+        .chars()
+        .map(|c| UnicodeWidthChar::width(c).unwrap_or(0))
+        .sum();
+    if width == 0 {
+        1
+    } else {
+        width.div_ceil(inner_width)
+    }
+}
+
+/// Wrap a styled line at character boundaries so each emitted row fits within
+/// `inner_width` display columns. Span styles are preserved across splits.
+/// An empty input yields a single empty row so blank lines still take a row.
+fn wrap_line_to_rows(line: &Line<'static>, inner_width: usize) -> Vec<Line<'static>> {
+    let inner_width = inner_width.max(1);
+    let mut rows: Vec<Line<'static>> = Vec::new();
+    let mut current_row: Vec<Span<'static>> = Vec::new();
+    let mut current_width: usize = 0;
+
+    for span in &line.spans {
+        let style = span.style;
+        let mut buf = String::new();
+        for c in span.content.chars() {
+            let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+            if current_width + cw > inner_width && current_width > 0 {
+                if !buf.is_empty() {
+                    current_row.push(Span::styled(std::mem::take(&mut buf), style));
+                }
+                rows.push(Line::from(std::mem::take(&mut current_row)));
+                current_width = 0;
+            }
+            buf.push(c);
+            current_width += cw;
+        }
+        if !buf.is_empty() {
+            current_row.push(Span::styled(buf, style));
+        }
+    }
+    if !current_row.is_empty() || rows.is_empty() {
+        rows.push(Line::from(current_row));
+    }
+    rows
+}
 
 /// テキストエリアのキー入力結果
 pub enum TextAreaAction {
@@ -34,6 +111,9 @@ pub struct TextArea {
     /// 最後にレンダリングされた領域の可視行数（ボーダー除く）
     /// render()で実際のレンダリング領域から更新される（interior mutability）
     visible_height: Cell<usize>,
+    /// Inner width of the last rendered area (excluding borders).
+    /// Used to compute wrapped display-row counts (interior mutability).
+    inner_width: Cell<usize>,
     /// Custom submit key binding (default: Ctrl+S)
     submit_key: Option<KeySequence>,
     /// State for tracking pending key sequences
@@ -54,6 +134,7 @@ impl TextArea {
             cursor_col: 0,
             scroll_offset: Cell::new(0),
             visible_height: Cell::new(1),
+            inner_width: Cell::new(1),
             submit_key: None,
             sequence_state: SequenceState::new(),
         }
@@ -67,6 +148,7 @@ impl TextArea {
             cursor_col: 0,
             scroll_offset: Cell::new(0),
             visible_height: Cell::new(1),
+            inner_width: Cell::new(1),
             submit_key: Some(submit_key),
             sequence_state: SequenceState::new(),
         }
@@ -274,27 +356,22 @@ impl TextArea {
         styled_lines: Option<&[Line<'static>]>,
     ) {
         let visible_height = area.height.saturating_sub(2).max(1) as usize; // borders
+        let inner_width = area.width.saturating_sub(2).max(1) as usize;
         self.visible_height.set(visible_height);
-        // visible_height が変わった可能性があるのでスクロールを再調整
-        // （ターミナルリサイズで高さが縮小した場合、stale な scroll_offset でカーソルが画面外になる）
+        self.inner_width.set(inner_width);
+        // visible_height/inner_width may have changed; re-adjust scroll so the
+        // cursor stays visible after a terminal resize.
         self.adjust_scroll();
 
         let scroll_offset = self.scroll_offset.get();
 
-        // styled_lines がある場合は Line<'static> をそのまま clone（Cow の共有で済む）、
-        // ない場合はプレーンテキストから構築
-        let text: Vec<Line<'static>> = if let Some(styled) = styled_lines {
-            styled
-                .iter()
-                .skip(scroll_offset)
-                .take(visible_height)
-                .cloned()
-                .collect()
+        // Pre-wrap lines at character boundaries so what we render matches
+        // exactly what the cursor math (display_rows_for_line) predicts.
+        let logical_lines: Vec<Line<'static>> = if let Some(styled) = styled_lines {
+            styled.to_vec()
         } else {
             self.lines
                 .iter()
-                .skip(scroll_offset)
-                .take(visible_height)
                 .map(|l| Line::from(l.to_owned()))
                 .collect()
         };
@@ -303,19 +380,37 @@ impl TextArea {
         let display_text: Vec<Line<'static>> = if self.is_empty() {
             vec![Line::styled(placeholder.to_owned(), placeholder_style)]
         } else {
-            text
+            logical_lines
+                .iter()
+                .flat_map(|l| wrap_line_to_rows(l, inner_width))
+                .skip(scroll_offset)
+                .take(visible_height)
+                .collect()
         };
 
         let paragraph =
             Paragraph::new(display_text).block(Block::default().borders(Borders::ALL).title(title));
         frame.render_widget(paragraph, area);
 
-        // カーソル表示（CJK文字の表示幅を考慮）
-        let cursor_x = area.x + 1 + self.cursor_display_width() as u16;
-        let cursor_y = area.y + 1 + (self.cursor_row.saturating_sub(scroll_offset)) as u16;
+        // Cursor placement: account for CJK display width and word wrap.
+        let cursor_disp_col = self.cursor_display_width();
+        let cursor_abs_row = self.cursor_absolute_display_row();
+        let cursor_x = area.x + 1 + (cursor_disp_col % inner_width) as u16;
+        let cursor_y = area.y + 1 + (cursor_abs_row.saturating_sub(scroll_offset)) as u16;
         if cursor_y < area.y + area.height.saturating_sub(1) {
             frame.set_cursor_position((cursor_x, cursor_y));
         }
+    }
+
+    /// Absolute display-row index of the cursor (cumulative from line 0,
+    /// accounting for word wrap).
+    fn cursor_absolute_display_row(&self) -> usize {
+        let inner_width = self.inner_width.get().max(1);
+        let preceding: usize = self.lines[..self.cursor_row]
+            .iter()
+            .map(|l| display_rows_for_line(l, inner_width))
+            .sum();
+        preceding + self.cursor_display_width() / inner_width
     }
 
     fn insert_char(&mut self, c: char) {
@@ -438,16 +533,28 @@ impl TextArea {
     }
 
     fn adjust_scroll(&self) {
-        // スクロール調整: カーソルが見えるように（render()で設定された実際の可視高さを使用）
+        // Scroll adjustment in display-row space so wrapped lines are
+        // accounted for and the cursor stays visible.
         let visible_height = self.visible_height.get();
-        let scroll_offset = self.scroll_offset.get();
-        if self.cursor_row < scroll_offset {
-            self.scroll_offset.set(self.cursor_row);
+        let inner_width = self.inner_width.get().max(1);
+        let total_rows: usize = self
+            .lines
+            .iter()
+            .map(|l| display_rows_for_line(l, inner_width))
+            .sum();
+        let max_scroll = total_rows.saturating_sub(visible_height);
+        let cursor_row = self.cursor_absolute_display_row();
+        let mut scroll_offset = self.scroll_offset.get();
+        if cursor_row < scroll_offset {
+            scroll_offset = cursor_row;
+        } else if cursor_row >= scroll_offset + visible_height {
+            scroll_offset = cursor_row + 1 - visible_height;
         }
-        if self.cursor_row >= scroll_offset + visible_height {
-            self.scroll_offset
-                .set(self.cursor_row.saturating_sub(visible_height) + 1);
-        }
+        // Clamp so we never scroll past the end of content. This also
+        // recovers from stale scroll values produced by input()-time
+        // adjustment before the first render (inner_width defaults to 1).
+        scroll_offset = scroll_offset.min(max_scroll);
+        self.scroll_offset.set(scroll_offset);
     }
 }
 
@@ -848,5 +955,238 @@ mod tests {
             7,
             "scroll_offset should be re-adjusted when viewport shrinks during render"
         );
+    }
+
+    /// Read the visible (non-border) cells of a TestBackend buffer back as
+    /// trimmed strings, one per row, so wrap behavior is asserted on the
+    /// actual rendered grid rather than on internal state.
+    fn read_inner_rows(terminal: &ratatui::Terminal<ratatui::backend::TestBackend>) -> Vec<String> {
+        let buf = terminal.backend().buffer();
+        let area = buf.area;
+        (1..area.height - 1)
+            .map(|y| {
+                let mut s = String::new();
+                let mut skip_next = false;
+                for x in 1..area.width - 1 {
+                    if skip_next {
+                        skip_next = false;
+                        continue;
+                    }
+                    let sym = buf[(x, y)].symbol();
+                    s.push_str(sym);
+                    let w: usize = sym
+                        .chars()
+                        .map(|c| UnicodeWidthChar::width(c).unwrap_or(0))
+                        .sum();
+                    if w == 2 {
+                        skip_next = true;
+                    }
+                }
+                s.trim_end().to_string()
+            })
+            .collect()
+    }
+
+    fn render_to(
+        ta: &TextArea,
+        width: u16,
+        height: u16,
+    ) -> ratatui::Terminal<ratatui::backend::TestBackend> {
+        let backend = ratatui::backend::TestBackend::new(width, height);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                ta.render_with_title(frame, area, "T", "");
+            })
+            .unwrap();
+        terminal
+    }
+
+    #[test]
+    fn test_long_line_wraps_at_inner_width() {
+        // inner_width = 10 (width 12, minus 2 for borders).
+        let mut ta = TextArea::new();
+        ta.set_content("abcdefghijklmnop"); // 16 chars > inner_width 10
+        let term = render_to(&ta, 12, 5);
+        let rows = read_inner_rows(&term);
+        assert_eq!(rows[0], "abcdefghij");
+        assert_eq!(rows[1], "klmnop");
+    }
+
+    #[test]
+    fn test_typing_past_inner_width_keeps_cursor_visible() {
+        let mut ta = TextArea::new();
+        // Type 25 chars into a 10-col-wide inner area, viewport tall enough
+        // to hold all wrapped rows.
+        for c in "abcdefghijklmnopqrstuvwxy".chars() {
+            ta.input(KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers: KeyModifiers::NONE,
+                kind: KeyEventKind::Press,
+                state: KeyEventState::NONE,
+            });
+        }
+        let term = render_to(&ta, 12, 6); // visible_height = 4
+        let rows = read_inner_rows(&term);
+        assert_eq!(rows[0], "abcdefghij");
+        assert_eq!(rows[1], "klmnopqrst");
+        assert_eq!(rows[2], "uvwxy");
+        // 3 wrapped rows fit in visible_height=4, so no scroll needed.
+        assert_eq!(ta.scroll_offset.get(), 0);
+    }
+
+    #[test]
+    fn test_typing_past_visible_height_scrolls() {
+        let mut ta = TextArea::new();
+        // 35 chars => 4 wrapped rows at inner_width=10. visible_height=2 means
+        // the last 2 rows should be visible and scroll_offset should advance.
+        for c in "abcdefghijklmnopqrstuvwxyzABCDEFGHI".chars() {
+            ta.input(KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers: KeyModifiers::NONE,
+                kind: KeyEventKind::Press,
+                state: KeyEventState::NONE,
+            });
+        }
+        let term = render_to(&ta, 12, 4); // visible_height = 2
+        assert_eq!(ta.visible_height.get(), 2);
+        // cursor is on the 4th wrapped row (index 3); with visible_height=2
+        // scroll_offset is 3+1-2 = 2.
+        assert_eq!(ta.scroll_offset.get(), 2);
+        let rows = read_inner_rows(&term);
+        assert_eq!(rows[0], "uvwxyzABCD");
+        assert_eq!(rows[1], "EFGHI");
+    }
+
+    #[test]
+    fn test_wrap_handles_cjk_double_width() {
+        let mut ta = TextArea::new();
+        // Each あ is 2 display columns. 6 of them = 12 cols; with inner_width=8
+        // the wrap should land after 4 chars (8 cols).
+        ta.set_content("ああああああ");
+        let term = render_to(&ta, 10, 4); // inner_width = 8
+        let rows = read_inner_rows(&term);
+        assert_eq!(rows[0], "ああああ");
+        assert_eq!(rows[1], "ああ");
+    }
+
+    #[test]
+    fn test_cursor_absolute_display_row_after_wrap() {
+        let mut ta = TextArea::new();
+        ta.set_content("abcdefghijklmnop"); // 16 chars
+                                            // Render with inner_width=10 to populate inner_width Cell.
+        let _ = render_to(&ta, 12, 4);
+        // Move cursor to char 12 (on the second wrapped row, col 2).
+        ta.cursor_col = 12;
+        assert_eq!(ta.cursor_absolute_display_row(), 1);
+    }
+
+    #[test]
+    fn test_input_before_render_does_not_panic() {
+        // inner_width is initialized to 1 before any render. Verify that
+        // typing into a fresh TextArea still works and yields sane state.
+        let mut ta = TextArea::new();
+        for c in "hi".chars() {
+            ta.input(KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers: KeyModifiers::NONE,
+                kind: KeyEventKind::Press,
+                state: KeyEventState::NONE,
+            });
+        }
+        assert_eq!(ta.content(), "hi");
+    }
+
+    #[test]
+    fn test_cursor_lands_on_typed_glyph_after_wrap() {
+        // Core invariant of the wrap fix: after typing past the right edge
+        // of the box, the terminal cursor must land on the cell holding the
+        // most recently typed character — not on the row above it where it
+        // would sit if cursor math used logical row index instead of
+        // wrapped display row.
+        let mut ta = TextArea::new();
+        // 12 chars into a 12-wide box (inner_width = 10) wraps to row 2,
+        // col 2 within the inner area.
+        for c in "abcdefghijkl".chars() {
+            ta.input(KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers: KeyModifiers::NONE,
+                kind: KeyEventKind::Press,
+                state: KeyEventState::NONE,
+            });
+        }
+        let mut term = render_to(&ta, 12, 5);
+        let pos = term.get_cursor_position().unwrap();
+        // border at x=0/y=0; first wrapped row at y=1, cursor on second
+        // wrapped row at y=2. cursor_disp_col = 12, inner_width = 10, so
+        // x within inner = 2; absolute x = 1 (border) + 2 = 3.
+        assert_eq!(pos.x, 3);
+        assert_eq!(pos.y, 2);
+    }
+
+    #[test]
+    fn test_up_arrow_on_wrapped_line_does_not_move_logical_row() {
+        // Up/Down navigate logical lines, not visual rows. With wrap, a
+        // single logical line can span many visual rows; pressing Up at
+        // the end of a wrapped line on row 0 must be a no-op, since there
+        // is no logical line above it.
+        let mut ta = TextArea::new();
+        ta.set_content("abcdefghijklmnopqrstuvwxyz"); // wraps at inner=10
+                                                      // Render so inner_width is set; place cursor at end of logical line.
+        let _ = render_to(&ta, 12, 6);
+        ta.input(key_event(KeyCode::End));
+        assert_eq!(ta.cursor_row, 0);
+        ta.input(key_event(KeyCode::Up));
+        assert_eq!(ta.cursor_row, 0, "Up must not navigate visual rows");
+    }
+
+    #[test]
+    fn test_wrap_preserves_span_styles_across_boundary() {
+        // The styled-line render path is what suggestion-input uses for
+        // syntax highlighting. Styles must survive the split when a single
+        // span crosses a wrap boundary, and a span boundary that happens
+        // to coincide with a wrap boundary must not corrupt either side.
+        let red = Style::default().fg(Color::Red);
+        let blue = Style::default().fg(Color::Blue);
+        let line = Line::from(vec![
+            Span::styled("aaaaaaaa".to_string(), red), // 8 cols, red
+            Span::styled("bbbbbb".to_string(), blue),  // 6 cols, blue (wraps)
+        ]);
+        let rows = wrap_line_to_rows(&line, 10);
+        assert_eq!(rows.len(), 2, "expected wrap into 2 rows");
+
+        // Row 0: "aaaaaaaa" (red) + "bb" (blue) — fits 10 cols exactly.
+        assert_eq!(rows[0].spans.len(), 2);
+        assert_eq!(rows[0].spans[0].content, "aaaaaaaa");
+        assert_eq!(rows[0].spans[0].style, red);
+        assert_eq!(rows[0].spans[1].content, "bb");
+        assert_eq!(rows[0].spans[1].style, blue);
+
+        // Row 1: remaining 4 b's, blue.
+        assert_eq!(rows[1].spans.len(), 1);
+        assert_eq!(rows[1].spans[0].content, "bbbb");
+        assert_eq!(rows[1].spans[0].style, blue);
+    }
+
+    #[test]
+    fn test_empty_text_area_renders_placeholder() {
+        let ta = TextArea::new();
+        let term = render_to(&ta, 30, 4);
+        let rows = read_inner_rows(&term);
+        // render_to passes "" as placeholder, which means an empty visible
+        // first row. Use a non-empty placeholder to check the path.
+        assert!(rows[0].is_empty(), "empty placeholder yields empty row");
+
+        let backend = ratatui::backend::TestBackend::new(30, 4);
+        let mut terminal = ratatui::Terminal::new(backend).unwrap();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                ta.render_with_title(frame, area, "T", "Type your reply...");
+            })
+            .unwrap();
+        let rows = read_inner_rows(&terminal);
+        assert_eq!(rows[0], "Type your reply...");
     }
 }


### PR DESCRIPTION
Reply/comment text input now wraps inside the box. Previously typing past the right edge ran off-screen and hid what was being typed.