### PR TITLE
fix: clamp description scroll by wrapped visual lines

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "or"
 path = "src/main.rs"
 
 [dependencies]
-ratatui = "0.30.0"
+ratatui = { version = "0.30.0", features = ["unstable-rendered-line-info"] }
 crossterm = "0.28.1"
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "rt", "macros", "sync", "process", "io-util", "time"] }
 tokio-util = "0.7.18"

--- a/src/ui/issue_detail.rs
+++ b/src/ui/issue_detail.rs
@@ -227,11 +227,11 @@ fn render_body(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect, bo
         .is_some_and(|s| s.issue_detail_cache.is_some());
 
     if has_cache {
-        let (body_lines, total_lines, scroll_offset) = {
+        let body_lines: Vec<Line> = {
             let state = app.issue_state.as_ref().unwrap();
             let cache = state.issue_detail_cache.as_ref().unwrap();
 
-            let lines: Vec<Line> = cache
+            cache
                 .lines
                 .iter()
                 .filter(|line| line.line_type != LineType::Header)
@@ -251,35 +251,38 @@ fn render_body(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect, bo
                         .collect();
                     Line::from(spans)
                 })
-                .collect();
-
-            let total = lines.len();
-            let content_height = area.height.saturating_sub(2) as usize;
-            let max_scroll = total.saturating_sub(content_height);
-            let offset = state.issue_detail_scroll_offset.min(max_scroll);
-
-            (lines, total, offset)
+                .collect()
         };
 
-        if let Some(ref mut state) = app.issue_state {
-            state.issue_detail_scroll_offset = scroll_offset;
-        }
-
+        // Scroll offset is measured in *wrapped* (visual) rows because
+        // `Paragraph::scroll` applies after wrapping. Count wrapped rows at the
+        // inner content width so the clamp reaches the true bottom; the logical
+        // line count would leave the wrapped tail unreachable.
         let content_height = area.height.saturating_sub(2) as usize;
-        let max_scroll = total_lines.saturating_sub(content_height);
+        let inner_width = area.width.saturating_sub(2);
 
-        let body = Paragraph::new(body_lines)
+        let body = Paragraph::new(body_lines).wrap(Wrap { trim: false });
+        let total_visual = body.line_count(inner_width);
+        let max_scroll = total_visual.saturating_sub(content_height);
+
+        let scroll_offset = if let Some(ref mut state) = app.issue_state {
+            state.issue_detail_scroll_offset = state.issue_detail_scroll_offset.min(max_scroll);
+            state.issue_detail_scroll_offset
+        } else {
+            0
+        };
+
+        let body = body
             .block(
                 Block::default()
                     .borders(Borders::ALL)
                     .border_style(border_style)
                     .title("Body"),
             )
-            .wrap(Wrap { trim: false })
             .scroll((scroll_offset as u16, 0));
         frame.render_widget(body, area);
 
-        if total_lines > content_height {
+        if total_visual > content_height {
             let mut scrollbar_state = ScrollbarState::new(max_scroll + 1).position(scroll_offset);
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
                 .begin_symbol(None)
@@ -324,7 +327,11 @@ mod tests {
     use ratatui::Terminal;
 
     fn render_full(app: &mut App) -> String {
-        let backend = TestBackend::new(100, 24);
+        render_at(app, 100, 24)
+    }
+
+    fn render_at(app: &mut App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| {
@@ -333,9 +340,9 @@ mod tests {
             .unwrap();
         let buf = terminal.backend().buffer();
         let mut lines = Vec::new();
-        for y in 0..24u16 {
+        for y in 0..height {
             let mut line = String::new();
-            for x in 0..100u16 {
+            for x in 0..width {
                 let cell = &buf[(x, y)];
                 line.push_str(cell.symbol());
             }
@@ -448,6 +455,39 @@ mod tests {
         assert!(
             output.contains("(no description)"),
             "should show fallback text"
+        );
+    }
+
+    /// Regression: a long issue body whose logical lines wrap across many visual
+    /// rows must remain fully scrollable. Jumping to the bottom (offset = MAX) has
+    /// to reveal the final line — the scroll clamp must be based on wrapped visual
+    /// lines, not logical line count.
+    #[test]
+    fn test_long_wrapping_body_tail_reachable() {
+        let mut app = App::new_for_test();
+        app.state = AppState::IssueDetail;
+        let mut issue_state = IssueState::new();
+
+        let mut body = String::new();
+        for i in 0..8 {
+            body.push_str(&format!(
+                "Paragraph {i} is intentionally long so that it wraps across several visual rows when rendered inside a narrow terminal viewport.\n"
+            ));
+        }
+        body.push_str("UNIQUE_TAIL_MARKER");
+
+        issue_state.issue_detail =
+            crate::app::LoadState::Loaded(make_detail(9, "Long body issue", Some(&body)));
+        app.issue_state = Some(issue_state);
+        app.rebuild_issue_detail_cache();
+
+        // Emulate "jump to bottom".
+        app.issue_state.as_mut().unwrap().issue_detail_scroll_offset = usize::MAX;
+
+        let out = render_at(&mut app, 40, 12);
+        assert!(
+            out.contains("UNIQUE_TAIL_MARKER"),
+            "final line must be reachable when scrolled to the bottom:\n{out}"
         );
     }
 

--- a/src/ui/pr_description.rs
+++ b/src/ui/pr_description.rs
@@ -78,35 +78,36 @@ fn render_body(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
         })
         .collect();
 
-    let total_lines = lines.len();
-    let max_scroll = total_lines.saturating_sub(content_height);
+    // Scroll offset is measured in *wrapped* (visual) rows because
+    // `Paragraph::scroll` applies after wrapping. Count wrapped rows at the inner
+    // content width so the clamp reaches the true bottom; using the logical line
+    // count would leave the wrapped tail unreachable.
+    let inner_width = area.width.saturating_sub(2);
+    let body = Paragraph::new(lines).wrap(Wrap { trim: false });
+    let total_visual = body.line_count(inner_width);
+    let max_scroll = total_visual.saturating_sub(content_height);
     if app.pr_description_scroll_offset > max_scroll {
         app.pr_description_scroll_offset = max_scroll;
     }
+    let offset = app.pr_description_scroll_offset;
 
-    let scroll_info = if total_lines > content_height {
-        format!(
-            " ({}/{})",
-            app.pr_description_scroll_offset + 1,
-            max_scroll + 1
-        )
+    let scroll_info = if total_visual > content_height {
+        format!(" ({}/{})", offset + 1, max_scroll + 1)
     } else {
         String::new()
     };
 
-    let body = Paragraph::new(lines)
+    let body = body
         .block(
             Block::default()
                 .borders(Borders::ALL)
                 .title(format!("Description{}", scroll_info)),
         )
-        .wrap(Wrap { trim: false })
-        .scroll((app.pr_description_scroll_offset as u16, 0));
+        .scroll((offset as u16, 0));
     frame.render_widget(body, area);
 
-    if total_lines > content_height {
-        let mut scrollbar_state =
-            ScrollbarState::new(max_scroll + 1).position(app.pr_description_scroll_offset);
+    if total_visual > content_height {
+        let mut scrollbar_state = ScrollbarState::new(max_scroll + 1).position(offset);
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
             .begin_symbol(None)
             .end_symbol(None);
@@ -139,7 +140,11 @@ mod tests {
     use ratatui::Terminal;
 
     fn render_full(app: &mut App) -> String {
-        let backend = TestBackend::new(100, 24);
+        render_at(app, 100, 24)
+    }
+
+    fn render_at(app: &mut App, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
         terminal
             .draw(|frame| {
@@ -148,15 +153,69 @@ mod tests {
             .unwrap();
         let buf = terminal.backend().buffer();
         let mut lines = Vec::new();
-        for y in 0..24u16 {
+        for y in 0..height {
             let mut line = String::new();
-            for x in 0..100u16 {
+            for x in 0..width {
                 let cell = &buf[(x, y)];
                 line.push_str(cell.symbol());
             }
             lines.push(line.trim_end().to_string());
         }
         lines.join("\n")
+    }
+
+    fn app_with_pr_body(body: &str) -> App {
+        use crate::app::DataState;
+        use crate::github::{Branch, PullRequest, User};
+
+        let (mut app, _) = App::new_loading("owner/repo", 1, crate::config::Config::default());
+        let pr = Box::new(PullRequest {
+            number: 1,
+            node_id: None,
+            title: "Test PR".to_string(),
+            body: Some(body.to_string()),
+            state: "open".to_string(),
+            head: Branch {
+                ref_name: "feature".to_string(),
+                sha: "abc".to_string(),
+            },
+            base: Branch {
+                ref_name: "main".to_string(),
+                sha: "def".to_string(),
+            },
+            user: User {
+                login: "user".to_string(),
+            },
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+        });
+        app.data_state = DataState::Loaded { pr, files: vec![] };
+        app.open_pr_description();
+        app
+    }
+
+    /// Regression: a long description whose logical lines wrap across many visual
+    /// rows must remain fully scrollable. Jumping to the bottom (offset = MAX) has
+    /// to reveal the final line — the scroll clamp must be based on wrapped visual
+    /// lines, not logical line count.
+    #[test]
+    fn test_long_wrapping_description_tail_reachable() {
+        let mut body = String::new();
+        for i in 0..8 {
+            body.push_str(&format!(
+                "Paragraph {i} is intentionally long so that it wraps across several visual rows when rendered inside a narrow terminal viewport.\n"
+            ));
+        }
+        body.push_str("UNIQUE_TAIL_MARKER");
+
+        let mut app = app_with_pr_body(&body);
+        // Emulate "jump to bottom" (Shift+G sets offset to usize::MAX).
+        app.pr_description_scroll_offset = usize::MAX;
+
+        let out = render_at(&mut app, 40, 12);
+        assert!(
+            out.contains("UNIQUE_TAIL_MARKER"),
+            "final line must be reachable when scrolled to the bottom:\n{out}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

PR/Issue の description（本文）が長いと、後半が表示しきれずスクロールしても末尾に到達できなかった。「末尾ジャンプ」しても切れたままになる。

## Root cause

description / issue body の viewer は `Paragraph` を `Wrap { trim: false }` + `.scroll()` で描画しているが、スクロール上限 `max_scroll` を**論理行数**（`lines.len()`）で計算していた。一方 ratatui の `Paragraph::scroll` は**折り返し後の視覚行**を単位に動く。長い行が折り返すと視覚行数 > 論理行数となり、到達可能なスクロール量が真の最下部より不足して末尾が構造的に見切れていた（`Shift+G` の末尾ジャンプでも論理行上限に丸められて届かない）。

## Fix

ratatui 公式の `Paragraph::line_count(width)`（`WordWrapper` と完全一致する折り返し後の行数を返す）で視覚行数を求め、それを基準にクランプするよう変更。

- `Cargo.toml`: `ratatui` に `features = ["unstable-rendered-line-info"]` を追加（`line_count` を有効化）
- `src/ui/pr_description.rs`: `max_scroll` を `line_count(inner_width)` の視覚行数から算出。スクロールバーと `(x/y)` 表示も同じ単位に統一
- `src/ui/issue_detail.rs`: `render_body` のキャッシュ経路を同様に視覚行数ベースへ（キャッシュ無しの fallback 経路はスクロール状態を持たないため変更なし）

## Tests

- 折り返す長文を狭幅で末尾ジャンプし、最終行が可視になることを検証する回帰テストを両画面に追加（修正前は failed → 修正後 pass を確認）
- `cargo clippy -- -D warnings` / `cargo test`（1299 + 77 + 12）/ `cargo check` / `cargo fmt --check` すべてグリーン
- 目視確認: 末尾ジャンプで `(28/28)` まで到達し最終行が表示、先頭は `(1/28)`、スクロールバー位置も上下に追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qcRp83aTX7YjKgQhR5Nn2