### PR TITLE
feat: extend diff line bg color to full visible width

### DIFF
--- a/benches/ui_rendering.rs
+++ b/benches/ui_rendering.rs
@@ -177,6 +177,7 @@ fn bench_selected_line_rendering(c: &mut Criterion) {
                         comments,
                         false,
                         None,
+                        120,
                     ))
                 });
             },
@@ -259,6 +260,7 @@ fn bench_visible_range_processing(c: &mut Criterion) {
                         comments,
                         false,
                         None,
+                        120,
                     ))
                 });
             },

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -49,8 +49,8 @@ impl LineType {
     #[inline]
     pub fn bg_color(&self) -> Option<ratatui::style::Color> {
         match self {
-            Self::Added => Some(ratatui::style::Color::Rgb(0, 60, 0)),
-            Self::Removed => Some(ratatui::style::Color::Rgb(60, 0, 0)),
+            Self::Added => Some(ratatui::style::Color::Rgb(0, 40, 0)),
+            Self::Removed => Some(ratatui::style::Color::Rgb(40, 0, 0)),
             _ => None,
         }
     }

--- a/src/ui/diff_view/mod.rs
+++ b/src/ui/diff_view/mod.rs
@@ -1082,13 +1082,17 @@ pub fn render_cached_lines<'a>(
     comment_lines: &HashSet<usize>,
     bg_color: bool,
     multiline_range: Option<(usize, usize)>,
+    content_width: u16,
 ) -> Vec<Line<'a>> {
+    use unicode_width::UnicodeWidthStr;
+
     // Clamp range to valid bounds to prevent out-of-bounds panic
     let len = cache.lines.len();
     let safe_start = range.start.min(len);
     let safe_end = range.end.min(len);
     // Handle case where start > end after clamping (produces empty slice)
     let safe_range = safe_start..safe_start.max(safe_end);
+    let cw = content_width as usize;
 
     cache.lines[safe_range.clone()]
         .iter()
@@ -1109,7 +1113,24 @@ pub fn render_cached_lines<'a>(
                 .spans
                 .iter()
                 .map(|s| Span::styled(cache.resolve(s.content), s.style));
-            let all_spans: Vec<Span<'_>> = marker.into_iter().chain(base).collect();
+            let mut all_spans: Vec<Span<'_>> = marker.into_iter().chain(base).collect();
+
+            // Pad trailing spaces so a line-level background color extends to the
+            // visible width. Only pad when a bg will actually be applied — the
+            // padded spaces inherit the line's bg via Style merging, so they
+            // become the colored fill.
+            let line_bg_will_be_set = is_in_multiline
+                || (!is_selected && bg_color && cached.line_type.bg_color().is_some());
+            if line_bg_will_be_set && cw > 0 {
+                let display_width: usize = all_spans
+                    .iter()
+                    .map(|s| UnicodeWidthStr::width(s.content.as_ref()))
+                    .sum();
+                let pad_len = (cw - (display_width % cw)) % cw;
+                if pad_len > 0 {
+                    all_spans.push(Span::raw(" ".repeat(pad_len)));
+                }
+            }
 
             let line = Line::from(all_spans);
             if is_in_multiline {
@@ -1249,6 +1270,7 @@ pub(crate) fn render_diff_content(frame: &mut Frame, app: &App, area: ratatui::l
             &app.cmt.file_comment_lines,
             app.config.diff.bg_color,
             multiline_range,
+            area.width.saturating_sub(2),
         );
         (rendered, 0u16)
     } else {
@@ -2284,8 +2306,15 @@ mod tests {
         );
 
         // render_cached_lines でコメントマーカーが挿入されること
-        let plain_rendered =
-            render_cached_lines(&plain, 0..plain.lines.len(), 0, &comment_lines, false, None);
+        let plain_rendered = render_cached_lines(
+            &plain,
+            0..plain.lines.len(),
+            0,
+            &comment_lines,
+            false,
+            None,
+            0,
+        );
         let hl_rendered = render_cached_lines(
             &highlighted,
             0..highlighted.lines.len(),
@@ -2293,6 +2322,7 @@ mod tests {
             &comment_lines,
             false,
             None,
+            0,
         );
 
         for &line_idx in &[4usize, 6] {
@@ -2467,7 +2497,7 @@ mod tests {
         assert_eq!(cache.lines.len(), 4);
 
         // range が完全に範囲外 → 空の Vec
-        let result = render_cached_lines(&cache, 100..200, 0, &HashSet::new(), false, None);
+        let result = render_cached_lines(&cache, 100..200, 0, &HashSet::new(), false, None, 0);
         assert!(
             result.is_empty(),
             "Out-of-bounds range should return empty Vec"
@@ -2479,7 +2509,7 @@ mod tests {
         let cache = build_plain_diff_cache("", 4);
         assert!(cache.lines.is_empty());
 
-        let result = render_cached_lines(&cache, 0..10, 0, &HashSet::new(), false, None);
+        let result = render_cached_lines(&cache, 0..10, 0, &HashSet::new(), false, None, 0);
         assert!(result.is_empty(), "Empty cache should return empty Vec");
     }
 }

--- a/src/ui/git_ops.rs
+++ b/src/ui/git_ops.rs
@@ -313,6 +313,7 @@ fn render_diff_body(
             &empty_comments,
             bg_color,
             None,
+            area.width.saturating_sub(2),
         )
     } else {
         vec![Line::from(Span::styled(
@@ -393,6 +394,7 @@ fn render_commit_diff_body(
             &empty_comments,
             bg_color,
             None,
+            area.width.saturating_sub(2),
         )
     } else {
         vec![Line::from(Span::styled(

--- a/src/ui/split_view.rs
+++ b/src/ui/split_view.rs
@@ -542,6 +542,7 @@ fn render_diff_body(
             &app.cmt.file_comment_lines,
             app.config.diff.bg_color,
             multiline_range,
+            area.width.saturating_sub(2),
         );
         (rendered, 0u16)
     } else {


### PR DESCRIPTION
## Summary

- Diff bg color (green for `+`, red for `-`) used to stop at the end of the code line. Now it fills to the full visible width of the diff pane by appending a trailing space span padded to the next multiple of the content width. Padding spaces inherit the line's bg via Style merging, so they become the colored fill.
- Lowered the default Added/Removed bg brightness (`Rgb(0/60/0)` → `Rgb(0/40/0)`, `Rgb(60/0/0)` → `Rgb(40/0/0)`) for a calmer look.
- `render_cached_lines` gains a `content_width: u16` parameter; all 4 production callers (`diff_view`, `git_ops` x2, `split_view`) pass `area.width.saturating_sub(2)` (border-adjusted). Benches and tests updated accordingly.
- Padding only triggers when a line-level bg is actually applied (Added/Removed in normal mode, or multiline-selected). Plain selected lines (REVERSED only) are unaffected.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — all green (1178 + 73 + 12 tests pass)
- [ ] Visual: open a PR with mixed Added/Removed/Context lines and confirm bg fills to right edge in main diff view, split view, and git ops diff
- [ ] Visual: scroll/select with `v` to enter multiline selection — selection bg also fills width
- [ ] Visual: long lines that wrap — bg fills last visual row to width
- [ ] Visual: confirm new darker greens/reds are subjectively correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)