### PR TITLE
feat: add diff_page_down/diff_page_up keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,8 @@ The split view shows the file list (left) and a diff preview (right). The defaul
 |-----|--------|
 | `j` / `↓` | Move file selection (diff follows) |
 | `k` / `↑` | Move file selection (diff follows) |
+| `PageDown` | Scroll diff page down (regardless of focused pane) |
+| `PageUp` | Scroll diff page up (regardless of focused pane) |
 | `t` | Toggle file tree view |
 | `Enter` / `→` / `l` | Focus diff pane |
 | `Z` | Toggle zen mode |
@@ -583,8 +585,10 @@ The split view shows the file list (left) and a diff preview (right). The defaul
 | `gf` | Open file in $EDITOR |
 | `gg` / `G` | Jump to first/last line |
 | `Ctrl-o` | Jump back |
-| `Ctrl-d` | Page down |
-| `Ctrl-u` | Page up |
+| `Ctrl-d` | Page down (focus-aware) |
+| `Ctrl-u` | Page up (focus-aware) |
+| `PageDown` | Scroll diff page down (regardless of focused pane) |
+| `PageUp` | Scroll diff page up (regardless of focused pane) |
 | `n` | Jump to next comment |
 | `N` | Jump to previous comment |
 | `c` | Add comment at line |
@@ -609,6 +613,8 @@ The split view shows the file list (left) and a diff preview (right). The defaul
 | `N` | Jump to previous comment |
 | `Ctrl-d` | Page down |
 | `Ctrl-u` | Page up |
+| `PageDown` | Scroll diff page down |
+| `PageUp` | Scroll diff page up |
 | `c` | Add comment at line |
 | `s` | Add suggestion at line |
 | `Shift+Enter` / `V` | Enter multiline selection mode |
@@ -836,6 +842,10 @@ move_down = "j"
 # Key with modifiers
 page_down = { key = "d", ctrl = true }
 
+# Named key (PageDown / PageUp / etc.)
+diff_page_down = "PageDown"
+diff_page_up = "PageUp"
+
 # Two-key sequence
 go_to_definition = ["g", "d"]
 ```
@@ -849,8 +859,10 @@ go_to_definition = ["g", "d"]
 | `move_up` | `k` | Move up |
 | `move_left` | `h` | Move left / back |
 | `move_right` | `l` | Move right / select |
-| `page_down` | `Ctrl+d` | Page down |
-| `page_up` | `Ctrl+u` | Page up |
+| `page_down` | `Ctrl+d` | Page down (focus-aware: file list moves selection, diff scrolls) |
+| `page_up` | `Ctrl+u` | Page up (focus-aware) |
+| `diff_page_down` | `PageDown` | Scroll diff page down (works from any pane in split view) |
+| `diff_page_up` | `PageUp` | Scroll diff page up (works from any pane in split view) |
 | `jump_to_first` | `gg` | Jump to first line |
 | `jump_to_last` | `G` | Jump to last line |
 | `jump_back` | `Ctrl+o` | Jump to previous position |

--- a/src/app/input_diff.rs
+++ b/src/app/input_diff.rs
@@ -24,6 +24,21 @@ impl App {
         let has_filter = self.file_list_filter.is_some();
         let tree_active = self.is_file_tree_active();
 
+        // diff_page_down / diff_page_up: scroll the diff regardless of focused pane.
+        if self.matches_single_key(&key, &kb.diff_page_down) {
+            let term_h = terminal.size()?.height as usize;
+            let visible_lines = self.diff_visible_lines(term_h, DiffViewVariant::SplitPane);
+            self.scroll_diff_page_down(visible_lines);
+            return Ok(());
+        }
+
+        if self.matches_single_key(&key, &kb.diff_page_up) {
+            let term_h = terminal.size()?.height as usize;
+            let visible_lines = self.diff_visible_lines(term_h, DiffViewVariant::SplitPane);
+            self.scroll_diff_page_up(visible_lines);
+            return Ok(());
+        }
+
         if self.matches_single_key(&key, &kb.tree_toggle) && !has_filter {
             self.toggle_file_tree();
             return Ok(());
@@ -550,6 +565,16 @@ impl App {
             return Ok(());
         }
 
+        if self.matches_single_key(&key, &kb.diff_page_down) {
+            self.scroll_diff_page_down(visible_lines);
+            return Ok(());
+        }
+
+        if self.matches_single_key(&key, &kb.diff_page_up) {
+            self.scroll_diff_page_up(visible_lines);
+            return Ok(());
+        }
+
         if self.matches_single_key(&key, &kb.page_down) || Self::is_shift_char_shortcut(&key, 'j') {
             if self.diff_scroll.line_count > 0 {
                 self.diff_scroll.selected_line = (self.diff_scroll.selected_line + 20)
@@ -668,4 +693,40 @@ impl App {
                 .saturating_sub(visible_lines.saturating_sub(margin + 1));
         }
     }
+
+    pub(crate) fn scroll_diff_page_down(&mut self, visible_lines: usize) {
+        if self.diff_scroll.line_count == 0 {
+            return;
+        }
+        self.diff_scroll.selected_line = (self.diff_scroll.selected_line + DIFF_PAGE_STEP)
+            .min(self.diff_scroll.line_count.saturating_sub(1));
+        self.adjust_scroll(visible_lines);
+    }
+
+    pub(crate) fn scroll_diff_page_up(&mut self, visible_lines: usize) {
+        self.diff_scroll.selected_line = self
+            .diff_scroll
+            .selected_line
+            .saturating_sub(DIFF_PAGE_STEP);
+        self.adjust_scroll(visible_lines);
+    }
+
+    pub(super) fn diff_visible_lines(&self, term_h: usize, variant: DiffViewVariant) -> usize {
+        if self.cmt.comment_panel_open {
+            let has_rally = self.has_background_rally();
+            let fixed = if has_rally { 7 } else { 6 };
+            let remaining = term_h.saturating_sub(fixed);
+            let (diff_pct, total_pct) = match variant {
+                DiffViewVariant::Fullscreen if !has_rally => (55usize, 95usize),
+                _ => (50, 90),
+            };
+            (remaining * diff_pct / total_pct).saturating_sub(2)
+        } else {
+            term_h.saturating_sub(8)
+        }
+    }
 }
+
+/// Diff page-scroll step, in lines. Shared by `kb.page_down` (focus-aware) and
+/// `kb.diff_page_down` (focus-independent).
+pub(crate) const DIFF_PAGE_STEP: usize = 20;

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -7583,3 +7583,178 @@ fn test_try_open_comment_panel_ignores_non_matching_key() {
     assert!(!app.try_open_comment_panel(&key, &kb));
     assert!(!app.cmt.comment_panel_open);
 }
+
+// ========================================
+// Diff page-scroll pure functions (issue #161)
+// ========================================
+
+#[test]
+fn test_scroll_diff_page_down_advances_by_step() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.diff_scroll.line_count = 100;
+    app.diff_scroll.selected_line = 0;
+
+    app.scroll_diff_page_down(40);
+
+    assert_eq!(
+        app.diff_scroll.selected_line,
+        super::input_diff::DIFF_PAGE_STEP
+    );
+}
+
+#[test]
+fn test_scroll_diff_page_down_clamps_at_end() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.diff_scroll.line_count = 10;
+    app.diff_scroll.selected_line = 5;
+
+    app.scroll_diff_page_down(40);
+
+    assert_eq!(app.diff_scroll.selected_line, 9);
+}
+
+#[test]
+fn test_scroll_diff_page_down_no_op_on_empty_diff() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.diff_scroll.line_count = 0;
+    app.diff_scroll.selected_line = 0;
+
+    app.scroll_diff_page_down(40);
+
+    assert_eq!(app.diff_scroll.selected_line, 0);
+}
+
+#[test]
+fn test_scroll_diff_page_up_saturates_at_zero() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.diff_scroll.line_count = 100;
+    app.diff_scroll.selected_line = 5;
+
+    app.scroll_diff_page_up(40);
+
+    assert_eq!(app.diff_scroll.selected_line, 0);
+}
+
+#[test]
+fn test_scroll_diff_page_up_full_step_when_room() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.diff_scroll.line_count = 100;
+    app.diff_scroll.selected_line = 50;
+
+    app.scroll_diff_page_up(40);
+
+    assert_eq!(
+        app.diff_scroll.selected_line,
+        50 - super::input_diff::DIFF_PAGE_STEP
+    );
+}
+
+#[test]
+fn test_diff_visible_lines_panel_closed_uses_term_minus_8() {
+    let config = Config::default();
+    let (app, _tx) = App::new_loading("owner/repo", 1, config);
+    assert!(!app.cmt.comment_panel_open);
+
+    let lines = app.diff_visible_lines(50, super::types::DiffViewVariant::SplitPane);
+    assert_eq!(lines, 50 - 8);
+}
+
+#[test]
+fn test_diff_visible_lines_tiny_terminal_does_not_panic() {
+    let config = Config::default();
+    let (app, _tx) = App::new_loading("owner/repo", 1, config);
+
+    let lines = app.diff_visible_lines(4, super::types::DiffViewVariant::SplitPane);
+    assert_eq!(lines, 0);
+}
+
+#[test]
+fn test_diff_visible_lines_panel_open_split_pane_pct() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.cmt.comment_panel_open = true;
+
+    let term_h = 50usize;
+    let lines = app.diff_visible_lines(term_h, super::types::DiffViewVariant::SplitPane);
+    let fixed = 6;
+    let expected = (term_h.saturating_sub(fixed) * 50 / 90).saturating_sub(2);
+    assert_eq!(lines, expected);
+}
+
+// ========================================
+// Scenario: diff_page_down/up in split view contexts (issue #161)
+// ========================================
+
+#[test]
+fn test_diff_page_down_in_split_file_list_advances_only_diff() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.state = AppState::SplitViewFileList;
+    app.diff_scroll.line_count = 100;
+    app.diff_scroll.selected_line = 0;
+    app.selected_file = 1;
+
+    app.scroll_diff_page_down(40);
+
+    assert_eq!(
+        app.diff_scroll.selected_line,
+        super::input_diff::DIFF_PAGE_STEP
+    );
+    assert_eq!(app.selected_file, 1, "file selection must not change");
+}
+
+#[test]
+fn test_diff_page_up_in_split_file_list_does_not_change_file_selection() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.state = AppState::SplitViewFileList;
+    app.diff_scroll.line_count = 100;
+    app.diff_scroll.selected_line = 60;
+    app.selected_file = 2;
+
+    app.scroll_diff_page_up(40);
+
+    assert_eq!(
+        app.diff_scroll.selected_line,
+        60 - super::input_diff::DIFF_PAGE_STEP
+    );
+    assert_eq!(app.selected_file, 2);
+}
+
+#[test]
+fn test_diff_page_down_works_with_filter_active() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.state = AppState::SplitViewFileList;
+    app.file_list_filter = Some(crate::filter::ListFilter::new());
+    app.diff_scroll.line_count = 100;
+    app.diff_scroll.selected_line = 0;
+
+    app.scroll_diff_page_down(40);
+
+    assert_eq!(
+        app.diff_scroll.selected_line,
+        super::input_diff::DIFF_PAGE_STEP
+    );
+}
+
+#[test]
+fn test_diff_page_down_in_diff_focus_matches_page_down_step() {
+    let config = Config::default();
+    let (mut app, _tx) = App::new_loading("owner/repo", 1, config);
+    app.state = AppState::SplitViewDiff;
+    app.diff_scroll.line_count = 200;
+    app.diff_scroll.selected_line = 30;
+
+    app.scroll_diff_page_down(40);
+
+    assert_eq!(
+        app.diff_scroll.selected_line,
+        30 + super::input_diff::DIFF_PAGE_STEP
+    );
+}

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -18,6 +18,8 @@ pub struct KeybindingsConfig {
     pub move_right: KeySequence,
     pub page_down: KeySequence,
     pub page_up: KeySequence,
+    pub diff_page_down: KeySequence,
+    pub diff_page_up: KeySequence,
     pub jump_to_first: KeySequence,
     pub jump_to_last: KeySequence,
     pub jump_back: KeySequence,
@@ -93,6 +95,8 @@ impl Default for KeybindingsConfig {
                 .with_alt(vec![KeyBinding::named(crate::keybinding::NamedKey::Right)]),
             page_down: KeySequence::single(KeyBinding::ctrl('d')),
             page_up: KeySequence::single(KeyBinding::ctrl('u')),
+            diff_page_down: KeySequence::single(KeyBinding::named(NamedKey::PageDown)),
+            diff_page_up: KeySequence::single(KeyBinding::named(NamedKey::PageUp)),
             jump_to_first: KeySequence::double(KeyBinding::char('g'), KeyBinding::char('g')),
             jump_to_last: KeySequence::single(KeyBinding::char('G')),
             jump_back: KeySequence::single(KeyBinding::ctrl('o')),
@@ -177,6 +181,8 @@ impl KeybindingsConfig {
             ("move_right", &self.move_right),
             ("page_down", &self.page_down),
             ("page_up", &self.page_up),
+            ("diff_page_down", &self.diff_page_down),
+            ("diff_page_up", &self.diff_page_up),
             ("jump_to_first", &self.jump_to_first),
             ("jump_to_last", &self.jump_to_last),
             ("jump_back", &self.jump_back),
@@ -378,6 +384,8 @@ impl Serialize for KeybindingsConfig {
         map.serialize_entry("move_right", &seq_to_value(&self.move_right))?;
         map.serialize_entry("page_down", &seq_to_value(&self.page_down))?;
         map.serialize_entry("page_up", &seq_to_value(&self.page_up))?;
+        map.serialize_entry("diff_page_down", &seq_to_value(&self.diff_page_down))?;
+        map.serialize_entry("diff_page_up", &seq_to_value(&self.diff_page_up))?;
         map.serialize_entry("jump_to_first", &seq_to_value(&self.jump_to_first))?;
         map.serialize_entry("jump_to_last", &seq_to_value(&self.jump_to_last))?;
         map.serialize_entry("jump_back", &seq_to_value(&self.jump_back))?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -64,6 +64,13 @@ mod tests {
     }
 
     #[test]
+    fn test_default_diff_page_keybindings() {
+        let config = KeybindingsConfig::default();
+        assert_eq!(config.diff_page_down.display(), "PageDown");
+        assert_eq!(config.diff_page_up.display(), "PageUp");
+    }
+
+    #[test]
     fn test_parse_simple_keybinding() {
         let toml_str = r#"
             [keybindings]
@@ -861,6 +868,8 @@ timeout_secs = 3600
             "move_right",
             "page_down",
             "page_up",
+            "diff_page_down",
+            "diff_page_up",
             "jump_to_first",
             "jump_to_last",
             "jump_back",

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -553,6 +553,17 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
             )
         )),
         Line::from(format!(
+            "{}  Scroll diff page (regardless of focus)",
+            fmt_key(
+                &format!(
+                    "{}/{}",
+                    kb.diff_page_down.display(),
+                    kb.diff_page_up.display()
+                ),
+                key_width
+            )
+        )),
+        Line::from(format!(
             "{}  Filter list",
             fmt_key(&kb.filter.display(), key_width)
         )),
@@ -585,6 +596,17 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
             "{}  Page scroll (also J/K)",
             fmt_key(
                 &format!("{}/{}", kb.page_down.display(), kb.page_up.display()),
+                key_width
+            )
+        )),
+        Line::from(format!(
+            "{}  Scroll diff page (regardless of focus)",
+            fmt_key(
+                &format!(
+                    "{}/{}",
+                    kb.diff_page_down.display(),
+                    kb.diff_page_up.display()
+                ),
                 key_width
             )
         )),
@@ -698,6 +720,14 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Page up (also K)",
             fmt_key(&kb.page_up.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Scroll diff page down",
+            fmt_key(&kb.diff_page_down.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Scroll diff page up",
+            fmt_key(&kb.diff_page_up.display(), key_width)
         )),
         Line::from(format!(
             "{}  Add comment at line",


### PR DESCRIPTION
## Summary

Adds new configurable keybinding actions `diff_page_down` / `diff_page_up` that always scroll the diff view in split mode, regardless of which pane is focused. Closes #161.

- **Defaults**: `PageDown` / `PageUp` (currently unassigned physical keys)
- **Existing `page_down` / `page_up` (Ctrl-d / Ctrl-u) preserved**: focus-aware behavior is unchanged for vim users
- Follows the lazygit `scrollUpMain` / `scrollDownMain` convention

## Design

- New constant `DIFF_PAGE_STEP = 20` (matches existing diff page step)
- New pure functions on `App`: `scroll_diff_page_down/up(visible_lines)` and `diff_visible_lines(term_h, variant)` — terminal-independent so they're easy to unit-test
- New dispatch branches:
  - `handle_split_view_file_list_input`: catches the keys before the focus-aware `page_down`/`tree_toggle` branches, so file selection / tree state are not disturbed
  - `handle_diff_input_common`: parallel branch added for consistency in the diff pane
- `multiline_selection` and `comment_panel_open` modes are intentionally not affected (they early-return before this dispatch). Standalone `AppState::FileList` (no diff visible) is also untouched.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` (zero warnings)
- [x] `cargo check --all-targets`
- [x] `cargo test --lib` — 1221 passed (13 new tests)
  - 8 unit tests covering pure functions: empty diff, end clamp, saturating sub, tiny terminal, comment-panel open/closed
  - 4 scenario tests covering split file-list focus, file selection invariance, filter active, diff focus
  - 1 default keybindings display test
- [ ] Manual: launch in split view, press `PageDown` from file-list focus → diff scrolls, file selection unchanged
- [ ] Manual: `Ctrl-d` / `Ctrl-u` retain existing focus-aware behavior
- [ ] Manual: rebind via config.toml (`diff_page_down = { key = "f", ctrl = true }`) and verify it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)