### PR TITLE
feat: integrate hearth-graph symbol engine

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.95.0
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
+          toolchain: 1.95.0
           components: rustfmt
 
       - name: Check formatting
@@ -37,6 +38,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
+          toolchain: 1.95.0
           components: clippy
 
       - name: Cache cargo dependencies
@@ -58,6 +60,8 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.95.0
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.95.0
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
@@ -128,6 +130,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
+          toolchain: 1.95.0
           targets: ${{ matrix.target }}
 
       - name: Cache cargo dependencies
@@ -211,6 +214,8 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.95.0
 
       - name: Obtain token via trusted publishing
         uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79fcda08c33bb58b97008b2cdada6622500e949e060f5913361763121abd2416"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "serde",
+ "static_assertions",
+ "zmij",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -948,6 +962,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "hearth-graph"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ec4cd2eb3541701be3c3bbc80d3ef2596d4d5759d96e28555716da4259e5e5d"
+dependencies = [
+ "compact_str 0.10.0",
+ "parking_lot",
+ "rustc-hash",
+ "smallvec",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
+ "tree-sitter-go",
+ "tree-sitter-haskell",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-lua",
+ "tree-sitter-md",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-swift",
+ "tree-sitter-typescript",
+ "tree-sitter-zig",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +1485,7 @@ dependencies = [
  "clap",
  "criterion",
  "crossterm 0.28.1",
+ "hearth-graph",
  "insta",
  "lasso",
  "notify",
@@ -1450,6 +1496,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_chacha",
  "ratatui 0.30.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "serial_test",
@@ -2081,6 +2128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2331,9 +2384,12 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2768,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.3"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "974d205cc395652cfa8b37daa053fe56eebd429acf8dc055503fee648dae981e"
+checksum = "af1c71c1c4cc0920b20d6b0f6572e7682cd07a6a2faec71067a31fa394c586df"
 dependencies = [
  "cc",
  "regex",
@@ -3530,6 +3586,12 @@ name = "xdg"
 version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [".", "crates/tree-sitter-moonbit", "crates/tree-sitter-vue3"]
 name = "octorus"
 version = "0.6.7"
 edition = "2021"
+rust-version = "1.95"
 authors = ["ushironoko"]
 description = "A TUI tool for GitHub PR review, designed for Helix editor users"
 license = "MIT"
@@ -16,6 +17,7 @@ name = "or"
 path = "src/main.rs"
 
 [dependencies]
+hearth-graph = { version = "=0.1.1", default-features = false, features = ["bundled-languages", "fs"] }
 ratatui = { version = "0.30.0", features = ["unstable-rendered-line-info"] }
 crossterm = "0.28.1"
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "rt", "macros", "sync", "process", "io-util", "time"] }
@@ -39,6 +41,7 @@ chrono = "0.4.43"
 thiserror = "2.0.18"
 smallvec = "1.15.0"
 lasso = "0.7.3"
+rustc-hash = "=2.1.3"
 # compile-time perfect hash map for capture-to-scope mapping
 phf = { version = "0.13.1", features = ["macros"] }
 # tree-sitter for CST-based syntax highlighting

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ High-performance code review in your terminal for GitHub PRs, issues, local diff
 ## Requirements
 
 - [GitHub CLI (gh)](https://cli.github.com/) - Must be installed and authenticated
-- Rust 1.70+ (for building from source)
+- Rust 1.95+ (for building from source)
 - **For AI Rally feature** (optional, choose one or both):
   - [Claude Code](https://claude.ai/code) - Anthropic's CLI tool
   - [OpenAI Codex CLI](https://github.com/openai/codex) - OpenAI's CLI tool

--- a/benches/symbol_index.rs
+++ b/benches/symbol_index.rs
@@ -1,10 +1,10 @@
 //! Symbol index benchmarks for the Repository Browser.
 //!
-//! These measure the tree-sitter tags pipeline that backs the file outline,
-//! workspace symbol search and Go to Definition:
-//! - `extract_symbols` — per-file outline extraction across languages and sizes
-//! - `SymbolIndex::from_files` — building the name lookup table
-//! - `SymbolIndex::definitions` / `search` — query latency on a large index
+//! These measure the `hearth-graph` pipeline through the octorus compatibility
+//! facade that backs file outline, workspace symbol search, and Go to Definition:
+//! - `extract_symbols` — Hearth extraction plus conversion to octorus public types
+//! - `SymbolIndex::from_files` — facade conversion and Hearth index construction
+//! - `SymbolIndex::definitions` / `search` — Hearth queries plus ref projection
 //!
 //! Index build time is what the user waits on when opening the browser, and
 //! search latency is what they feel on every keystroke of a symbol query.
@@ -154,9 +154,9 @@ fn bench_index_queries(c: &mut Criterion) {
         b.iter(|| black_box(index.definitions(black_box("no_such_symbol_anywhere"))));
     });
 
-    // `search` memoises the last (needle, limit) pair, so repeating one query
-    // measures rebuilding `SymbolRef`s from the cache — not the scan. Both
-    // paths matter and the names must say which is which: the overlay redraws
+    // Hearth memoises the last (needle, limit) pair, so repeating one query
+    // measures rebuilding and projecting `SymbolRef`s from the cache — not the
+    // scan. Both paths matter and the names must say which is which: the overlay redraws
     // through the cached path on every frame, and takes the cold path once per
     // keystroke.
     for query in ["h", "handle", "handle_request_2500", "hrq"] {

--- a/benches/ui_rendering.rs
+++ b/benches/ui_rendering.rs
@@ -96,8 +96,10 @@ fn assert_browse_frames_are_comparable(small: &[String], huge: &[String]) {
     let huge_lines = visible_file_lines(huge);
     assert_eq!(small_lines, huge_lines);
     assert_eq!(small_lines.len(), 18);
-    assert_eq!(small_lines.first(), Some(&101));
-    assert_eq!(small_lines.last(), Some(&118));
+    // Browse scrolling keeps the cursor (line 101) inside the configured
+    // margin, so an 18-row viewport starts eight lines above it.
+    assert_eq!(small_lines.first(), Some(&93));
+    assert_eq!(small_lines.last(), Some(&110));
 
     let small_title_row = small
         .iter()

--- a/docs/repo-browse-architecture.md
+++ b/docs/repo-browse-architecture.md
@@ -8,15 +8,12 @@ Read this before adding features.
 | File | Role |
 |------|------|
 | `src/app/browse.rs` | State definitions, file loading, spawning and collecting async tasks |
-| `src/symbols.rs` | Symbol engine (independent of the screen, see [symbol-index.md](symbol-index.md)) |
+| `src/symbols.rs` | octorus compatibility facade over the Hearth symbol engine (independent of the screen, see [symbol-index.md](symbol-index.md)) |
 | `src/ui/browse.rs` | Rendering |
 | `src/app/input_browse.rs` | Key handling (2 panes + 2 overlays) |
 
-All four files are new, so their line counts are exactly this branch's added
-lines. **Do not put line counts in this table.** They used to be here, but every
-round that touched `src/app/browse.rs` and `src/symbols.rs` missed the update;
-the previous revision said 2,870 / 1,868 lines when the actual counts were
-3,018 / 1,942. Counting takes one command.
+Do not put line counts in this table; they become stale whenever the browser or
+its compatibility facade changes. Count the current checkout when needed.
 
 ```bash
 wc -l src/app/browse.rs src/symbols.rs src/ui/browse.rs src/app/input_browse.rs
@@ -32,16 +29,17 @@ Changes to existing files are kept minimal:
 - `src/main.rs` — the `--browse` flag
 - `src/ui/help.rs` — help entries
 - `src/app/cockpit.rs` / `src/ui/cockpit.rs` — the Cockpit menu item that opens the browser
-- `src/language.rs` — language detection for the added grammars
-- `src/lib.rs` — `pub mod symbols;`
-- `src/syntax/parser_pool.rs` — parser pool support for the added grammars
-- `src/queries/{bash,c_sharp,haskell,markdown,moonbit,zig}/tags.scm` — queries that extract symbols for each language
-- `Cargo.toml` — the `symbol_index` bench target, and excluding `docs/` from the package
-- `benches/ui_rendering.rs` — the `browse_render` group (8 sections) / `benches/symbol_index.rs` is new
-- `tests/cli.rs` — e2e tests that launch the binary (7 sections)
+- `src/language.rs` — highlighting-language detection plus the public tags-query compatibility accessor
+- `src/lib.rs` — `pub mod symbols;` and the public `ParserPool` re-export
+- `src/syntax/parser_pool.rs` — highlight caches plus the Hearth parser/query cache
+- `src/queries/moonbit/tags.scm` — the host-owned MoonBit symbol query; bundled-language queries are owned by Hearth
+- `Cargo.toml` / `Cargo.lock` — the exact `hearth-graph` dependency, Rust version, and the `symbol_index` bench target
+- `benches/ui_rendering.rs` — the `browse_render` group / `benches/symbol_index.rs` — facade extraction, build, and query benchmarks
+- `tests/cli.rs` — e2e tests that launch the binary
 
-No new dependency crates were added (the `Cargo.toml` diff is just the two
-points above).
+The symbol implementation depends on exact registry release `hearth-graph
+0.1.1` with only its `bundled-languages` and `fs` features. See
+[symbol-index.md](symbol-index.md) for ownership and compatibility boundaries.
 
 ## 2. State machine
 
@@ -50,27 +48,11 @@ conditional flags" — **not a single boolean flag representing a screen, a mode
 or a load state was added**. `BrowseState` has no `bool` fields; "which screen",
 "is it loading", and "is the index ready" are all answered by the enums below.
 
-This branch adds 3 `bool` **fields**, none of which stands in for a state
-machine. When counting, exclude function parameters (`focused` on
-`render_tree` / `render_content`, `selected` on `outline_row`, `bg_color` on
-`content_lines`) — an earlier revision conflated those and said 2.
-
-```bash
-git diff main -- src/ | grep -E '^\+[^+].*: *bool' | grep -v 'fn '
-```
-
-- `OpenFile::viewable` (`src/app/browse.rs`) — a property of a single file that
-  has finished reading, not a transition. The rendering side branches on the
-  presence of `notice`; the only reader of this value is the guard in
-  `start_browse_highlight()` (see §3). As an enum it would only ever be the two
-  values `Viewable | Unviewable`, with no transitions.
-- `ChunkOutcome::stopped_early` (`src/symbols.rs`) — part of the return value of
-  a single index-build worker. It is held by neither `App` nor `BrowseState`;
-  `build_cancellable` uses it to decide whether to return
-  `IndexBuild::Cancelled`, then discards it.
-- `Args::browse` (`src/main.rs`) — the clap flag for `--browse`. It is the CLI
-  argument representation, not running state; it is read once at startup and
-  collapses into the initial `AppState`.
+Persistent browser modes and loading transitions remain represented by enums,
+not boolean flags. `OpenFile::viewable` is a property of loaded content, and
+`Args::browse` is a one-shot CLI input rather than runtime state. The symbol
+facade introduces no persistent boolean state: cancellation is read through a
+stateless `CancelSignal` and Hearth returns an `IndexBuild` outcome.
 
 ```
 AppState
@@ -490,14 +472,14 @@ is "where are the tests for what", so that table stays:
 | Where | What |
 |-------|------|
 | `src/app/browse.rs` | `git ls-files` parsing, pseudo-patch conversion, tree, filter, cursor/scroll, file loading and its cancellation |
-| `src/symbols.rs` | per-language extraction snapshots, boundaries (empty/unsupported/syntax errors/CJK), the index, scoring, build cancellation |
+| `src/symbols.rs` | Hearth-registry extraction snapshots, compatibility boundaries (including C macro merging, empty files, duplicate paths, CJK and checked conversion), projected index refs, search, and build cancellation |
 | `src/ui/browse.rs` | inline rendering snapshots, tiny-terminal clipping, wide-glyph border repair |
 | `src/app/input_browse.rs` | **scenario tests** (tree navigation → open → scroll → back, filter → cancel, outline → jump → back, etc.) |
 | `src/main.rs` | the flag set allowed to start without a repository (including `--browse`) |
 | `tests/cli.rs` | e2e launching the binary via `assert_cmd` (non-git directory, git repo without a GitHub remote) |
 
-The top four files are new on this branch, so their per-module test counts are
-exactly the number of new tests. The counting command:
+Count the current per-module tests rather than relying on historical branch
+deltas:
 
 ```bash
 cargo test --lib -- --list | grep ': test$' | awk -F'::' '{print $1"::"$2}' | sort | uniq -c
@@ -584,18 +566,17 @@ test fails. Maintain this mapping when editing.
     `test_cancelled_ready_load_is_not_delivered`
 
 - **Cancellation of the index build**
-  - remove the `PREFILTER_CANCEL_POLL_INTERVAL` poll from
-    `SymbolIndex::build_cancellable`'s metadata prefilter →
-    `test_cancelled_build_stops_the_metadata_prefilter`
-  - remove the poll at the head of `index_chunk` → `test_cancelled_build_stops_scanning_early`
+  - stop adapting `CancelSignal` to the closure passed to
+    `hearth_graph::build_index` → `test_cancelled_build_stops_metadata_prefilter`,
+    `test_cancelled_build_stops_scanning_early`, and
+    `test_precancelled_build_scans_nothing`
   - remove `state.cancel_token.cancel()` in `open_repo_browse` (re-entry to a
     different root) →
     `test_open_repo_browse_replaces_different_root_and_cancels_old_session`
   - change `IndexBuild::Cancelled { .. } => {}` in `start_symbol_index_build` to
     "send something" → `test_pre_cancelled_real_symbol_index_build_delivers_nothing`.
-    This one runs the real `SymbolIndex::build_cancellable` through
-    `spawn_blocking` and checks all the way down to the cancelled session's
-    build delivering nothing on the channel (the receiver returns `None`)
+    This runs the real Hearth-backed build through `spawn_blocking` and checks
+    that a cancelled session delivers nothing on the channel
 
 - **Nothing reaches the highlighter**: §3's
   `test_unviewable_files_never_start_background_highlighting`

--- a/docs/symbol-index.md
+++ b/docs/symbol-index.md
@@ -1,200 +1,220 @@
 # Symbol Index — Technical Reference
 
-The details of the tree-sitter-tags-based symbol engine implemented in
-`src/symbols.rs`. Read this when adding a language or adjusting queries.
+The Repository Browser symbol engine is exposed by `src/symbols.rs`, an
+octorus-owned compatibility facade over the exact crates.io dependency
+`hearth-graph = "=0.1.1"`.
 
-## 1. What it does
+Read this document when changing the facade, adding a symbol language, or
+upgrading Hearth. The browser architecture and task lifecycle remain documented
+in [`repo-browse-architecture.md`](repo-browse-architecture.md).
 
-It runs tree-sitter's `tags.scm` queries against the CST and extracts symbols
-from pairs of `@definition.*` captures and `@name` captures. This is the same
-query asset GitHub's code navigation ("Go to definition" / "Find all
-references") uses.
+## 1. Ownership and data flow
 
-```
-source ──parse──> Tree ──Query(tags.scm)──> QueryMatch*
-                                              │
-                            ┌─────────────────┴──────────────────┐
-                            │ @name           → name and position │
-                            │ @definition.xxx → kind and range    │
-                            └─────────────────┬──────────────────┘
-                                              ↓
-                              collapse_duplicate_tags()   ← dedupe per name node
-                                              ↓
-                              sort (start_byte asc, end_byte desc)
-                                              ↓
-                              containment stack computes depth
-                                              ↓
-                                        Vec<Symbol>
-```
+Hearth owns parsing, tags-query execution, duplicate collapse, nesting,
+repository index construction, search scoring, search memoization, and
+definition ranking. octorus owns the public API consumed by the browser:
 
-`Symbol` is `{ name, kind, line (1-based), column (0-based chars), depth }`.
-
-## 2. Where each language's tags query comes from
-
-Returned by `SupportedLanguage::tags_query()` (`src/language.rs`).
-
-| Language | Source | Notes |
-|----------|--------|-------|
-| Rust | `tree_sitter_rust::TAGS_QUERY` | 14 patterns |
-| TypeScript / TSX | **JS + TS concatenated** (`TYPESCRIPT_COMBINED_TAGS_QUERY`) | pitfall 2 below |
-| JavaScript / JSX | `tree_sitter_javascript::TAGS_QUERY` | 11 patterns |
-| Go | `tree_sitter_go::TAGS_QUERY` | |
-| Python | `tree_sitter_python::TAGS_QUERY` | |
-| Ruby | `tree_sitter_ruby::TAGS_QUERY` | |
-| C | `tree_sitter_c::TAGS_QUERY` | |
-| C++ | `tree_sitter_cpp::TAGS_QUERY` | **Self-contained**. No concatenation with C needed (unlike highlights) |
-| Java | `tree_sitter_java::TAGS_QUERY` | |
-| Lua | `tree_sitter_lua::TAGS_QUERY` | |
-| PHP | `tree_sitter_php::TAGS_QUERY` | |
-| Swift | `tree_sitter_swift::TAGS_QUERY` | |
-| C# | `src/queries/c_sharp/tags.scm` | the crate ships `queries/tags.scm` but exports no constant |
-| Zig | `src/queries/zig/tags.scm` | no upstream tags.scm |
-| Bash | `src/queries/bash/tags.scm` | no upstream tags.scm |
-| Haskell | `src/queries/haskell/tags.scm` | no upstream tags.scm |
-| MoonBit | `src/queries/moonbit/tags.scm` | vendored grammar |
-| Markdown | `src/queries/markdown/tags.scm` | turns headings into an outline |
-| Svelte / Vue / CSS / MarkdownInline | `None` | deliberate. An SFC's `<script>` belongs to the embedded language; CSS has no named entities |
-
-The `None` set is pinned by the test
-`test_languages_without_tags_query_are_intentional`. Update that test when you
-add a language — it is the guard against "accidentally left unsupported".
-
-## 3. Pitfalls hit during implementation (important)
-
-### 3.1 `Query::new` accepts the tags.scm directives
-
-`tags.scm` files contain directives specific to the `tree-sitter-tags` crate,
-such as `#strip!` / `#select-adjacent!` / `#not-eq?`. `tree_sitter::Query::new`
-accepts these as general predicates and does not fail to compile. Therefore
-**no dependency on the `tree-sitter-tags` crate is needed** — a bare `Query` +
-`QueryCursor` suffices.
-
-(Nothing depends on whether text predicates like `#not-eq?` are evaluated at
-runtime. If they are not, the only consequence is one extra symbol — nothing
-breaks.)
-
-### 3.2 TypeScript's TAGS_QUERY assumes it inherits JavaScript
-
-`tree_sitter_typescript::TAGS_QUERY` contains only the TS-specific patterns
-(`function_signature`, `interface_declaration`, `module`, etc.).
-`class_declaration` and `function_declaration` live on the JavaScript side.
-
-Without concatenation, `export class Widget {}` yields **not a single symbol**.
-This has exactly the same structure as `TYPESCRIPT_COMBINED_QUERY` for
-`HIGHLIGHTS_QUERY`, so `TYPESCRIPT_COMBINED_TAGS_QUERY` sits right next to it.
-
-C++ is the opposite: its `tags.scm` is self-contained (it carries both
-`class_specifier` and `struct_specifier` itself). Concatenating by analogy with
-the `highlights` habit produces duplicates — beware.
-
-### 3.3 Rust: the same node matches two patterns
-
-`tree-sitter-rust`'s tags.scm matches a function inside an impl block twice.
-
-```scm
-(declaration_list (function_item name: (identifier) @name) @definition.method)
-(function_item     name: (identifier) @name)                @definition.function
+```text
+source + path
+    │
+    ▼
+octorus ParserPool ──borrows──> hearth_graph::ParserPool
+    │
+    ▼
+hearth_graph::extract_symbols
+    │  CompactString / u32 / u16 + byte ranges
+    ▼
+src/symbols.rs compatibility conversion
+    │  String / usize
+    ▼
+Vec<octorus::symbols::Symbol>
 ```
 
-`@definition.method` and `@definition.function` land on **the same
-`function_item` node**. Processed naively,
+Repository construction follows the same boundary:
 
-- the outline shows `new` twice
-- the containment stack decides the node "contains itself" and depth splits into 0 and 1
-
-The countermeasure is `collapse_duplicate_tags()`. It keeps exactly one entry
-**keyed by the name node's byte offset**. Priority is the lexicographic order of
-`(kind_specificity, width of the definition node)`: `Method` is more specific
-than `Function`, and between equals the narrower range wins.
-
-### 3.4 Rust: `impl Foo` does not appear in the outline
-
-`(impl_item type: (type_identifier) @name !trait) @reference.implementation` —
-upstream treats it as a **reference**, not a definition. So the heading of an
-`impl` block never shows up in the outline; the methods inside are listed
-directly. This is an upstream design decision and octorus does not override it
-(to change it, swap in a custom query for Rust alone).
-
-### 3.5 Markdown: headings are siblings, so nesting is lost
-
-`atx_heading` nodes do not contain one another. The nesting lives in `section`.
-
-```scm
-; ✗ this puts everything at depth 0
-(atx_heading heading_content: (inline) @name) @definition.heading
-
-; ✓ capturing the section puts `##` beneath `#`
-(section (atx_heading heading_content: (inline) @name)) @definition.heading
+```text
+repo root + paths + local CancelSignal
+    │
+    ├─ FsLoader / BuildOptions / cancellation closure
+    ▼
+hearth_graph::build_index
+    │
+    ▼
+Hearth SymbolIndex + octorus projection
+    │
+    ├─ definitions(name)
+    ├─ search(query, limit)
+    └─ file_symbols(path)
 ```
 
-### 3.6 Zig: `const Foo = struct {}` is a variable_declaration
+The facade deliberately prevents Hearth storage choices from leaking into
+browser state, tests, or benchmarks.
 
-What looks like a type is expressed not as a type-declaration node but as a
-variable declaration whose initializer is a container declaration.
+## 2. Compatibility types and conversion rules
 
-```scm
-(variable_declaration (identifier) @name (struct_declaration)) @definition.class
+The octorus-facing types remain:
+
+```rust
+Symbol {
+    name: String,
+    kind: SymbolKind,
+    line: usize,
+    column: usize,
+    depth: usize,
+}
+
+FileSymbols {
+    path: String,
+    symbols: Vec<Symbol>,
+}
 ```
 
-### 3.7 Bash: only top-level assignments are picked up
+Hearth stores `CompactString`, `u32` line/column/byte offsets, and `u16` depth.
+Conversions from Hearth widen into octorus types. Conversions from synthetic or
+host-provided octorus fixtures use `u32::try_from` / `u16::try_from` and panic
+with a stable explanation when a value cannot be represented. Never replace
+these with `as`: truncation must not differ between debug and release builds.
 
-Capturing `variable_assignment` unconditionally floods the outline with
-function-local variables. The query is anchored with `(program ...)` to
-restrict it to the top level.
+`SymbolIndex` retains both:
 
-### 3.8 Haskell: one match per defining equation
+- the Hearth index used for every query;
+- an octorus-owned projection used to return `SymbolRef<'_>` with the original
+  `&str` / `&Symbol` API.
 
-A function defined by several equations (`f [] = ...` / `f (x:xs) = ...`)
-matches once per equation. This is absorbed after depth computation by
-**folding adjacent identical `(name, kind, depth)` entries into one**.
-"Adjacent only" is the important part: a method of the same name in a different
-impl block stays separate.
+Hearth query refs point into stable per-file symbol vectors. The facade records
+each Hearth symbol address in an `FxHashMap` whose value is the parallel
+`(file, symbol)` position, so hits are projected in O(1) without comparing names,
+hashing paths, or scanning a file outline. `SymbolIndex::from_files` fixtures
+have no source ranges, so their source-order position becomes a coherent
+synthetic one-byte range.
 
-### 3.9 tree-sitter columns are byte offsets
+## 3. Language registry
 
-`Node::start_position().column` returns a byte offset. octorus handles display
-width and cursor positions entirely in characters, so `char_column()` converts.
-It actually drifts with CJK identifiers, or when a line starts with a Japanese
-comment.
+`symbol_language_registry()` starts with `LanguageRegistry::bundled()` and then
+registers MoonBit through the public host API:
 
-## 4. Search scoring
+```rust
+LanguageSpec::new("moonbit", tree_sitter_moonbit::LANGUAGE.into(), ["mbt"])
+    .with_tags_query(MOONBIT_TAGS_QUERY)
+```
 
-`fuzzy_score_lowered(lowered_name, needle)`. It is **private**, and **both
-arguments are assumed already lowercased**. On the needle side,
-`LoweredNeedle` guarantees this at construction; on the name side,
-`from_files()` passes the precomputed `lowered_names` (so a keystroke does not
-lowercase every symbol one by one). There is no public API for scoring a single
-name; scores are observed only as the ordering `search()` returns.
+Last registration wins for an extension. MoonBit therefore remains an octorus
+host grammar without requiring a private Hearth field or a struct literal.
+`LanguageSpec` is non-exhaustive; always use its constructor/builders.
 
-| Tier | Score | Example (needle = `parse`) |
-|------|-------|---------------------------|
-| Exact match | 10,000 − length | `parse` |
-| Prefix match | 8,000 − length | `parse_line` |
-| Substring after a word boundary | 6,000 − position − length | `do_parse` (right after `_` `-` `.` `:`) |
-| Substring | 4,000 − position − length | `reparsed` |
-| Subsequence | 2,000 − min(gap, 1,000) − length | `please_advance_rest_of_set` |
+### Bundled by Hearth
 
-"Length" is `chars().count()` (not bytes). The 1,000 cap on the subsequence
-tier's gap is what keeps the tiers separated — without it, a scattered
-subsequence match could sink below the tier beneath it. Ties are broken by
-"shorter name → path order → line number" (so the rendered order does not change
-from run to run).
+| Language | Extensions used for symbols | Query ownership |
+|---|---|---|
+| Rust | `.rs` | Hearth / grammar crate |
+| TypeScript | `.ts`, `.mts`, `.cts` | Hearth combines JavaScript + TypeScript |
+| TSX | `.tsx` | Hearth combines JavaScript + TypeScript |
+| JavaScript | `.js`, `.mjs`, `.cjs` | Hearth / grammar crate |
+| JSX | `.jsx` | Hearth / grammar crate |
+| Go | `.go` | Hearth / grammar crate |
+| Python | `.py` | Hearth / grammar crate |
+| Ruby | `.rb`, `.rake`, `.gemspec` | Hearth / grammar crate |
+| C | `.c`, `.h` | Hearth / grammar crate |
+| C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | Hearth / grammar crate |
+| Java | `.java` | Hearth / grammar crate |
+| C# | `.cs` | Hearth-bundled query |
+| Zig | `.zig` | Hearth-bundled query |
+| Bash | `.sh`, `.bash`, `.zsh` | Hearth-bundled query |
+| Haskell | `.hs`, `.lhs` | Hearth-bundled query |
+| Lua | `.lua` | Hearth / grammar crate |
+| PHP | `.php` | Hearth / grammar crate |
+| Swift | `.swift` | Hearth / grammar crate |
+| Markdown | `.md`, `.markdown` | Hearth-bundled query |
 
-`search(query, limit)` scores every entry, then cuts to `limit` entries with a
-**top-N partial selection via `select_nth_unstable_by`, not a full sort**,
-before ordering them (the measurements justifying this live in a comment inside
-the function). On top of that, the most recent `(needle, limit)` pair's result
-is memoized, so re-issuing the same query with the same limit does not rescan.
-**A different limit misses the memo** — adding extra call sites doesn't just
-recompute, the returned sets themselves diverge. The UI's single call site is
-`BrowseState::symbol_search_hits()`; rendering, selection clamping, and Enter
-resolution all go through it.
+### Registered by octorus
 
-The ordering of `definitions()` is separate — a priority of "which one do you
-want to jump to": types (Class/Interface/Type) → callables
-(Function/Method/Macro) → Constant/Module → Field/Property/Heading.
+| Language | Extensions | Query ownership |
+|---|---|---|
+| MoonBit | `.mbt` | `src/queries/moonbit/tags.scm` |
 
-## 5. Index construction
+Svelte, Vue, CSS, and MarkdownInline remain highlighting/injection languages,
+not standalone symbol languages. Their handling in `SupportedLanguage` is
+independent of the Hearth symbol registry.
+
+## 4. Parser and query reuse
+
+The existing `crate::syntax::ParserPool` still owns highlighting parsers and
+queries. It now also contains a `hearth_graph::ParserPool<'static>` tied to the
+static symbol registry. `extract_symbols` borrows that cache rather than
+constructing a registry, parser, or query for each call.
+
+Repository builds use Hearth's worker-local parser pools. They remain blocking
+and CPU-bound and must be called from `spawn_blocking`, never from the draw loop.
+
+## 5. Extraction behavior and grammar quirks
+
+These behaviors are implemented upstream but remain user-visible contracts for
+octorus.
+
+### TypeScript inherits JavaScript tags
+
+The TypeScript tags query contains only TypeScript-specific patterns. Hearth
+combines it with the JavaScript query; otherwise ordinary classes and functions
+would disappear. C++ is the opposite: its tags query is self-contained and must
+not be concatenated with C.
+
+### Rust duplicate captures
+
+A function inside an `impl` can match both `@definition.method` and
+`@definition.function`. Hearth collapses captures by the name node byte offset,
+preferring the more specific kind and then the narrower definition span.
+`impl Foo` itself remains an upstream reference rather than an outline
+definition, so methods appear at top level.
+
+### Haskell equations
+
+Haskell is registered with
+`with_merge_adjacent_same_name_definitions(true)`. Consecutive equations such as
+`describe 0 = ...` and `describe value = ...` become one logical symbol.
+Ordinary sibling overloads in other languages are preserved.
+
+### Markdown nesting
+
+Markdown headings capture their enclosing `section`, not only the heading node.
+That gives `##` and `###` their expected outline depth.
+
+### Character columns
+
+tree-sitter reports byte columns. Hearth converts the prefix to characters, so
+CJK and accented identifiers agree with octorus cursor coordinates. The facade
+widens the resulting `u32` character column to `usize`.
+
+### Deterministic ordering
+
+Hearth sorts raw tags by definition start, outer definition first, line, name,
+and finally name-byte offset. The final key is an intentional difference from
+the former `HashMap` iteration corner case and guarantees deterministic output.
+
+## 6. Search and definitions
+
+`SymbolIndex::search(query, limit)` delegates ranking and top-N selection to
+Hearth. The observable tiers remain:
+
+| Tier | Example for `parse` |
+|---|---|
+| Exact | `parse` |
+| Prefix | `parse_line` |
+| Boundary substring | `do_parse` |
+| Other substring | `reparsed` |
+| Subsequence | `please_advance_rest_of_set` |
+
+Ties use shorter name, path, line, and stable index position. Hearth performs a
+top-N partial selection before sorting and memoizes the latest `(needle, limit)`
+pair. The octorus facade only projects the returned refs; it must not rescore or
+resort them.
+
+`definitions(name)` remains case-insensitive and prefers types, then callables,
+then constants/modules, then fields/properties/headings, followed by depth,
+path, and line.
+
+## 7. Repository build and cancellation
+
+The compatibility entry point remains:
 
 ```rust
 SymbolIndex::build_cancellable(
@@ -204,135 +224,76 @@ SymbolIndex::build_cancellable(
 ) -> IndexBuild
 ```
 
-There is no non-cancellable `build`. The return type is `IndexBuild`, not
-`SymbolIndex`, so the caller can render the three outcomes distinctly.
+The local trait is adapted with a closure, so browser code does not expose
+Hearth's cancellation trait. `CancellationToken` continues to implement the
+local seam.
 
-| Variant | Meaning | Screen |
-|---|---|---|
-| `Completed(SymbolIndex)` | every indexable path was walked | `IndexState::Ready` |
-| `Cancelled { scanned_files }` | the signal fired mid-run (overtaken by a newer build) | draw nothing; send nothing on the channel |
-| `Failed { message }` | it could not run at all — the repo root vanished / a worker panicked | error banner |
+Build options retain the octorus limits:
 
-Having `Failed` is the point: it avoids swallowing a worker panic and passing
-off "an index with fewer symbols" as success.
+- maximum file size: `MAX_INDEXED_FILE_BYTES = 2 MiB`;
+- maximum workers: 8;
+- maximum symbols per file: Hearth's `MAX_SYMBOLS_PER_FILE = 10,000`.
 
-`cancel` is a `&dyn CancelSignal` rather than a
-`tokio_util::sync::CancellationToken` **so that polling granularity is
-testable**. Pass a test signal that fires "after N polls" and you can pin down
-how many files a cancelled build touches without depending on wall-clock time.
-`CancellationToken` has an implementation of the trait.
+Outcomes remain `Completed`, `Cancelled { scanned_files }`, and
+`Failed { message }`. Unsupported, oversized, missing, and unreadable individual
+files are skipped. Root verification and worker panics are failures.
 
-- Blocking, CPU-bound. **Always call it from `spawn_blocking`** (never from the draw loop)
-- Eligible files: `supports_symbols()` is true, regular file, at most `MAX_INDEXED_FILE_BYTES = 2 MiB`
-- Two polling sites: the metadata prefilter every `PREFILTER_CANCEL_POLL_INTERVAL`,
-  and each worker inside `index_chunk`. Stopping at the former means `scanned_files` is 0
-- Worker count is `available_parallelism().clamp(1, 8)`, further capped by the
-  number of indexable files. Work is split under `std::thread::scope`, one
-  `ParserPool` per worker (to reuse parsers and compiled queries)
-- Chunks complete in arbitrary order, so results are re-sorted by path — to keep
-  snapshots and search results deterministic
+## 8. Intentional compatibility differences
 
-No parallel runtime like rayon was added. `thread::scope` is enough.
+These differences are accepted by issue #177 and must remain explicit:
 
-## 6. Measured numbers
+- duplicate input paths are last-wins;
+- successfully analyzed files with no symbols remain addressable as `Some(&[])`;
+- Hearth uses `parking_lot`, so there is no mutex-poison recovery contract;
+- raw symbol ordering includes the name-byte tie breaker;
+- `.mjs`, `.cjs`, `.mts`, and `.cts` are symbol-indexable;
+- root error wording may refer to a source root rather than a repository root;
+- direct extraction of source larger than `u32::MAX` bytes returns no symbols;
+- checked facade narrowing rejects synthetic values outside Hearth's integer
+  ranges instead of truncating them.
 
-**Only values reproducible via `benches/symbol_index.rs` go in this table.** It
-used to carry ad-hoc numbers from "measured octorus itself once"; with no
-reproduction procedure, the `search` implementation then changed from a full
-sort to top-N partial selection + memoization and nobody could follow up.
+Any additional divergence requires a compatibility test and an update here.
 
-Synthetic index (5,000 files × 20 symbols = 100,000 symbols, release build,
-measured on this machine with `--warm-up-time 1 --measurement-time 3`,
-Criterion median estimates):
+## 9. Benchmarks
 
-| Operation | Measured |
-|-----------|----------|
-| `from_files` (5,000 files / 100,000 symbols) | 8.48 ms |
-| `definitions` hit | 39.6 ns |
-| `definitions` miss | 27.0 ns |
-| `search_cached` (`h` / `handle` / `hrq`) | 462 / 462 / 465 ns |
-| `search_cached` (`handle_request_2500`) | 290 ns |
-| `search_cold` (`h` / `handle` / `hrq`) | 1.66 / 1.73 / 3.17 ms |
-| `search_cold` (`handle_request_2500`) | 6.99 ms |
+`benches/symbol_index.rs` measures the public facade, not Hearth directly:
 
-**`search_cached` and `search_cold` are different things — do not conflate
-them.** Memoization keys on `(needle, limit)`, so a `b.iter` that repeats the
-same query measures not a scan but "the cost of rehydrating the cached 200
-entries into `SymbolRef`s". Both are meaningful — the overlay takes the cached
-path every frame, and the cold path runs once per keystroke. The gap is
-3,500×, so mixing up the names means missing a regression entirely.
-`search_cold` defeats the memo by alternating the limit by 1.
+- `extract_symbols_rust/{10,50,200,1000}`;
+- `extract_symbols_language/{rust,typescript,markdown}`;
+- `from_files/{100,1000,5000}`;
+- `query/{definitions_hit,definitions_miss,search_cached/*,search_cold/*}`.
 
-`handle_request_2500` is the slowest cold case because a longer needle makes the
-`find` and the subsequence walk over all 100k symbols heavier, and the smaller
-hit count does not make up for it.
+`search_cached` includes Hearth cache lookup plus octorus ref projection.
+`search_cold` alternates the limit to force rescoring. Do not compare these two
+as if they measured the same path.
 
-### Properties not protected by automated gates
-
-- **The `lowered_names` precomputation**: `from_files()` caches the lowercased
-  names because re-lowercasing inside `fuzzy_score_lowered` would **allocate one
-  String per candidate**. On a 100k-symbol index that is 100k allocations per
-  keystroke. But **the results are exactly identical**, so removing the cache
-  fails not a single test (measured in a revert sweep). Case-insensitive
-  matching itself is pinned by the
-  `test_search_is_case_insensitive_in_both_directions` family, but what it
-  guards is correctness, not cost (what
-  `test_search_is_case_insensitive_for_queries` looks at is the match results).
-  To see the regression, run the `search_cold` bench.
-
-- **Worker panics taking precedence over cancellation**: `build_cancellable`
-  `return`s `IndexBuild::Failed` the moment it finds a join error while walking
-  `outcomes`, and the `stopped_early` check happens only after that loop.
-  Structurally, a panic therefore always beats cancellation. Swap that order
-  and a panic that coincides with cancellation gets reported as `Cancelled`,
-  which the caller (the empty arm in `start_symbol_index_build`) throws away —
-  no banner, the panic fully swallowed. **No test pins this order** — a
-  deterministic reproduction would need one worker to panic while only another
-  gets cancelled, and which worker consumes which poll is thread-schedule
-  dependent. When reordering, verify it yourself.
-
-`benches/symbol_index.rs` holds the Criterion benches:
+Run:
 
 ```bash
 cargo bench --bench symbol_index
 ```
 
-Four measured groups:
-- `extract_symbols_rust/{10,50,200,1000}` — throughput by file size
-- `extract_symbols_language/{rust,typescript,markdown}` — by language
-- `from_files/{100,1000,5000}` — index construction (up to 100k symbols)
-- `query/{definitions_hit,definitions_miss,search_cached/*,search_cold/*}` — query latency
+Historic timings from the octorus-owned implementation are not baseline values
+for the facade because conversion and projection changed the measured boundary.
+Record new numbers only from a reproducible Criterion run and include the exact
+Hearth version.
 
-CI (`.github/workflows/benchmark.yml`) currently runs only `ui_rendering` and
-`diff_parsing`. To put `symbol_index` under regression watch, add it there.
+## 10. Adding a symbol language
 
-## 7. How to add a language
+1. Prefer adding the grammar/query to Hearth when it is generally useful.
+2. For an octorus-only grammar, add the grammar dependency and query asset.
+3. Register it after `LanguageRegistry::bundled()` with `LanguageSpec` builders.
+4. Add extraction and `supports_symbols` compatibility tests.
+5. Confirm every registered query compiles through Hearth's `ParserPool`.
+6. Update the language tables and run `cargo bench --bench symbol_index`.
 
-1. Add the grammar crate to `Cargo.toml` and a variant to `SupportedLanguage`
-   (fill in all of `from_extension` / `default_extension` / `ts_language` /
-   `highlights_query` / `keywords` / `definition_prefixes` / `all()`; the
-   compiler reports what you missed)
-2. If the crate exports a `TAGS_QUERY`, return it from `tags_query()`
-3. If not, write `src/queries/<lang>/tags.scm` and embed it with `include_str!`
-   - The fastest way to check node names is `Parser::parse()` and dump the tree with `to_sexp()`
-   - Use `@definition.*` names that `SymbolKind::from_capture()` knows. Unknown
-     names are **silently dropped** (the judgement being that showing nothing
-     beats showing a wrong icon)
-4. Confirm `test_all_tags_queries_compile` passes (it catches query compile errors)
-5. Update the expectations of `test_languages_without_tags_query_are_intentional`
-6. Add one inline snapshot test for the extraction results
+Do not restore tags-query ownership to `SupportedLanguage`; highlighting and
+symbol registration intentionally have separate owners now.
 
-## 8. Relationship to the existing `src/symbol.rs`
+## 11. Relationship to `src/symbol.rs`
 
-`src/symbol.rs` is not deleted. The roles differ:
-
-| | `src/symbol.rs` (existing) | `src/symbols.rs` (new) |
-|---|---|---|
-| Technique | definition-keyword prefix match + `rg`/`grep` | tags queries over the CST |
-| Scope | inside the PR's patch / repository grep | the whole indexed repository |
-| Used by | `gd` in the diff view | `gd` / `o` / `s` in Repo Browse |
-| False positives | hits same-named tokens in comments and strings | does not |
-| Preparation | none (instant) | index build (background, hundreds of ms) |
-
-The diff view's `gd` could eventually lean on the index too, but the diff view's
-value is "works instantly with no index", so replace it with care.
+`src/symbol.rs` still provides the lightweight keyword/grep navigation used by
+the diff view. `src/symbols.rs` is the repository-wide CST index used by Repo
+Browse (`gd`, outline, and symbol search). Replacing the former with the latter
+would remove the diff view's instant no-index fallback and is outside this
+integration.

--- a/docs/symbol-index.md
+++ b/docs/symbol-index.md
@@ -48,7 +48,11 @@ Hearth SymbolIndex + octorus projection
 ```
 
 The facade deliberately prevents Hearth storage choices from leaking into
-browser state, tests, or benchmarks.
+browser state, tests, or benchmarks. The previously public
+`SupportedLanguage::tags_query` and `ParserPool::get_or_create_tags_query`
+methods remain available as compatibility accessors; both resolve through this
+same registry and Hearth query cache rather than restoring local query
+ownership.
 
 ## 2. Compatibility types and conversion rules
 
@@ -91,16 +95,23 @@ synthetic one-byte range.
 ## 3. Language registry
 
 `symbol_language_registry()` starts with `LanguageRegistry::bundled()` and then
-registers MoonBit through the public host API:
+applies two host registrations through the public API:
 
 ```rust
+LanguageSpec::new("c", tree_sitter_c::LANGUAGE.into(), ["c", "h"])
+    .with_tags_query(tree_sitter_c::TAGS_QUERY)
+    .with_merge_adjacent_same_name_definitions(true)
+
 LanguageSpec::new("moonbit", tree_sitter_moonbit::LANGUAGE.into(), ["mbt"])
     .with_tags_query(MOONBIT_TAGS_QUERY)
 ```
 
-Last registration wins for an extension. MoonBit therefore remains an octorus
-host grammar without requiring a private Hearth field or a struct literal.
-`LanguageSpec` is non-exhaustive; always use its constructor/builders.
+Last registration wins for an extension. The C override preserves the former
+octorus behavior for function-like macro definitions whose query captures the
+same macro identifier on adjacent definitions; ordinary non-adjacent symbols
+remain distinct. MoonBit remains an octorus host grammar without requiring a
+private Hearth field or a struct literal. `LanguageSpec` is non-exhaustive;
+always use its constructor/builders.
 
 ### Bundled by Hearth
 
@@ -114,7 +125,7 @@ host grammar without requiring a private Hearth field or a struct literal.
 | Go | `.go` | Hearth / grammar crate |
 | Python | `.py` | Hearth / grammar crate |
 | Ruby | `.rb`, `.rake`, `.gemspec` | Hearth / grammar crate |
-| C | `.c`, `.h` | Hearth / grammar crate |
+| C | `.c`, `.h` | grammar-crate query, re-registered by octorus to enable legacy adjacent-definition merging |
 | C++ | `.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx` | Hearth / grammar crate |
 | Java | `.java` | Hearth / grammar crate |
 | C# | `.cs` | Hearth-bundled query |

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]
+profile = "minimal"

--- a/src/language.rs
+++ b/src/language.rs
@@ -63,20 +63,6 @@ static TYPESCRIPT_COMBINED_QUERY: LazyLock<String> = LazyLock::new(|| {
     )
 });
 
-/// Combined TypeScript tags query (JavaScript base + TypeScript-specific).
-///
-/// Mirrors [`TYPESCRIPT_COMBINED_QUERY`]: `tree-sitter-typescript`'s tags query
-/// only declares signatures, interfaces and modules, and inherits classes and
-/// functions from JavaScript. Without the JavaScript half, `class Widget {}`
-/// produces no symbol at all.
-static TYPESCRIPT_COMBINED_TAGS_QUERY: LazyLock<String> = LazyLock::new(|| {
-    format!(
-        "{}\n{}",
-        tree_sitter_javascript::TAGS_QUERY,
-        tree_sitter_typescript::TAGS_QUERY
-    )
-});
-
 /// Combined C++ highlights query (C base + C++-specific).
 ///
 /// C++'s HIGHLIGHT_QUERY only contains C++-specific patterns (class, virtual, etc.)
@@ -121,14 +107,6 @@ static VUE_COMBINED_QUERY: LazyLock<String> = LazyLock::new(|| {
 
 /// C# highlights query (bundled as tree-sitter-c-sharp doesn't export it).
 const CSHARP_HIGHLIGHTS_QUERY: &str = include_str!("queries/c_sharp/highlights.scm");
-
-/// Tags queries bundled by octorus for grammars that ship none upstream.
-const CSHARP_TAGS_QUERY: &str = include_str!("queries/c_sharp/tags.scm");
-const ZIG_TAGS_QUERY: &str = include_str!("queries/zig/tags.scm");
-const BASH_TAGS_QUERY: &str = include_str!("queries/bash/tags.scm");
-const HASKELL_TAGS_QUERY: &str = include_str!("queries/haskell/tags.scm");
-const MOONBIT_TAGS_QUERY: &str = include_str!("queries/moonbit/tags.scm");
-const MARKDOWN_TAGS_QUERY: &str = include_str!("queries/markdown/tags.scm");
 
 /// All definition prefixes from all supported languages, deduplicated.
 static ALL_DEFINITION_PREFIXES: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
@@ -352,44 +330,6 @@ impl SupportedLanguage {
             // Phase 4: Markdown (block + inline)
             Self::Markdown => tree_sitter_md::HIGHLIGHT_QUERY_BLOCK,
             Self::MarkdownInline => tree_sitter_md::HIGHLIGHT_QUERY_INLINE,
-        }
-    }
-
-    /// Get the tags query for this language, if symbol extraction is supported.
-    ///
-    /// Tags queries drive the symbol index (file outline, workspace symbol
-    /// search, Go to Definition). Most grammars ship a `tags.scm` upstream and
-    /// export it as `TAGS_QUERY`; for the rest octorus bundles its own under
-    /// `src/queries/<lang>/tags.scm`.
-    ///
-    /// Returns `None` for languages with no meaningful named entities (CSS) or
-    /// where the grammar is only used as an injection target
-    /// (`MarkdownInline`) or an SFC wrapper (Svelte/Vue — their `<script>`
-    /// blocks are handled by the embedded language).
-    pub fn tags_query(&self) -> Option<&'static str> {
-        match self {
-            Self::Rust => Some(tree_sitter_rust::TAGS_QUERY),
-            Self::TypeScript | Self::TypeScriptReact => {
-                Some(TYPESCRIPT_COMBINED_TAGS_QUERY.as_str())
-            }
-            Self::JavaScript | Self::JavaScriptReact => Some(tree_sitter_javascript::TAGS_QUERY),
-            Self::Go => Some(tree_sitter_go::TAGS_QUERY),
-            Self::Python => Some(tree_sitter_python::TAGS_QUERY),
-            Self::Ruby => Some(tree_sitter_ruby::TAGS_QUERY),
-            Self::C => Some(tree_sitter_c::TAGS_QUERY),
-            Self::Cpp => Some(tree_sitter_cpp::TAGS_QUERY),
-            Self::Java => Some(tree_sitter_java::TAGS_QUERY),
-            Self::Lua => Some(tree_sitter_lua::TAGS_QUERY),
-            Self::Php => Some(tree_sitter_php::TAGS_QUERY),
-            Self::Swift => Some(tree_sitter_swift::TAGS_QUERY),
-            // Bundled locally: upstream ships no tags.scm (or does not export it)
-            Self::CSharp => Some(CSHARP_TAGS_QUERY),
-            Self::Zig => Some(ZIG_TAGS_QUERY),
-            Self::Bash => Some(BASH_TAGS_QUERY),
-            Self::Haskell => Some(HASKELL_TAGS_QUERY),
-            Self::MoonBit => Some(MOONBIT_TAGS_QUERY),
-            Self::Markdown => Some(MARKDOWN_TAGS_QUERY),
-            Self::Svelte | Self::Vue | Self::Css | Self::MarkdownInline => None,
         }
     }
 

--- a/src/language.rs
+++ b/src/language.rs
@@ -333,6 +333,17 @@ impl SupportedLanguage {
         }
     }
 
+    /// Get the tags query for this language, if symbol extraction is supported.
+    ///
+    /// This compatibility accessor reads from the Hearth language registry, so
+    /// symbol-query ownership remains centralized there. It returns `None` for
+    /// highlighting-only languages such as CSS and SFC wrappers.
+    pub fn tags_query(&self) -> Option<&'static str> {
+        let registry = crate::symbols::symbol_language_registry();
+        let id = crate::symbols::symbol_language_id(self.default_extension())?;
+        registry.get(id)?.tags_query.as_deref()
+    }
+
     /// Get the definition keyword prefixes for this language.
     ///
     /// Each entry is a keyword (including trailing space) that precedes a symbol

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,66 +1,46 @@
-//! Tree-sitter tags based symbol extraction and repository-wide symbol index.
+//! Compatibility facade over the `hearth-graph` symbol engine.
 //!
-//! This is the code-intelligence layer that turns octorus from a diff reader
-//! into a repository viewer. Unlike [`crate::symbol`] — which greps for
-//! definition keyword prefixes — symbols here come from the concrete syntax
-//! tree, so `fn parse` and the word `parse` inside a comment are never
-//! confused.
-//!
-//! The queries are the same `tags.scm` files GitHub uses for its own code
-//! navigation, so there is no language server to install, nothing to index
-//! ahead of time, and no daemon to keep alive: the grammars are already
-//! compiled into the binary.
-//!
-//! Two entry points:
-//!
-//! - [`extract_symbols`] — the outline of a single file, in source order.
-//! - [`SymbolIndex`] — every symbol in the repository, queryable by exact name
-//!   ([`SymbolIndex::definitions`]) or by fuzzy match
-//!   ([`SymbolIndex::search`]).
+//! octorus keeps its original `String` / `usize` public types so the browser,
+//! tests, and benchmarks do not depend on Hearth's compact storage choices.
+//! Extraction, indexing, search, definition lookup, and repository walking are
+//! delegated to Hearth; all representation conversion stays in this module.
 
-use std::collections::HashMap;
 use std::path::Path;
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Mutex;
+use std::sync::LazyLock;
 
-use smallvec::SmallVec;
-use tree_sitter::{QueryCursor, StreamingIterator};
+use hearth_graph::{
+    BuildOptions, FileSymbols as HearthFileSymbols, FsLoader, IndexBuild as HearthIndexBuild,
+    LanguageRegistry, LanguageSpec, Symbol as HearthSymbol, SymbolIndex as HearthSymbolIndex,
+    SymbolKind as HearthSymbolKind, SymbolRef as HearthSymbolRef,
+};
+use rustc_hash::FxHashMap;
 
-use crate::language::SupportedLanguage;
 use crate::syntax::ParserPool;
 
 /// Files larger than this are skipped when indexing.
-///
-/// Generated bundles and vendored blobs are the usual inhabitants of this
-/// bucket, and parsing them costs far more than the symbols are worth.
 pub const MAX_INDEXED_FILE_BYTES: u64 = 2 * 1024 * 1024;
 
 /// Maximum number of symbols retained per file.
-///
-/// Guards against pathological generated sources producing a multi-megabyte
-/// outline.
-pub const MAX_SYMBOLS_PER_FILE: usize = 10_000;
+pub const MAX_SYMBOLS_PER_FILE: usize = hearth_graph::MAX_SYMBOLS_PER_FILE;
 
-/// Number of metadata pre-filter entries processed between cancellation polls.
-const PREFILTER_CANCEL_POLL_INTERVAL: usize = 128;
+const MOONBIT_TAGS_QUERY: &str = include_str!("queries/moonbit/tags.scm");
 
-/// Repository-relative path that makes an indexing worker panic.
-///
-/// The join-error arm of [`SymbolIndex::build_cancellable`] is otherwise
-/// unreachable from a test, and without a guard it can be replaced by a
-/// `continue` that silently returns a short index. Test-only so nothing in the
-/// production build can reach it.
-#[cfg(test)]
-const WORKER_PANIC_PROBE_PATH: &str = "src/__octorus_worker_panic_probe.rs";
+/// Hearth's bundled registry plus the host-owned MoonBit grammar.
+static SYMBOL_LANGUAGES: LazyLock<LanguageRegistry> = LazyLock::new(|| {
+    let mut registry = LanguageRegistry::bundled();
+    registry.register(
+        LanguageSpec::new("moonbit", tree_sitter_moonbit::LANGUAGE.into(), ["mbt"])
+            .with_tags_query(MOONBIT_TAGS_QUERY),
+    );
+    registry
+});
 
-/// A cooperative cancellation signal polled by [`SymbolIndex::build_cancellable`].
-///
-/// Abstracted over [`tokio_util::sync::CancellationToken`] rather than taking
-/// one directly so the build's polling *granularity* is directly testable: a
-/// test signal that fires after a fixed number of polls pins down exactly how
-/// many files a cancelled build touches, with no timing assumption and no
-/// flaky wall-clock bound.
+/// Registry shared by the facade and the symbol parser cache.
+pub(crate) fn symbol_language_registry() -> &'static LanguageRegistry {
+    &SYMBOL_LANGUAGES
+}
+
+/// A cooperative cancellation signal used by octorus background work.
 pub trait CancelSignal: Sync {
     fn is_cancelled(&self) -> bool;
 }
@@ -71,7 +51,7 @@ impl CancelSignal for tokio_util::sync::CancellationToken {
     }
 }
 
-/// The kind of a named entity, derived from the `@definition.*` capture.
+/// The kind of a named entity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SymbolKind {
     Function,
@@ -89,28 +69,6 @@ pub enum SymbolKind {
 }
 
 impl SymbolKind {
-    /// Map a tags capture name (`definition.function`) to a kind.
-    ///
-    /// Unknown capture names return `None` and are skipped, so a grammar that
-    /// grows a new `@definition.*` capture degrades to "not shown" rather than
-    /// to a misleading icon.
-    fn from_capture(capture: &str) -> Option<Self> {
-        match capture.strip_prefix("definition.")? {
-            "function" => Some(Self::Function),
-            "method" => Some(Self::Method),
-            "class" | "struct" | "enum" | "union" => Some(Self::Class),
-            "interface" | "trait" | "protocol" => Some(Self::Interface),
-            "module" | "namespace" | "package" => Some(Self::Module),
-            "macro" => Some(Self::Macro),
-            "constant" => Some(Self::Constant),
-            "type" => Some(Self::Type),
-            "field" => Some(Self::Field),
-            "property" => Some(Self::Property),
-            "heading" => Some(Self::Heading),
-            _ => None,
-        }
-    }
-
     /// Single-character glyph used in outline and search rows.
     pub fn glyph(self) -> &'static str {
         match self {
@@ -129,6 +87,42 @@ impl SymbolKind {
     }
 }
 
+impl From<HearthSymbolKind> for SymbolKind {
+    fn from(kind: HearthSymbolKind) -> Self {
+        match kind {
+            HearthSymbolKind::Function => Self::Function,
+            HearthSymbolKind::Method => Self::Method,
+            HearthSymbolKind::Class => Self::Class,
+            HearthSymbolKind::Interface => Self::Interface,
+            HearthSymbolKind::Module => Self::Module,
+            HearthSymbolKind::Macro => Self::Macro,
+            HearthSymbolKind::Constant => Self::Constant,
+            HearthSymbolKind::Type => Self::Type,
+            HearthSymbolKind::Field => Self::Field,
+            HearthSymbolKind::Property => Self::Property,
+            HearthSymbolKind::Heading => Self::Heading,
+        }
+    }
+}
+
+impl From<SymbolKind> for HearthSymbolKind {
+    fn from(kind: SymbolKind) -> Self {
+        match kind {
+            SymbolKind::Function => Self::Function,
+            SymbolKind::Method => Self::Method,
+            SymbolKind::Class => Self::Class,
+            SymbolKind::Interface => Self::Interface,
+            SymbolKind::Module => Self::Module,
+            SymbolKind::Macro => Self::Macro,
+            SymbolKind::Constant => Self::Constant,
+            SymbolKind::Type => Self::Type,
+            SymbolKind::Field => Self::Field,
+            SymbolKind::Property => Self::Property,
+            SymbolKind::Heading => Self::Heading,
+        }
+    }
+}
+
 /// A named entity in a source file.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Symbol {
@@ -142,6 +136,13 @@ pub struct Symbol {
     pub depth: usize,
 }
 
+/// Symbols of one file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSymbols {
+    pub path: String,
+    pub symbols: Vec<Symbol>,
+}
+
 /// A symbol together with the file it lives in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SymbolRef<'a> {
@@ -150,9 +151,7 @@ pub struct SymbolRef<'a> {
 }
 
 impl SymbolRef<'_> {
-    /// Single source of truth for a symbol-search result row: `ƒ name  path:line`.
-    ///
-    /// Callers render this label directly instead of rebuilding the row format.
+    /// Single source of truth for a symbol-search result row.
     pub fn search_label(&self) -> String {
         format!(
             "{} {}  {}:{}",
@@ -166,720 +165,267 @@ impl SymbolRef<'_> {
 
 /// Whether symbol extraction is possible for the given filename.
 pub fn supports_symbols(filename: &str) -> bool {
-    language_for_file(filename).is_some()
+    symbol_language_registry().supports_symbols(Path::new(filename))
 }
 
-/// Resolve a filename to a language that has a tags query.
-fn language_for_file(filename: &str) -> Option<SupportedLanguage> {
-    let ext = Path::new(filename).extension()?.to_str()?;
-    let lang = SupportedLanguage::from_extension(ext)?;
-    lang.tags_query().map(|_| lang)
-}
-
-/// Intermediate match before nesting depth is known.
-struct RawTag {
-    name: String,
-    kind: SymbolKind,
-    line: usize,
-    column: usize,
-    /// Byte offset of the name node — the identity of the tagged entity.
-    name_byte: usize,
-    /// Byte range of the whole definition node, used to derive nesting.
-    start_byte: usize,
-    end_byte: usize,
-}
-
-/// Preference order when several patterns tag the same name node.
-///
-/// Rust's `tags.scm`, for example, matches an `impl` body's `fn` as both a
-/// method and a function. The more specific label wins so the outline reads
-/// `m new` rather than listing `new` twice.
-fn kind_specificity(kind: SymbolKind) -> u8 {
-    match kind {
-        SymbolKind::Method => 0,
-        SymbolKind::Property => 1,
-        SymbolKind::Field => 2,
-        SymbolKind::Constant => 3,
-        SymbolKind::Macro => 4,
-        SymbolKind::Function => 5,
-        SymbolKind::Interface => 6,
-        SymbolKind::Class => 7,
-        SymbolKind::Type => 8,
-        SymbolKind::Module => 9,
-        SymbolKind::Heading => 10,
-    }
-}
-
-/// Extract the symbols of a single file, in source order.
-///
-/// Returns an empty vector when the language is unsupported, the file fails to
-/// parse, or it simply contains no named entities. Callers render an empty
-/// outline rather than an error — an empty file is a use case, not a failure.
+/// Extract symbols through Hearth while preserving the octorus return type.
 pub fn extract_symbols(source: &str, filename: &str, pool: &mut ParserPool) -> Vec<Symbol> {
-    let Some(lang) = language_for_file(filename) else {
-        return Vec::new();
-    };
-
-    let tree = {
-        let Some(parser) = pool.get_or_create(lang.default_extension()) else {
-            return Vec::new();
-        };
-        match parser.parse(source, None) {
-            Some(tree) => tree,
-            None => return Vec::new(),
-        }
-    };
-
-    let Some(query) = pool.get_or_create_tags_query(lang) else {
-        return Vec::new();
-    };
-
-    let capture_names = query.capture_names();
-    let bytes = source.as_bytes();
-    let mut raw: Vec<RawTag> = Vec::new();
-
-    let mut cursor = QueryCursor::new();
-    let mut matches = cursor.matches(query, tree.root_node(), bytes);
-    while let Some(m) = matches.next() {
-        let mut name_node = None;
-        let mut definition = None;
-
-        for capture in m.captures {
-            let capture_name = capture_names[capture.index as usize];
-            if capture_name == "name" {
-                name_node.get_or_insert(capture.node);
-            } else if let Some(kind) = SymbolKind::from_capture(capture_name) {
-                definition.get_or_insert((kind, capture.node));
-            }
-        }
-
-        let (Some(name_node), Some((kind, def_node))) = (name_node, definition) else {
-            continue;
-        };
-
-        let Ok(name) = name_node.utf8_text(bytes) else {
-            continue;
-        };
-        let name = name.trim();
-        if name.is_empty() {
-            continue;
-        }
-
-        let position = name_node.start_position();
-        raw.push(RawTag {
-            name: name.to_string(),
-            kind,
-            line: position.row + 1,
-            column: char_column(source, name_node.start_byte(), position.column),
-            name_byte: name_node.start_byte(),
-            start_byte: def_node.start_byte(),
-            end_byte: def_node.end_byte(),
-        });
-
-        if raw.len() >= MAX_SYMBOLS_PER_FILE {
-            break;
-        }
-    }
-
-    let mut raw = collapse_duplicate_tags(raw);
-
-    // Source order, outer definitions before the ones they contain.
-    raw.sort_by(|a, b| {
-        a.start_byte
-            .cmp(&b.start_byte)
-            .then(b.end_byte.cmp(&a.end_byte))
-            .then(a.line.cmp(&b.line))
-            .then(a.name.cmp(&b.name))
-    });
-
-    let mut symbols: Vec<Symbol> = Vec::with_capacity(raw.len());
-    // Stack of enclosing definition end offsets; its height is the depth.
-    let mut enclosing: Vec<usize> = Vec::new();
-
-    for tag in raw {
-        while enclosing.last().is_some_and(|end| *end <= tag.start_byte) {
-            enclosing.pop();
-        }
-        let depth = enclosing.len();
-        enclosing.push(tag.end_byte);
-
-        // Grammars such as Haskell emit one match per defining equation, and
-        // some tags queries match a declaration through two patterns. Collapse
-        // only *adjacent* repeats so genuinely distinct same-named symbols
-        // (a method repeated across impl blocks) are preserved.
-        if let Some(previous) = symbols.last() {
-            if previous.name == tag.name && previous.kind == tag.kind && previous.depth == depth {
-                continue;
-            }
-        }
-
-        symbols.push(Symbol {
-            name: tag.name,
-            kind: tag.kind,
-            line: tag.line,
-            column: tag.column,
-            depth,
-        });
-    }
-
-    symbols
+    hearth_graph::extract_symbols(source, filename, pool.symbol_parser_pool())
+        .iter()
+        .map(symbol_from_hearth)
+        .collect()
 }
 
-/// Keep one tag per tagged name node.
-///
-/// Several patterns in the same `tags.scm` routinely match one entity — the
-/// winner is the most specific kind, and among equal kinds the tightest
-/// definition node, so nesting is computed from the innermost enclosing
-/// construct.
-fn collapse_duplicate_tags(raw: Vec<RawTag>) -> Vec<RawTag> {
-    let mut best: HashMap<usize, RawTag> = HashMap::with_capacity(raw.len());
-
-    for tag in raw {
-        match best.entry(tag.name_byte) {
-            std::collections::hash_map::Entry::Vacant(slot) => {
-                slot.insert(tag);
-            }
-            std::collections::hash_map::Entry::Occupied(mut slot) => {
-                let current = slot.get();
-                let span = tag.end_byte.saturating_sub(tag.start_byte);
-                let current_span = current.end_byte.saturating_sub(current.start_byte);
-                let better = (kind_specificity(tag.kind), span)
-                    < (kind_specificity(current.kind), current_span);
-                if better {
-                    slot.insert(tag);
-                }
-            }
-        }
+fn symbol_from_hearth(symbol: &HearthSymbol) -> Symbol {
+    Symbol {
+        name: symbol.name.to_string(),
+        kind: symbol.kind.into(),
+        line: usize::try_from(symbol.line)
+            .expect("hearth-graph symbol line does not fit octorus usize"),
+        column: usize::try_from(symbol.column)
+            .expect("hearth-graph symbol column does not fit octorus usize"),
+        depth: usize::from(symbol.depth),
     }
-
-    best.into_values().collect()
 }
 
-/// Convert a tree-sitter byte column to a character column.
-///
-/// tree-sitter reports columns in bytes; every column consumer in octorus
-/// counts characters, so multi-byte identifiers (CJK, accented Latin) would
-/// otherwise point past the symbol.
-fn char_column(source: &str, start_byte: usize, byte_column: usize) -> usize {
-    let line_start = start_byte.saturating_sub(byte_column);
-    if line_start >= source.len() || !source.is_char_boundary(line_start) {
-        return byte_column;
+fn symbol_to_hearth(symbol: Symbol, position: usize) -> HearthSymbol {
+    let name_start =
+        u32::try_from(position).expect("symbol position exceeds hearth-graph u32 range");
+    let def_end = name_start
+        .checked_add(1)
+        .expect("symbol position exceeds hearth-graph u32 range");
+
+    HearthSymbol {
+        name: symbol.name.into(),
+        kind: symbol.kind.into(),
+        line: u32::try_from(symbol.line).expect("symbol line exceeds hearth-graph u32 range"),
+        column: u32::try_from(symbol.column).expect("symbol column exceeds hearth-graph u32 range"),
+        depth: u16::try_from(symbol.depth).expect("symbol depth exceeds hearth-graph u16 range"),
+        // `from_files` fixtures have no source byte ranges. Hearth's index
+        // only needs a stable per-file identity here, so the source-order
+        // position provides a coherent synthetic one-byte range.
+        name_start,
+        def_start: name_start,
+        def_end,
     }
-    let end = start_byte.min(source.len());
-    if !source.is_char_boundary(end) {
-        return byte_column;
-    }
-    source[line_start..end].chars().count()
 }
 
-/// Symbols of one file.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FileSymbols {
-    pub path: String,
-    pub symbols: Vec<Symbol>,
+fn file_to_hearth(file: FileSymbols, position: usize) -> HearthFileSymbols {
+    let content_hash = u64::try_from(position)
+        .expect("file position exceeds hearth-graph content hash range")
+        .checked_add(1)
+        .expect("file position exceeds hearth-graph content hash range");
+    HearthFileSymbols {
+        path: file.path.into(),
+        content_hash,
+        symbols: file
+            .symbols
+            .into_iter()
+            .enumerate()
+            .map(|(position, symbol)| symbol_to_hearth(symbol, position))
+            .collect(),
+    }
 }
 
 /// Outcome of a cancellable repository-wide index build.
-///
-/// Three distinct outcomes rather than `Option<SymbolIndex>` plus a flag,
-/// because the caller renders a different thing for each: the finished index,
-/// nothing at all (a newer build superseded this one), or an error banner.
 #[derive(Debug)]
 pub enum IndexBuild {
-    /// The walk visited every indexable path.
     Completed(SymbolIndex),
-    /// The signal fired mid-walk; `scanned_files` files had been walked when it did.
     Cancelled { scanned_files: usize },
-    /// The build could not run at all — e.g. the repository root vanished
-    /// (a worktree removed mid-session), or an indexing worker panicked and the
-    /// index would otherwise silently under-report.
     Failed { message: String },
 }
 
-/// A search needle, lower-cased by construction.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct LoweredNeedle(String);
-
-impl LoweredNeedle {
-    fn new(query: &str) -> Self {
-        Self(query.to_lowercase())
-    }
-
-    fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
 #[derive(Debug)]
-struct CachedSearch {
-    needle: LoweredNeedle,
-    limit: usize,
-    hits: Vec<(u32, u32)>,
+struct ProjectedFile {
+    file: FileSymbols,
 }
 
-/// A scored search hit ordered by [`compare_search_candidates`].
-///
-/// The index tie-breakers reproduce the insertion order of the original stable
-/// full sort when all user-visible keys are equal.
+/// A repository-wide symbol index backed by Hearth.
 #[derive(Debug)]
-struct SearchCandidate<'a> {
-    score: i64,
-    name_len: usize,
-    path: &'a str,
-    line: usize,
-    file_index: u32,
-    symbol_index: u32,
-}
-
-fn compare_search_candidates(
-    a: &SearchCandidate<'_>,
-    b: &SearchCandidate<'_>,
-) -> std::cmp::Ordering {
-    b.score
-        .cmp(&a.score)
-        .then(a.name_len.cmp(&b.name_len))
-        .then(a.path.cmp(b.path))
-        .then(a.line.cmp(&b.line))
-        .then(a.file_index.cmp(&b.file_index))
-        .then(a.symbol_index.cmp(&b.symbol_index))
-}
-
-/// A repository-wide symbol index.
-///
-/// Built once per browse session from a list of repository-relative paths and
-/// queried synchronously afterwards.
-#[derive(Debug, Default)]
 pub struct SymbolIndex {
-    files: Vec<FileSymbols>,
-    /// Lower-cased names parallel to `files`, with `None` when the original is
-    /// already lower-case.
-    lowered_names: Vec<Vec<Option<Box<str>>>>,
-    /// Lower-cased name -> (file index, symbol index) pairs.
-    by_name: HashMap<String, SmallVec<[(u32, u32); 2]>>,
-    /// Number of files that were walked, including ones with no symbols.
-    scanned_files: usize,
-    /// Test-only cost probe counting comparator invocations for one search.
+    // Keep the compatibility wrapper small enough to move through the existing
+    // `IndexBuild` / `IndexDelivery` state-machine variants without inflating
+    // every cancellation and failure value to Hearth's full index size.
+    inner: Box<HearthSymbolIndex>,
+    files: Vec<ProjectedFile>,
+    file_by_path: FxHashMap<String, usize>,
+    /// Hearth symbol address -> (projected file, projected symbol).
     ///
-    /// Counts the ordering *work*, not a number recorded next to it: a probe
-    /// that reports the post-truncate candidate count reads the same value
-    /// whether the top-N partition or an ordinary full sort produced it, so it
-    /// cannot tell the two apart. Comparison counts can.
-    #[cfg(test)]
-    search_comparisons: AtomicUsize,
-    /// Last search, kept so the render loop can redraw the overlay without
-    /// rescoring the repository: the overlay re-queries on every frame and the
-    /// query only changes on a keystroke.
-    last_search: Mutex<Option<CachedSearch>>,
+    /// Hearth refs point into stable per-file vectors. One fast integer lookup
+    /// avoids hashing both path strings and name offsets for every one of the
+    /// 200 rows rebuilt by a cached search on each render frame.
+    symbol_projection: FxHashMap<usize, (usize, usize)>,
+}
+
+impl Default for SymbolIndex {
+    fn default() -> Self {
+        Self::from_hearth(HearthSymbolIndex::new())
+    }
 }
 
 impl SymbolIndex {
-    /// Build an index from already-extracted per-file symbols.
+    /// Build an index from already-extracted octorus symbols.
     pub fn from_files(files: Vec<FileSymbols>) -> Self {
-        let mut by_name: HashMap<String, SmallVec<[(u32, u32); 2]>> = HashMap::new();
-        let mut lowered_names = Vec::with_capacity(files.len());
-        let scanned_files = files.len();
-
-        for (file_index, file) in files.iter().enumerate() {
-            let mut file_lowered_names = Vec::with_capacity(file.symbols.len());
-            for (symbol_index, symbol) in file.symbols.iter().enumerate() {
-                let lowered = symbol.name.to_lowercase();
-                let cached_lowered =
-                    (lowered != symbol.name).then(|| lowered.clone().into_boxed_str());
-                by_name
-                    .entry(lowered)
-                    .or_default()
-                    .push((file_index as u32, symbol_index as u32));
-                file_lowered_names.push(cached_lowered);
-            }
-            lowered_names.push(file_lowered_names);
-        }
-
-        Self {
+        let files = files
+            .into_iter()
+            .enumerate()
+            .map(|(position, file)| file_to_hearth(file, position))
+            .collect();
+        Self::from_hearth(HearthSymbolIndex::from_files(
             files,
-            lowered_names,
-            by_name,
-            scanned_files,
-            ..Self::default()
-        }
+            symbol_language_registry().generation(),
+        ))
     }
 
-    /// Build an index by reading and parsing every given repository-relative path.
+    /// Build an index by reading and parsing repository-relative paths.
     ///
-    /// Blocking and CPU-bound — call it from `spawn_blocking`, never from the
-    /// render loop. Unreadable, oversized and unsupported individual files are
-    /// skipped silently; a repository is allowed to contain files octorus
-    /// cannot parse.
+    /// Blocking and CPU-bound — call from `spawn_blocking`.
     pub fn build_cancellable(
         repo_root: &Path,
         paths: &[String],
         cancel: &dyn CancelSignal,
     ) -> IndexBuild {
-        let root_metadata = match std::fs::metadata(repo_root) {
-            Ok(metadata) => metadata,
-            Err(error) => {
-                return IndexBuild::Failed {
-                    message: format!(
-                        "cannot build symbol index: repository root '{}' is unavailable: {error}",
-                        repo_root.display()
-                    ),
-                };
-            }
+        let loader = FsLoader::new(repo_root);
+        let cancellation = || cancel.is_cancelled();
+        let options = BuildOptions {
+            max_file_bytes: MAX_INDEXED_FILE_BYTES,
+            max_workers: 8,
         };
-        if !root_metadata.is_dir() {
-            return IndexBuild::Failed {
-                message: format!(
-                    "cannot build symbol index: repository root '{}' is not a directory",
-                    repo_root.display()
-                ),
-            };
-        }
 
-        if cancel.is_cancelled() {
-            return IndexBuild::Cancelled { scanned_files: 0 };
-        }
-
-        let mut indexable = Vec::new();
-        for (position, path) in paths.iter().enumerate() {
-            if position != 0
-                && position % PREFILTER_CANCEL_POLL_INTERVAL == 0
-                && cancel.is_cancelled()
-            {
-                return IndexBuild::Cancelled { scanned_files: 0 };
+        match hearth_graph::build_index(
+            symbol_language_registry(),
+            &loader,
+            paths,
+            &cancellation,
+            &options,
+        ) {
+            HearthIndexBuild::Completed(index) => IndexBuild::Completed(Self::from_hearth(index)),
+            HearthIndexBuild::Cancelled { scanned_files } => {
+                IndexBuild::Cancelled { scanned_files }
             }
-            if !supports_symbols(path) {
-                continue;
-            }
-            let indexable_file = std::fs::metadata(repo_root.join(path.as_str()))
-                .map(|meta| meta.is_file() && meta.len() <= MAX_INDEXED_FILE_BYTES)
-                .unwrap_or(false);
-            if indexable_file {
-                indexable.push(path);
-            }
+            HearthIndexBuild::Failed { message } => IndexBuild::Failed { message },
         }
-
-        let workers = std::thread::available_parallelism()
-            .map(|n| n.get())
-            .unwrap_or(1)
-            .clamp(1, 8)
-            .min(indexable.len().max(1));
-
-        let chunk_size = indexable.len().div_ceil(workers).max(1);
-        let outcomes: Vec<std::thread::Result<ChunkOutcome>> = std::thread::scope(|scope| {
-            let handles: Vec<_> = indexable
-                .chunks(chunk_size)
-                .map(|chunk| scope.spawn(move || index_chunk(repo_root, chunk, cancel)))
-                .collect();
-
-            handles.into_iter().map(|handle| handle.join()).collect()
-        });
-
-        let mut files = Vec::new();
-        let mut scanned_files = 0;
-        let mut stopped_early = false;
-        for outcome in outcomes {
-            let outcome = match outcome {
-                Ok(outcome) => outcome,
-                Err(_) => {
-                    return IndexBuild::Failed {
-                        message: format!(
-                            "symbol indexing worker panicked for repository '{}'; retry the build",
-                            repo_root.display()
-                        ),
-                    };
-                }
-            };
-            files.extend(outcome.files);
-            scanned_files += outcome.scanned;
-            stopped_early |= outcome.stopped_early;
-        }
-
-        if stopped_early {
-            return IndexBuild::Cancelled { scanned_files };
-        }
-
-        // Chunks finish out of order; a stable path order keeps search results
-        // and snapshots deterministic.
-        files.sort_by(|a, b| a.path.cmp(&b.path));
-        let mut index = Self::from_files(files);
-        index.scanned_files = scanned_files;
-        IndexBuild::Completed(index)
     }
 
-    /// Test-only probe for distinguishing files with symbols from scanned files.
+    fn from_hearth(inner: HearthSymbolIndex) -> Self {
+        let mut files = Vec::with_capacity(inner.file_count());
+        let mut file_by_path = FxHashMap::default();
+        file_by_path.reserve(inner.file_count());
+        let mut symbol_projection = FxHashMap::default();
+        symbol_projection.reserve(inner.symbol_count());
+
+        for path in inner.paths() {
+            let hearth_symbols = inner
+                .file_symbols(path)
+                .expect("hearth-graph path iterator returned a missing file");
+            let file_position = files.len();
+            let mut symbols = Vec::with_capacity(hearth_symbols.len());
+
+            for (symbol_position, symbol) in hearth_symbols.iter().enumerate() {
+                let key = std::ptr::from_ref(symbol) as usize;
+                let previous = symbol_projection.insert(key, (file_position, symbol_position));
+                assert!(
+                    previous.is_none(),
+                    "hearth-graph returned aliased symbol storage for {path}"
+                );
+                symbols.push(symbol_from_hearth(symbol));
+            }
+
+            let path = path.to_owned();
+            let previous = file_by_path.insert(path.clone(), file_position);
+            assert!(
+                previous.is_none(),
+                "hearth-graph returned duplicate indexed path {path}"
+            );
+            files.push(ProjectedFile {
+                file: FileSymbols { path, symbols },
+            });
+        }
+
+        Self {
+            inner: Box::new(inner),
+            files,
+            file_by_path,
+            symbol_projection,
+        }
+    }
+
+    /// Total number of indexed symbols.
+    pub fn symbol_count(&self) -> usize {
+        self.inner.symbol_count()
+    }
+
+    /// Number of successfully indexed files, including files with no symbols.
     #[cfg(test)]
     pub fn file_count(&self) -> usize {
         self.files.len()
     }
 
-    /// Test-only probe for build and cancellation accounting assertions.
+    /// Number of indexable inputs whose load was attempted.
     #[cfg(test)]
     pub fn scanned_file_count(&self) -> usize {
-        self.scanned_files
+        self.inner.scanned_file_count()
     }
 
-    /// Total number of indexed symbols.
-    pub fn symbol_count(&self) -> usize {
-        self.files.iter().map(|file| file.symbols.len()).sum()
-    }
-
-    /// Test-only probe for empty-index behavior; production reads `symbol_count`.
+    /// Test-only empty-state probe.
     #[cfg(test)]
     pub fn is_empty(&self) -> bool {
         self.symbol_count() == 0
     }
 
-    /// Test-only cost probe: comparator invocations made by the last [`Self::search`].
-    #[cfg(test)]
-    pub fn search_comparisons(&self) -> usize {
-        self.search_comparisons.load(Ordering::Relaxed)
-    }
-
-    /// Symbols of a single indexed file, if it was indexed.
+    /// Symbols of a single indexed file, including `Some(&[])` for an empty file.
     pub fn file_symbols(&self, path: &str) -> Option<&[Symbol]> {
-        self.files
-            .iter()
-            .find(|file| file.path == path)
-            .map(|file| file.symbols.as_slice())
+        let position = *self.file_by_path.get(path)?;
+        Some(self.files[position].file.symbols.as_slice())
     }
 
     /// All definitions with exactly this name, case-insensitively.
-    ///
-    /// Ordered so the best jump target comes first: callable definitions before
-    /// containers before fields, shallower before deeper, then by path and line
-    /// so the result never depends on filesystem iteration order.
     pub fn definitions(&self, name: &str) -> Vec<SymbolRef<'_>> {
-        let Some(hits) = self.by_name.get(&name.to_lowercase()) else {
-            return Vec::new();
-        };
-
-        let mut refs: Vec<SymbolRef<'_>> = hits
-            .iter()
-            .filter_map(|(file_index, symbol_index)| self.symbol_ref(*file_index, *symbol_index))
-            .collect();
-
-        refs.sort_by(|a, b| {
-            jump_priority(a.symbol.kind)
-                .cmp(&jump_priority(b.symbol.kind))
-                .then(a.symbol.depth.cmp(&b.symbol.depth))
-                .then(a.path.cmp(b.path))
-                .then(a.symbol.line.cmp(&b.symbol.line))
-        });
-        refs
+        self.inner
+            .definitions(name)
+            .into_iter()
+            .map(|hit| self.project_ref(hit))
+            .collect()
     }
 
     /// Fuzzy-search symbol names, best match first, capped at `limit`.
-    ///
-    /// An empty query returns nothing rather than the whole repository — an
-    /// unfiltered dump of 50,000 symbols is never what the caller wanted.
     pub fn search(&self, query: &str, limit: usize) -> Vec<SymbolRef<'_>> {
-        let query = query.trim();
-        if query.is_empty() || limit == 0 {
-            return Vec::new();
-        }
-        let needle = LoweredNeedle::new(query);
-        #[cfg(test)]
-        self.search_comparisons.store(0, Ordering::Relaxed);
-
-        let mut last_search = self
-            .last_search
-            .lock()
-            .unwrap_or_else(|error| error.into_inner());
-        if let Some(cached) = last_search
-            .as_ref()
-            .filter(|cached| cached.needle == needle && cached.limit == limit)
-        {
-            return cached
-                .hits
-                .iter()
-                .filter_map(|(file_index, symbol_index)| {
-                    self.symbol_ref(*file_index, *symbol_index)
-                })
-                .collect();
-        }
-
-        // Three 20-pass release runs (limit 200), mean query-set totals:
-        // repo/3,625 symbols — HEAP 1,621.702 us, SORT 1,579.293 us,
-        // SELECT 1,450.499 us; target/100,000 — HEAP 21,848.295 us,
-        // SORT 33,706.390 us, SELECT 21,746.457 us. SELECT wins at target
-        // scale and is faster here, so partition the matches before sorting.
-        // Do not reserve from the caller-controlled `limit`: the vector grows
-        // only for actual matches, keeping `usize::MAX` safe.
-        let mut candidates = Vec::new();
-        for (file_index, (file, lowered_names)) in
-            self.files.iter().zip(&self.lowered_names).enumerate()
-        {
-            for (symbol_index, (symbol, lowered_name)) in
-                file.symbols.iter().zip(lowered_names).enumerate()
-            {
-                let lowered_name = lowered_name.as_deref().unwrap_or(&symbol.name);
-                if let Some(score) = fuzzy_score_lowered(lowered_name, &needle) {
-                    candidates.push(SearchCandidate {
-                        score,
-                        name_len: symbol.name.len(),
-                        path: &file.path,
-                        line: symbol.line,
-                        file_index: file_index as u32,
-                        symbol_index: symbol_index as u32,
-                    });
-                }
-            }
-        }
-        #[cfg(test)]
-        let compare = |a: &SearchCandidate, b: &SearchCandidate| {
-            self.search_comparisons.fetch_add(1, Ordering::Relaxed);
-            compare_search_candidates(a, b)
-        };
-        #[cfg(not(test))]
-        let compare = compare_search_candidates;
-
-        if candidates.len() > limit {
-            candidates.select_nth_unstable_by(limit, &compare);
-            candidates.truncate(limit);
-        }
-        // The partition discarded every candidate outside the top N, so this
-        // full ordering never handles more than `limit` entries.
-        candidates.sort_by(&compare);
-
-        let hits: Vec<_> = candidates
+        self.inner
+            .search(query, limit)
             .into_iter()
-            .map(|candidate| (candidate.file_index, candidate.symbol_index))
-            .collect();
-        let result = hits
-            .iter()
-            .filter_map(|(file_index, symbol_index)| self.symbol_ref(*file_index, *symbol_index))
-            .collect();
-        *last_search = Some(CachedSearch {
-            needle,
-            limit,
-            hits,
-        });
-        result
+            .map(|hit| self.project_ref(hit))
+            .collect()
     }
 
-    fn symbol_ref(&self, file_index: u32, symbol_index: u32) -> Option<SymbolRef<'_>> {
-        let file = self.files.get(file_index as usize)?;
-        let symbol = file.symbols.get(symbol_index as usize)?;
-        Some(SymbolRef {
-            path: &file.path,
-            symbol,
-        })
-    }
-}
-
-/// Result of walking one worker chunk.
-struct ChunkOutcome {
-    files: Vec<FileSymbols>,
-    scanned: usize,
-    stopped_early: bool,
-}
-
-/// Index one chunk of paths with a single reusable parser pool.
-fn index_chunk(repo_root: &Path, paths: &[&String], cancel: &dyn CancelSignal) -> ChunkOutcome {
-    let mut pool = ParserPool::new();
-    let mut outcome = ChunkOutcome {
-        files: Vec::new(),
-        scanned: 0,
-        stopped_early: false,
-    };
-
-    for path in paths {
-        if cancel.is_cancelled() {
-            outcome.stopped_early = true;
-            return outcome;
-        }
-        #[cfg(test)]
-        assert_ne!(
-            path.as_str(),
-            WORKER_PANIC_PROBE_PATH,
-            "test-only symbol indexing worker panic probe"
+    fn project_ref(&self, hit: HearthSymbolRef<'_>) -> SymbolRef<'_> {
+        let key = std::ptr::from_ref(hit.symbol) as usize;
+        let &(file_position, symbol_position) = self
+            .symbol_projection
+            .get(&key)
+            .expect("Hearth search returned an unprojected symbol");
+        let projected = &self.files[file_position];
+        let symbol = &projected.file.symbols[symbol_position];
+        debug_assert_eq!(symbol.name, hit.symbol.name.as_str());
+        debug_assert_eq!(
+            symbol.line,
+            usize::try_from(hit.symbol.line)
+                .expect("hearth-graph symbol line does not fit octorus usize")
         );
-        outcome.scanned += 1;
-        let Ok(source) = std::fs::read_to_string(repo_root.join(path.as_str())) else {
-            continue;
-        };
-        let symbols = extract_symbols(&source, path, &mut pool);
-        if symbols.is_empty() {
-            continue;
-        }
-        outcome.files.push(FileSymbols {
-            path: (*path).clone(),
-            symbols,
-        });
-    }
 
-    outcome
-}
-
-/// Ordering hint for "which definition did the user most likely mean".
-fn jump_priority(kind: SymbolKind) -> u8 {
-    match kind {
-        SymbolKind::Class | SymbolKind::Interface | SymbolKind::Type => 0,
-        SymbolKind::Function | SymbolKind::Method | SymbolKind::Macro => 1,
-        SymbolKind::Constant | SymbolKind::Module => 2,
-        SymbolKind::Field | SymbolKind::Property | SymbolKind::Heading => 3,
-    }
-}
-
-/// Score a lower-cased name against a lower-cased search needle.
-///
-/// `lowered_name` must already be lower-cased; `LoweredNeedle` guarantees the
-/// same precondition for `needle`.
-fn fuzzy_score_lowered(lowered_name: &str, needle: &LoweredNeedle) -> Option<i64> {
-    let needle = needle.as_str();
-    if needle.is_empty() {
-        return None;
-    }
-    let length_penalty = lowered_name.chars().count() as i64;
-
-    if lowered_name == needle {
-        return Some(10_000 - length_penalty);
-    }
-    if lowered_name.starts_with(needle) {
-        return Some(8_000 - length_penalty);
-    }
-    if let Some(position) = lowered_name.find(needle) {
-        let boundary = lowered_name[..position]
-            .chars()
-            .next_back()
-            .is_some_and(|c| c == '_' || c == '-' || c == '.' || c == ':');
-        let base = if boundary { 6_000 } else { 4_000 };
-        return Some(base - position as i64 - length_penalty);
-    }
-
-    subsequence_score(lowered_name, needle).map(|score| score - length_penalty)
-}
-
-/// Score a scattered-subsequence match (`fdc` matching `find_diff_cache`).
-///
-/// Returns `None` unless every needle character appears in order.
-fn subsequence_score(haystack: &str, needle: &str) -> Option<i64> {
-    let mut haystack_chars = haystack.chars().enumerate().peekable();
-    let mut gaps: i64 = 0;
-    let mut previous: Option<usize> = None;
-
-    for wanted in needle.chars() {
-        loop {
-            let (position, actual) = haystack_chars.next()?;
-            if actual == wanted {
-                if let Some(previous) = previous {
-                    gaps += (position - previous - 1) as i64;
-                }
-                previous = Some(position);
-                break;
-            }
+        SymbolRef {
+            path: &projected.file.path,
+            symbol,
         }
     }
-
-    Some(2_000 - gaps.min(1_000))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
     use tokio_util::sync::CancellationToken;
 
-    /// Fires once it has been polled `limit` times — makes "how much work did a
-    /// cancelled build do" an exact, race-free assertion.
     struct PollCountCancel {
         limit: usize,
         polls: AtomicUsize,
@@ -895,7 +441,7 @@ mod tests {
         let mut pool = ParserPool::new();
         extract_symbols(source, filename, &mut pool)
             .into_iter()
-            .map(|s| (s.name, s.kind, s.line, s.depth))
+            .map(|symbol| (symbol.name, symbol.kind, symbol.line, symbol.depth))
             .collect()
     }
 
@@ -903,43 +449,24 @@ mod tests {
         let mut pool = ParserPool::new();
         extract_symbols(source, filename, &mut pool)
             .into_iter()
-            .map(|s| s.name)
+            .map(|symbol| symbol.name)
             .collect()
     }
 
-    // ===== every language advertising a tags query must compile it =====
-
     #[test]
-    fn test_all_tags_queries_compile() {
-        let mut pool = ParserPool::new();
-        for lang in SupportedLanguage::all() {
-            if lang.tags_query().is_none() {
-                continue;
-            }
+    fn test_all_registered_tags_queries_compile() {
+        let registry = symbol_language_registry();
+        let mut pool = hearth_graph::ParserPool::new(registry);
+
+        for (id, spec) in registry.iter() {
+            assert!(spec.tags_query.is_some(), "{} has no tags query", spec.name);
             assert!(
-                pool.get_or_create_tags_query(lang).is_some(),
-                "tags query for {lang:?} failed to compile"
+                pool.tags_query(id).is_some(),
+                "tags query for {} failed to compile",
+                spec.name
             );
         }
     }
-
-    #[test]
-    fn test_languages_without_tags_query_are_intentional() {
-        let unsupported: Vec<_> = SupportedLanguage::all()
-            .filter(|lang| lang.tags_query().is_none())
-            .collect();
-        assert_eq!(
-            unsupported,
-            vec![
-                SupportedLanguage::Svelte,
-                SupportedLanguage::Vue,
-                SupportedLanguage::Css,
-                SupportedLanguage::MarkdownInline,
-            ]
-        );
-    }
-
-    // ===== per-language extraction =====
 
     #[test]
     fn test_extract_rust_outline() {
@@ -991,7 +518,7 @@ export function setup() {}
 ";
         assert_eq!(
             names(source, "src/widget.ts"),
-            vec!["Props", "Widget", "render", "setup"]
+            ["Props", "Widget", "render", "setup"]
         );
     }
 
@@ -1040,65 +567,56 @@ func (c *Config) Load() {}
 
 func main() {}
 ";
-        assert_eq!(
-            names(source, "main.go"),
-            vec!["Config", "Load", "main"],
-            "go tags should yield the type, its method and the free function"
-        );
+        assert_eq!(names(source, "main.go"), ["Config", "Load", "main"]);
     }
 
     #[test]
-    fn test_extract_c_sharp_uses_bundled_query() {
+    fn test_extract_c_sharp_preserves_overloads() {
         let source = "\
-namespace Demo {
-  public class Service {
-    public void Run() {}
-    public int Count { get; set; }
-  }
-  interface IThing {}
+class Service {
+    void Run(int x) {}
+    void Run(string x) {}
 }
 ";
+        let symbols = outline(source, "Service.cs");
+        let runs: Vec<_> = symbols
+            .iter()
+            .filter(|(name, ..)| name == "Run")
+            .cloned()
+            .collect();
         assert_eq!(
-            names(source, "Service.cs"),
-            vec!["Demo", "Service", "Run", "Count", "IThing"]
+            runs,
+            [
+                ("Run".to_owned(), SymbolKind::Method, 2, 1),
+                ("Run".to_owned(), SymbolKind::Method, 3, 1),
+            ]
         );
     }
 
     #[test]
     fn test_extract_zig_uses_bundled_query() {
-        let source = "\
-const Point = struct { x: i32 };
-pub fn add(a: i32, b: i32) i32 { return a + b; }
-";
+        let source =
+            "const Point = struct { x: i32 };\npub fn add(a: i32, b: i32) i32 { return a + b; }\n";
         let names = names(source, "point.zig");
-        assert!(names.contains(&"Point".to_string()), "got {names:?}");
-        assert!(names.contains(&"add".to_string()), "got {names:?}");
+        assert!(names.contains(&"Point".to_owned()), "{names:?}");
+        assert!(names.contains(&"add".to_owned()), "{names:?}");
     }
 
     #[test]
     fn test_extract_bash_skips_function_local_assignments() {
-        let source = "\
-TOP_LEVEL=1
+        let source = "TOP_LEVEL=1\n\ndeploy() {\n  local_var=2\n  echo hi\n}\n";
+        assert_eq!(names(source, "deploy.sh"), ["TOP_LEVEL", "deploy"]);
+    }
 
-deploy() {
-  local_var=2
-  echo hi
-}
-";
-        assert_eq!(names(source, "deploy.sh"), vec!["TOP_LEVEL", "deploy"]);
+    #[test]
+    fn test_extract_haskell_merges_adjacent_equations() {
+        let source = "describe 0 = \"zero\"\ndescribe value = show value\n";
+        assert_eq!(names(source, "Fixture.hs"), ["describe"]);
     }
 
     #[test]
     fn test_extract_markdown_headings() {
-        let source = "\
-# Title
-
-intro
-
-## Usage
-
-### Options
-";
+        let source = "# Title\n\nintro\n\n## Usage\n\n### Options\n";
         insta::assert_debug_snapshot!(outline(source, "README.md"), @r#"
         [
             (
@@ -1123,56 +641,43 @@ intro
         "#);
     }
 
-    // ===== edge cases as use cases =====
-
     #[test]
-    fn test_empty_source_yields_no_symbols() {
-        assert!(names("", "src/lib.rs").is_empty());
+    fn test_moonbit_is_injected_through_the_host_registry() {
+        let moonbit = symbol_language_registry()
+            .for_path(Path::new("src/main.mbt"))
+            .and_then(|id| symbol_language_registry().get(id))
+            .expect("MoonBit host registration");
+        assert_eq!(moonbit.name, "moonbit");
+        assert!(moonbit.tags_query.is_some());
+        assert_eq!(
+            names("fn main {\n  println(\"hi\")\n}\n", "src/main.mbt"),
+            ["main"]
+        );
     }
 
     #[test]
-    fn test_unsupported_extension_yields_no_symbols() {
+    fn test_empty_and_unsupported_sources_yield_no_symbols() {
+        assert!(names("", "src/lib.rs").is_empty());
         assert!(names("fn main() {}", "notes.txt").is_empty());
         assert!(names("body { color: red }", "site.css").is_empty());
-    }
-
-    #[test]
-    fn test_file_without_extension_yields_no_symbols() {
         assert!(names("fn main() {}", "Makefile").is_empty());
     }
 
     #[test]
     fn test_syntax_errors_still_yield_recovered_symbols() {
-        // tree-sitter error recovery keeps the well-formed prefix usable.
-        let source = "fn ok() {}\nfn broken( {\n";
-        let names = names(source, "src/broken.rs");
-        assert!(names.contains(&"ok".to_string()), "got {names:?}");
+        let names = names("fn ok() {}\nfn broken( {\n", "src/broken.rs");
+        assert!(names.contains(&"ok".to_owned()), "{names:?}");
     }
 
     #[test]
-    fn test_cjk_identifier_is_extracted_with_location() {
-        let source = "// 日本語のコメント\nfn 名前() {}\n";
-        let mut pool = ParserPool::new();
-        let symbols = extract_symbols(source, "src/cjk.rs", &mut pool);
-        assert_eq!(symbols.len(), 1);
-        assert_eq!(symbols[0].name, "名前");
-        assert_eq!(symbols[0].line, 2);
-        // "fn " is three characters — a byte column would report 3 as well, so
-        // assert the far more interesting case below.
-        assert_eq!(symbols[0].column, 3);
-    }
-
-    #[test]
-    fn test_column_after_multibyte_prefix_is_in_characters() {
+    fn test_cjk_locations_use_character_columns() {
         let source = "class 構造体 { メソッド() {} }\n";
         let mut pool = ParserPool::new();
         let symbols = extract_symbols(source, "src/cjk.ts", &mut pool);
         let method = symbols
             .iter()
-            .find(|s| s.name == "メソッド")
+            .find(|symbol| symbol.name == "メソッド")
             .expect("method symbol");
-        // A byte column would report 18 here; characters are what the diff
-        // renderer and the jump stack both count in.
         assert_eq!(method.column, "class 構造体 { ".chars().count());
         assert_eq!(method.column, 12);
         assert_eq!("class 構造体 { ".len(), 18);
@@ -1180,56 +685,45 @@ intro
 
     #[test]
     fn test_supports_symbols() {
-        assert!(supports_symbols("src/main.rs"));
-        assert!(supports_symbols("README.md"));
+        for path in [
+            "src/main.rs",
+            "README.md",
+            "src/module.mjs",
+            "src/module.cjs",
+            "src/module.mts",
+            "src/module.cts",
+            "src/main.mbt",
+        ] {
+            assert!(supports_symbols(path), "{path}");
+        }
         assert!(!supports_symbols("style.css"));
         assert!(!supports_symbols("data.json"));
     }
 
-    // ===== index =====
-
-    fn sample_index() -> SymbolIndex {
-        SymbolIndex::from_files(vec![
-            FileSymbols {
-                path: "src/app.rs".to_string(),
-                symbols: vec![
-                    Symbol {
-                        name: "App".to_string(),
-                        kind: SymbolKind::Class,
-                        line: 10,
-                        column: 0,
-                        depth: 0,
-                    },
-                    Symbol {
-                        name: "render_app".to_string(),
-                        kind: SymbolKind::Function,
-                        line: 20,
-                        column: 0,
-                        depth: 0,
-                    },
-                ],
-            },
-            FileSymbols {
-                path: "src/ui.rs".to_string(),
-                symbols: vec![Symbol {
-                    name: "app".to_string(),
-                    kind: SymbolKind::Constant,
-                    line: 5,
-                    column: 0,
-                    depth: 0,
-                }],
-            },
-        ])
-    }
-
     fn test_symbol(name: &str, kind: SymbolKind, line: usize, column: usize) -> Symbol {
         Symbol {
-            name: name.to_string(),
+            name: name.to_owned(),
             kind,
             line,
             column,
             depth: 0,
         }
+    }
+
+    fn sample_index() -> SymbolIndex {
+        SymbolIndex::from_files(vec![
+            FileSymbols {
+                path: "src/app.rs".to_owned(),
+                symbols: vec![
+                    test_symbol("App", SymbolKind::Class, 10, 0),
+                    test_symbol("render_app", SymbolKind::Function, 20, 0),
+                ],
+            },
+            FileSymbols {
+                path: "src/ui.rs".to_owned(),
+                symbols: vec![test_symbol("app", SymbolKind::Constant, 5, 0)],
+            },
+        ])
     }
 
     fn completed_index(build: IndexBuild) -> SymbolIndex {
@@ -1242,57 +736,17 @@ intro
         }
     }
 
-    fn full_sort_search_reference<'a>(
-        index: &'a SymbolIndex,
-        query: &str,
-        limit: usize,
-    ) -> Vec<SymbolRef<'a>> {
-        let query = query.trim();
-        if query.is_empty() || limit == 0 {
-            return Vec::new();
-        }
-        let needle = LoweredNeedle::new(query);
-        let mut scored = Vec::new();
-
-        for file in &index.files {
-            for symbol in &file.symbols {
-                if let Some(score) = fuzzy_score_lowered(&symbol.name.to_lowercase(), &needle) {
-                    scored.push((
-                        score,
-                        SymbolRef {
-                            path: &file.path,
-                            symbol,
-                        },
-                    ));
-                }
-            }
-        }
-
-        scored.sort_by(|a, b| {
-            b.0.cmp(&a.0)
-                .then(a.1.symbol.name.len().cmp(&b.1.symbol.name.len()))
-                .then(a.1.path.cmp(b.1.path))
-                .then(a.1.symbol.line.cmp(&b.1.symbol.line))
-        });
-        scored.truncate(limit);
-        scored.into_iter().map(|(_, symbol)| symbol).collect()
-    }
-
     #[test]
-    fn test_index_counts() {
+    fn test_index_counts_and_empty_state() {
         let index = sample_index();
         assert_eq!(index.file_count(), 2);
         assert_eq!(index.symbol_count(), 3);
         assert!(!index.is_empty());
-    }
 
-    #[test]
-    fn test_empty_index_is_empty() {
-        let index = SymbolIndex::default();
-        assert!(index.is_empty());
-        assert_eq!(index.symbol_count(), 0);
-        assert!(index.definitions("anything").is_empty());
-        assert!(index.search("anything", 10).is_empty());
+        let empty = SymbolIndex::default();
+        assert!(empty.is_empty());
+        assert!(empty.definitions("anything").is_empty());
+        assert!(empty.search("anything", 10).is_empty());
     }
 
     #[test]
@@ -1303,10 +757,9 @@ intro
             .iter()
             .map(|hit| (hit.path, hit.symbol.name.as_str(), hit.symbol.kind))
             .collect();
-        // The class outranks the constant regardless of insertion order.
         assert_eq!(
             rendered,
-            vec![
+            [
                 ("src/app.rs", "App", SymbolKind::Class),
                 ("src/ui.rs", "app", SymbolKind::Constant),
             ]
@@ -1314,268 +767,142 @@ intro
     }
 
     #[test]
-    fn test_definitions_unknown_name() {
-        assert!(sample_index().definitions("nope").is_empty());
-    }
-
-    #[test]
     fn test_file_symbols_lookup() {
         let index = sample_index();
-        assert_eq!(index.file_symbols("src/ui.rs").map(|s| s.len()), Some(1));
+        assert_eq!(
+            index.file_symbols("src/ui.rs").map(<[Symbol]>::len),
+            Some(1)
+        );
         assert!(index.file_symbols("src/missing.rs").is_none());
     }
 
     #[test]
-    fn test_search_prefers_exact_over_boundary_match() {
+    fn test_projection_preserves_symbols_with_identical_public_fields() {
+        let symbol = test_symbol("overload", SymbolKind::Method, 7, 4);
+        let index = SymbolIndex::from_files(vec![FileSymbols {
+            path: "src/overloads.rs".to_owned(),
+            symbols: vec![symbol.clone(), symbol],
+        }]);
+
+        let hits = index.definitions("overload");
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].symbol, hits[1].symbol);
+        assert!(!std::ptr::eq(hits[0].symbol, hits[1].symbol));
+    }
+
+    #[test]
+    fn test_from_files_uses_last_duplicate_path_and_retains_empty_files() {
+        let index = SymbolIndex::from_files(vec![
+            FileSymbols {
+                path: "src/duplicate.rs".to_owned(),
+                symbols: vec![test_symbol("first", SymbolKind::Function, 1, 0)],
+            },
+            FileSymbols {
+                path: "src/duplicate.rs".to_owned(),
+                symbols: vec![test_symbol("last", SymbolKind::Function, 2, 0)],
+            },
+            FileSymbols {
+                path: "src/empty.rs".to_owned(),
+                symbols: Vec::new(),
+            },
+        ]);
+
+        assert_eq!(index.scanned_file_count(), 3);
+        assert_eq!(index.file_count(), 2);
+        assert!(index.definitions("first").is_empty());
+        assert_eq!(index.definitions("last")[0].path, "src/duplicate.rs");
+        assert_eq!(index.file_symbols("src/empty.rs"), Some([].as_slice()));
+    }
+
+    #[test]
+    #[should_panic(expected = "symbol line exceeds hearth-graph u32 range")]
+    fn test_from_files_rejects_lines_that_hearth_cannot_represent() {
+        SymbolIndex::from_files(vec![FileSymbols {
+            path: "src/overflow.rs".to_owned(),
+            symbols: vec![test_symbol(
+                "overflow",
+                SymbolKind::Function,
+                usize::try_from(u64::from(u32::MAX) + 1).expect("64-bit test host"),
+                0,
+            )],
+        }]);
+    }
+
+    #[test]
+    #[should_panic(expected = "symbol depth exceeds hearth-graph u16 range")]
+    fn test_from_files_rejects_depths_that_hearth_cannot_represent() {
+        let mut symbol = test_symbol("overflow", SymbolKind::Function, 1, 0);
+        symbol.depth = usize::from(u16::MAX) + 1;
+        SymbolIndex::from_files(vec![FileSymbols {
+            path: "src/overflow.rs".to_owned(),
+            symbols: vec![symbol],
+        }]);
+    }
+
+    #[test]
+    fn test_search_contracts_and_fuzzy_tiers() {
+        let index = SymbolIndex::from_files(vec![FileSymbols {
+            path: "src/search.rs".to_owned(),
+            symbols: vec![
+                test_symbol("parse", SymbolKind::Function, 1, 0),
+                test_symbol("parse_line", SymbolKind::Function, 2, 0),
+                test_symbol("do_parse", SymbolKind::Function, 3, 0),
+                test_symbol("reparsed", SymbolKind::Function, 4, 0),
+                test_symbol("please_advance_rest_of_set", SymbolKind::Function, 5, 0),
+            ],
+        }]);
+
+        let names: Vec<_> = index
+            .search("parse", usize::MAX)
+            .iter()
+            .map(|hit| hit.symbol.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            [
+                "parse",
+                "parse_line",
+                "do_parse",
+                "reparsed",
+                "please_advance_rest_of_set",
+            ]
+        );
+        assert_eq!(index.search("parse", 2).len(), 2);
+        assert!(index.search("", 10).is_empty());
+        assert!(index.search("parse", 0).is_empty());
+        assert!(index.search("xyz", 10).is_empty());
+    }
+
+    #[test]
+    fn test_search_subsequence_and_case_insensitivity() {
         let index = sample_index();
-        let hits = index.search("app", 10);
-        let names: Vec<_> = hits.iter().map(|hit| hit.symbol.name.as_str()).collect();
-        assert_eq!(names, vec!["App", "app", "render_app"]);
+        assert_eq!(index.search("rndap", 10)[0].symbol.name, "render_app");
+        assert_eq!(index.search("APP", 10), index.search("app", 10));
     }
 
     #[test]
-    fn test_search_respects_limit() {
-        assert_eq!(sample_index().search("app", 1).len(), 1);
-        assert!(sample_index().search("app", 0).is_empty());
-    }
-
-    #[test]
-    fn test_search_with_an_unbounded_limit_returns_every_match() {
-        let index = sample_index();
-        let expected = index.search("app", index.symbol_count());
-
-        assert_eq!(index.search("app", usize::MAX), expected);
-        assert_eq!(index.search("app", index.symbol_count() * 1_000), expected);
-    }
-
-    #[test]
-    fn test_search_empty_query_returns_nothing() {
-        assert!(sample_index().search("", 10).is_empty());
-        assert!(sample_index().search("   ", 10).is_empty());
-    }
-
-    #[test]
-    fn test_search_subsequence() {
-        let index = sample_index();
-        let hits = index.search("rndap", 10);
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].symbol.name, "render_app");
-    }
-
-    #[test]
-    fn test_search_reads_a_matching_cached_result() {
-        let index = sample_index();
-        *index.last_search.lock().unwrap() = Some(CachedSearch {
-            needle: LoweredNeedle::new("app"),
-            limit: 10,
-            hits: vec![(0, 1)],
-        });
-
-        let hits = index.search("app", 10);
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].symbol.name, "render_app");
-    }
-
-    /// Ties are broken all the way down to insertion order.
-    ///
-    /// The top-N partition is an *unstable* selection, so candidates the
-    /// comparator calls equal may be kept, dropped and ordered differently
-    /// between runs. Every user-visible key can genuinely tie — same score,
-    /// same name length, same file, same line describes overloads on one line
-    /// and macro-generated pairs — and only the index tie-breakers make the
-    /// result reproducible.
-    #[test]
-    fn test_candidates_equal_on_every_visible_key_still_have_one_order() {
+    fn test_candidates_equal_on_visible_keys_have_deterministic_order() {
         const TOTAL: usize = 300;
         const LIMIT: usize = 200;
-        // Equal-length names on one line in one file: score, name length, path
-        // and line are all identical across the set.
         let symbols = (0..TOTAL)
             .map(|index| test_symbol(&format!("tie_{index:04}"), SymbolKind::Function, 1, 0))
             .collect();
         let index = SymbolIndex::from_files(vec![FileSymbols {
-            path: "src/generated.rs".to_string(),
+            path: "src/generated.rs".to_owned(),
             symbols,
         }]);
 
-        let hits = index.search("tie", LIMIT);
-
-        assert_eq!(hits.len(), LIMIT);
-        let names: Vec<&str> = hits.iter().map(|hit| hit.symbol.name.as_str()).collect();
-        let expected: Vec<String> = (0..LIMIT).map(|index| format!("tie_{index:04}")).collect();
-        assert_eq!(
-            names, expected,
-            "candidates that tie on every visible key must still come back in \
-             index order; without it the unstable partition keeps a different \
-             subset each run"
-        );
-    }
-
-    /// A poisoned search cache is recovered from, not propagated.
-    ///
-    /// The scoring pass and the unstable partition both run while the cache
-    /// lock is held, so any panic there poisons it. Taking the lock with
-    /// `unwrap()` would then turn one panic into a panic on every subsequent
-    /// keystroke in the symbol-search overlay.
-    #[test]
-    fn test_a_poisoned_search_cache_does_not_break_every_later_search() {
-        let index = std::sync::Arc::new(sample_index());
-        assert!(!index.search("app", 10).is_empty());
-
-        let poisoner = std::sync::Arc::clone(&index);
-        let panicked = std::thread::spawn(move || {
-            let _guard = poisoner.last_search.lock().unwrap();
-            panic!("poison the search cache");
-        })
-        .join();
-        assert!(
-            panicked.is_err(),
-            "the fixture must actually poison the lock"
-        );
-
-        assert!(
-            !index.search("app", 10).is_empty(),
-            "one panic must not take every later symbol search with it"
-        );
-    }
-
-    #[test]
-    fn test_search_never_orders_more_than_the_limit() {
-        // Scrambled, not ascending. Candidates are collected in index order, so
-        // ascending lines would arrive already in final order and Rust's sort
-        // would finish in a single linear run — making a full sort *cheaper*
-        // than the partition and hiding the very substitution this test exists
-        // to catch. 7,919 is coprime with 5,000, so this is a permutation.
-        let symbols = (0..5_000)
-            .map(|index| {
-                test_symbol(
-                    &format!("matching_symbol_{index:04}"),
-                    SymbolKind::Function,
-                    (index * 7_919) % 5_000 + 1,
-                    0,
-                )
-            })
-            .collect();
-        let index = SymbolIndex::from_files(vec![FileSymbols {
-            path: "src/generated.rs".to_string(),
-            symbols,
-        }]);
-
-        assert_eq!(index.symbol_count(), 5_000);
-        assert_eq!(index.search("matching", usize::MAX).len(), 5_000);
-
-        let sorted = index.search("matching", 10);
-        assert_eq!(sorted.len(), 10);
-
-        // Ordering *work*, not a number recorded beside it: a probe reporting
-        // the post-truncate candidate count reads `limit` either way, so moving
-        // the truncate above it hides a full sort. Comparisons cannot be
-        // reordered around — top-N partitioning is linear in the match count
-        // while a full sort of 5,000 unordered candidates costs n log n.
-        let comparisons = index.search_comparisons();
-        assert!(
-            comparisons < 25_000,
-            "ordering 10 of 5,000 matches took {comparisons} comparisons; \
-             the top-N partition looks to have been replaced by a full sort"
-        );
-    }
-
-    #[test]
-    fn test_search_matches_a_full_sort_reference() {
-        let index = SymbolIndex::from_files(vec![
-            FileSymbols {
-                path: "src/z.rs".to_string(),
-                symbols: vec![
-                    test_symbol("sym", SymbolKind::Function, 50, 0),
-                    test_symbol("symé", SymbolKind::Function, 40, 0),
-                    test_symbol("syma", SymbolKind::Function, 40, 0),
-                    test_symbol("sym_a", SymbolKind::Function, 12, 0),
-                    test_symbol("sym_b", SymbolKind::Method, 12, 0),
-                    test_symbol("sym_a", SymbolKind::Constant, 12, 4),
-                    test_symbol("sym_long", SymbolKind::Function, 2, 0),
-                ],
-            },
-            FileSymbols {
-                path: "src/a.rs".to_string(),
-                symbols: vec![
-                    test_symbol("sym_c", SymbolKind::Function, 30, 0),
-                    test_symbol("sym_d", SymbolKind::Function, 10, 0),
-                    test_symbol("do_sym", SymbolKind::Function, 1, 0),
-                ],
-            },
-            FileSymbols {
-                path: "src/a.rs".to_string(),
-                symbols: vec![
-                    test_symbol("sym_e", SymbolKind::Method, 10, 2),
-                    test_symbol("asym", SymbolKind::Class, 5, 0),
-                ],
-            },
-        ]);
-
-        for limit in [1, 2, 5, 9, 20] {
-            let expected = full_sort_search_reference(&index, "sym", limit);
-            assert_eq!(index.search("sym", limit), expected, "limit {limit}");
-        }
-    }
-
-    #[test]
-    fn test_search_cache_is_keyed_by_needle_and_limit() {
-        let index = sample_index();
-        *index.last_search.lock().unwrap() = Some(CachedSearch {
-            needle: LoweredNeedle::new("app"),
-            limit: 1,
-            hits: vec![(0, 1)],
-        });
         let names: Vec<_> = index
-            .search("app", 10)
+            .search("tie", LIMIT)
             .iter()
             .map(|hit| hit.symbol.name.as_str())
             .collect();
-        assert_eq!(names, vec!["App", "app", "render_app"]);
-
-        *index.last_search.lock().unwrap() = Some(CachedSearch {
-            needle: LoweredNeedle::new("render"),
-            limit: 10,
-            hits: vec![(0, 1)],
-        });
-        let names: Vec<_> = index
-            .search("app", 10)
-            .iter()
-            .map(|hit| hit.symbol.name.as_str())
-            .collect();
-        assert_eq!(names, vec!["App", "app", "render_app"]);
+        let expected: Vec<_> = (0..LIMIT).map(|index| format!("tie_{index:04}")).collect();
+        assert_eq!(names, expected);
     }
 
     #[test]
-    fn test_search_writes_computed_results_to_cache() {
-        let index = sample_index();
-        let hits = index.search("app", 10);
-        let last_search = index.last_search.lock().unwrap();
-        let cached = last_search
-            .as_ref()
-            .expect("computed search was not cached");
-
-        assert_eq!(cached.needle.as_str(), "app");
-        assert_eq!(cached.limit, 10);
-        assert_eq!(cached.hits.len(), hits.len());
-    }
-
-    #[test]
-    fn test_search_scores_against_the_precomputed_lowered_names() {
-        let mut index = SymbolIndex::from_files(vec![FileSymbols {
-            path: "src/zebra.rs".to_string(),
-            symbols: vec![test_symbol("Zebra", SymbolKind::Function, 1, 0)],
-        }]);
-        index.lowered_names[0][0] = Some("apple".to_string().into_boxed_str());
-
-        let hits = index.search("apple", 10);
-        assert_eq!(hits.len(), 1);
-        assert_eq!(hits[0].symbol.name, "Zebra");
-        assert!(index.search("zebra", 10).is_empty());
-    }
-
-    #[test]
-    fn test_search_results_are_unchanged_by_precomputed_lowercasing() {
+    fn test_search_is_case_insensitive_for_unicode_names() {
         let names = ["MixedCase", "UPPERCASE", "名前", "İ", "ß", "Éclair"];
         let symbols = names
             .iter()
@@ -1583,53 +910,20 @@ intro
             .map(|(index, name)| test_symbol(name, SymbolKind::Function, index + 1, 0))
             .collect();
         let index = SymbolIndex::from_files(vec![FileSymbols {
-            path: "src/unicode.rs".to_string(),
-            symbols,
-        }]);
-
-        for query in ["case", "名前", "i", "ß", "é", "air", "xyz"] {
-            let expected = full_sort_search_reference(&index, query, names.len());
-            assert_eq!(
-                index.search(query, names.len()),
-                expected,
-                "query {query:?}"
-            );
-        }
-    }
-
-    #[test]
-    fn test_search_is_case_insensitive_for_queries() {
-        let names = ["MixedCase", "UPPERCASE", "名前", "İ", "ß", "Éclair"];
-        let symbols = names
-            .iter()
-            .enumerate()
-            .map(|(index, name)| test_symbol(name, SymbolKind::Function, index + 1, 0))
-            .collect();
-        let index = SymbolIndex::from_files(vec![FileSymbols {
-            path: "src/unicode.rs".to_string(),
+            path: "src/unicode.rs".to_owned(),
             symbols,
         }]);
 
         for query in ["MiXeDcAsE", "uPpErCaSe", "名前", "İ", "ß", "ÉcLaIr"] {
             let result = index.search(query, names.len());
-            let expected = full_sort_search_reference(&index, query, names.len());
-            assert_eq!(
-                result, expected,
-                "query {query:?} differs from the independent reference"
-            );
-            assert_eq!(
-                result,
-                index.search(&query.to_lowercase(), names.len()),
-                "query {query:?} differs from its lowercase form"
-            );
-            assert!(!result.is_empty(), "query {query:?} must match");
+            assert_eq!(result, index.search(&query.to_lowercase(), names.len()));
+            assert!(!result.is_empty(), "{query:?}");
         }
     }
 
     #[test]
     fn test_symbol_index_is_send_and_sync() {
         fn assert_send_and_sync<T: Send + Sync>() {}
-
         assert_send_and_sync::<SymbolIndex>();
     }
 
@@ -1646,13 +940,7 @@ intro
                 "src/parser/names.rs",
                 "m 名前  src/parser/names.rs:27",
             ),
-            (
-                test_symbol("Configuration", SymbolKind::Class, 91, 0),
-                "crates/core/src/config.rs",
-                "C Configuration  crates/core/src/config.rs:91",
-            ),
         ];
-
         for (symbol, path, expected) in &cases {
             assert_eq!(SymbolRef { path, symbol }.search_label(), *expected);
         }
@@ -1660,31 +948,15 @@ intro
 
     #[test]
     fn test_browse_symbol_search_results_match_symbol_ref_search_label() {
-        let mut nested = test_symbol("target_nested", SymbolKind::Method, 27, 4);
-        nested.depth = 2;
-        let index = std::sync::Arc::new(SymbolIndex::from_files(vec![
-            FileSymbols {
-                path: "src/search.rs".to_string(),
-                symbols: vec![
-                    test_symbol("target_function", SymbolKind::Function, 3, 0),
-                    nested,
-                ],
-            },
-            FileSymbols {
-                path: "src/検索/names.rs".to_string(),
-                symbols: vec![test_symbol("検索Target", SymbolKind::Class, 91, 0)],
-            },
-        ]));
+        let index = std::sync::Arc::new(sample_index());
         let mut state = crate::app::browse::BrowseState::new(
             std::path::PathBuf::from("/repo"),
             crate::app::AppState::FileList,
         );
         state.index = crate::app::browse::IndexState::Ready(std::sync::Arc::clone(&index));
 
-        let query = "target";
-        let expected = index.search(query, usize::MAX);
-        let actual = state.symbol_search_results(query);
-
+        let expected = index.search("app", usize::MAX);
+        let actual = state.symbol_search_results("app");
         assert_eq!(actual.len(), expected.len());
         for ((path, line, label), hit) in actual.iter().zip(expected) {
             assert_eq!(label, &hit.search_label());
@@ -1693,97 +965,10 @@ intro
         }
     }
 
-    // ===== fuzzy scoring =====
-
-    #[test]
-    fn test_fuzzy_score_tiers() {
-        let needle = LoweredNeedle::new("parse");
-        let exact = fuzzy_score_lowered("parse", &needle).unwrap();
-        let prefix = fuzzy_score_lowered("parse_line", &needle).unwrap();
-        let boundary = fuzzy_score_lowered("do_parse", &needle).unwrap();
-        let middle = fuzzy_score_lowered("reparsed", &needle).unwrap();
-        let scattered = fuzzy_score_lowered("please_advance_rest_of_set", &needle).unwrap();
-
-        assert!(exact > prefix, "{exact} > {prefix}");
-        assert!(prefix > boundary, "{prefix} > {boundary}");
-        assert!(boundary > middle, "{boundary} > {middle}");
-        assert!(middle > scattered, "{middle} > {scattered}");
-    }
-
-    #[test]
-    fn test_fuzzy_score_no_match() {
-        assert!(fuzzy_score_lowered("parse", &LoweredNeedle::new("xyz")).is_none());
-        assert!(fuzzy_score_lowered("parse", &LoweredNeedle::new("")).is_none());
-    }
-
-    #[test]
-    fn test_fuzzy_score_shorter_name_wins_within_tier() {
-        let needle = LoweredNeedle::new("parse");
-        let short = fuzzy_score_lowered("parse_a", &needle).unwrap();
-        let long = fuzzy_score_lowered("parse_a_very_long_name", &needle).unwrap();
-        assert!(short > long);
-    }
-
-    #[test]
-    fn test_fuzzy_score_is_case_insensitive() {
-        let mixed_case = fuzzy_score_lowered("parse", &LoweredNeedle::new("PaRsE"));
-        let lower_case = fuzzy_score_lowered("parse", &LoweredNeedle::new("parse"));
-
-        assert_eq!(mixed_case, lower_case);
-        assert!(mixed_case.is_some());
-    }
-
-    #[test]
-    fn test_fuzzy_score_is_case_insensitive_for_tricky_names() {
-        let names = [
-            "lowercase",
-            "UPPERCASE",
-            "MixedCase",
-            "identifier_123_name",
-            "名前",
-            "ǅ",
-            "İ",
-            "ß",
-            "Éclair",
-        ];
-        let needle_pairs = [
-            ("LoWeR", "lower"),
-            ("UpPeR", "upper"),
-            ("MiXeD", "mixed"),
-            ("Identifier_123", "identifier_123"),
-            ("ǅ", "ǆ"),
-            ("İ", "i\u{307}"),
-            ("ẞ", "ß"),
-            ("ÉcLaIr", "éclair"),
-            ("XyZ", "xyz"),
-        ];
-
-        for (mixed, lower) in needle_pairs {
-            assert_eq!(
-                mixed.to_lowercase(),
-                lower,
-                "invalid mixed/lower pair: {mixed:?}, {lower:?}"
-            );
-            let mixed_needle = LoweredNeedle::new(mixed);
-            let lower_needle = LoweredNeedle::new(lower);
-            for name in names {
-                let lowered_name = name.to_lowercase();
-                assert_eq!(
-                    fuzzy_score_lowered(&lowered_name, &mixed_needle),
-                    fuzzy_score_lowered(&lowered_name, &lower_needle),
-                    "name={name:?}, mixed={mixed:?}, lower={lower:?}"
-                );
-            }
-        }
-    }
-
-    // ===== index build over a real directory =====
-
     #[test]
     fn test_cancelled_build_stops_scanning_early() {
         let dir = tempfile::tempdir().unwrap();
-        let source_dir = dir.path().join("src");
-        std::fs::create_dir(&source_dir).unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
         let paths: Vec<_> = (0..1_000)
             .map(|index| {
                 let path = format!("src/file_{index:04}.rs");
@@ -1793,13 +978,12 @@ intro
             })
             .collect();
 
-        let completed =
-            SymbolIndex::build_cancellable(dir.path(), &paths, &CancellationToken::new());
-        let control_scanned = match completed {
-            IndexBuild::Completed(index) => index.scanned_file_count(),
-            other => panic!("control build did not complete: {other:?}"),
-        };
-        assert_eq!(control_scanned, 1_000);
+        let control = completed_index(SymbolIndex::build_cancellable(
+            dir.path(),
+            &paths,
+            &CancellationToken::new(),
+        ));
+        assert_eq!(control.scanned_file_count(), 1_000);
 
         let cancel = PollCountCancel {
             limit: 50,
@@ -1807,25 +991,16 @@ intro
         };
         match SymbolIndex::build_cancellable(dir.path(), &paths, &cancel) {
             IndexBuild::Cancelled { scanned_files } => {
-                assert!(scanned_files <= 64, "scanned {scanned_files} files");
-                assert!(scanned_files < control_scanned);
+                assert!(scanned_files <= 64, "{scanned_files}");
                 assert!(scanned_files < 1_000);
             }
-            IndexBuild::Completed(index) => panic!(
-                "cancelled build completed after scanning {} files",
-                index.scanned_file_count()
-            ),
-            IndexBuild::Failed { message } => {
-                panic!("cancelled build failed instead of stopping early: {message}")
-            }
+            other => panic!("cancelled build did not cancel: {other:?}"),
         }
     }
 
     #[test]
-    fn test_cancelled_build_stops_the_metadata_prefilter() {
+    fn test_cancelled_build_stops_metadata_prefilter() {
         let dir = tempfile::tempdir().unwrap();
-        // Deliberately non-indexable paths leave the pre-filter as the only
-        // work, so cancellation can only come from a poll inside that loop.
         let paths: Vec<_> = (0..5_000)
             .map(|index| format!("notes/file_{index:04}.txt"))
             .collect();
@@ -1836,12 +1011,7 @@ intro
 
         match SymbolIndex::build_cancellable(dir.path(), &paths, &cancel) {
             IndexBuild::Cancelled { scanned_files } => assert_eq!(scanned_files, 0),
-            IndexBuild::Completed(_) => {
-                panic!("metadata pre-filter ignored cancellation")
-            }
-            IndexBuild::Failed { message } => {
-                panic!("metadata pre-filter failed instead of cancelling: {message}")
-            }
+            other => panic!("metadata prefilter did not cancel: {other:?}"),
         }
     }
 
@@ -1852,61 +1022,61 @@ intro
         let cancel = CancellationToken::new();
         cancel.cancel();
 
-        match SymbolIndex::build_cancellable(dir.path(), &["file.rs".to_string()], &cancel) {
+        match SymbolIndex::build_cancellable(dir.path(), &["file.rs".to_owned()], &cancel) {
             IndexBuild::Cancelled { scanned_files } => assert_eq!(scanned_files, 0),
-            other => panic!("pre-cancelled build did not cancel: {other:?}"),
+            other => panic!("precancelled build did not cancel: {other:?}"),
         }
     }
 
     #[test]
-    fn test_precancelled_build_with_no_indexable_paths_is_cancelled() {
-        let dir = tempfile::tempdir().unwrap();
-        let cancel = CancellationToken::new();
-        cancel.cancel();
-        // Keep this below the pre-filter poll interval and non-indexable:
-        // otherwise a later pre-filter or worker poll would mask removal of the
-        // pre-build cancellation short-circuit.
-        let paths = ["notes.txt".to_string()];
-
-        match SymbolIndex::build_cancellable(dir.path(), &paths, &cancel) {
-            IndexBuild::Cancelled { scanned_files } => assert_eq!(scanned_files, 0),
-            other => panic!("pre-cancelled empty build did not cancel: {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_build_over_a_missing_root_fails() {
+    fn test_missing_or_non_directory_root_fails() {
         let dir = tempfile::tempdir().unwrap();
         let missing = dir.path().join("missing");
-
         match SymbolIndex::build_cancellable(&missing, &[], &CancellationToken::new()) {
             IndexBuild::Failed { message } => {
-                assert!(message.contains(&missing.to_string_lossy().into_owned()));
+                assert!(
+                    message.contains(&missing.display().to_string()),
+                    "{message}"
+                );
             }
             other => panic!("missing root did not fail: {other:?}"),
         }
+
+        let file = dir.path().join("root.rs");
+        std::fs::write(&file, "pub fn root() {}\n").unwrap();
+        match SymbolIndex::build_cancellable(
+            &file,
+            &["src/lib.rs".to_owned()],
+            &CancellationToken::new(),
+        ) {
+            IndexBuild::Failed { message } => {
+                assert!(message.contains("is not a directory"), "{message}");
+            }
+            other => panic!("file root did not fail: {other:?}"),
+        }
     }
 
     #[test]
-    fn test_completed_build_reports_every_walked_file() {
+    fn test_completed_build_retains_successfully_loaded_empty_files() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("symbols.rs"), "pub fn present() {}\n").unwrap();
         std::fs::write(dir.path().join("comments.rs"), "// no symbols here\n").unwrap();
         std::fs::write(dir.path().join("notes.txt"), "unsupported\n").unwrap();
         let paths = vec![
-            "symbols.rs".to_string(),
-            "comments.rs".to_string(),
-            "notes.txt".to_string(),
-            "missing.rs".to_string(),
+            "symbols.rs".to_owned(),
+            "comments.rs".to_owned(),
+            "notes.txt".to_owned(),
+            "missing.rs".to_owned(),
         ];
 
-        match SymbolIndex::build_cancellable(dir.path(), &paths, &CancellationToken::new()) {
-            IndexBuild::Completed(index) => {
-                assert_eq!(index.file_count(), 1);
-                assert_eq!(index.scanned_file_count(), 2);
-            }
-            other => panic!("build did not complete: {other:?}"),
-        }
+        let index = completed_index(SymbolIndex::build_cancellable(
+            dir.path(),
+            &paths,
+            &CancellationToken::new(),
+        ));
+        assert_eq!(index.file_count(), 2);
+        assert_eq!(index.scanned_file_count(), 2);
+        assert_eq!(index.file_symbols("comments.rs"), Some([].as_slice()));
     }
 
     #[test]
@@ -1917,18 +1087,16 @@ intro
         std::fs::write(dir.path().join("src/b.ts"), "export function beta() {}\n").unwrap();
         std::fs::write(dir.path().join("notes.txt"), "not code\n").unwrap();
 
-        let paths = vec![
-            "src/a.rs".to_string(),
-            "src/b.ts".to_string(),
-            "notes.txt".to_string(),
-            "src/missing.rs".to_string(),
-        ];
         let index = completed_index(SymbolIndex::build_cancellable(
             dir.path(),
-            &paths,
+            &[
+                "src/a.rs".to_owned(),
+                "src/b.ts".to_owned(),
+                "notes.txt".to_owned(),
+                "src/missing.rs".to_owned(),
+            ],
             &CancellationToken::new(),
         ));
-
         assert_eq!(index.file_count(), 2);
         assert_eq!(index.symbol_count(), 2);
         assert_eq!(index.definitions("alpha").len(), 1);
@@ -1936,120 +1104,28 @@ intro
     }
 
     #[test]
-    fn test_build_fails_when_index_worker_panics() {
+    fn test_empty_build_and_oversized_file() {
         let dir = tempfile::tempdir().unwrap();
-        std::fs::create_dir_all(dir.path().join("src")).unwrap();
-        let mut paths = Vec::new();
-        for (path, source) in [
-            ("src/ordinary_a.rs", "pub fn ordinary_a() {}\n"),
-            ("src/ordinary_b.rs", "pub fn ordinary_b() {}\n"),
-            ("src/ordinary_c.rs", "pub fn ordinary_c() {}\n"),
-        ] {
-            std::fs::write(dir.path().join(path), source).unwrap();
-            paths.push(path.to_string());
-        }
-        std::fs::write(
-            dir.path().join(WORKER_PANIC_PROBE_PATH),
-            "pub fn panic_probe() {}\n",
-        )
-        .unwrap();
-        assert!(supports_symbols(WORKER_PANIC_PROBE_PATH));
-        assert!(
-            std::fs::metadata(dir.path().join(WORKER_PANIC_PROBE_PATH))
-                .unwrap()
-                .len()
-                <= MAX_INDEXED_FILE_BYTES
-        );
-        paths.push(WORKER_PANIC_PROBE_PATH.to_string());
-
-        match SymbolIndex::build_cancellable(dir.path(), &paths, &CancellationToken::new()) {
-            IndexBuild::Completed(index) => panic!(
-                "worker panic degraded into a completed short index with {} indexed files",
-                index.file_count()
-            ),
-            IndexBuild::Failed { message } => {
-                assert!(
-                    message.contains("symbol indexing worker panicked"),
-                    "unexpected failure: {message}"
-                );
-                assert!(
-                    message.contains(&dir.path().display().to_string()),
-                    "failure did not name repository root: {message}"
-                );
-                assert!(!message.contains("is unavailable"), "{message}");
-                assert!(!message.contains("is not a directory"), "{message}");
-            }
-            IndexBuild::Cancelled { scanned_files } => {
-                panic!("worker panic was reported as cancellation after {scanned_files} files")
-            }
-        }
-    }
-
-    /// A repository root that is not a directory is a failure, not an empty index.
-    ///
-    /// Without the check every `repo_root.join(path)` simply fails to stat, so
-    /// the walk finishes and reports `Completed` with nothing in it. The user
-    /// then gets a silently empty symbol index and no banner explaining why —
-    /// the one outcome `IndexBuild::Failed` exists to prevent.
-    #[test]
-    fn test_a_repository_root_that_is_a_file_fails_instead_of_indexing_nothing() {
-        let dir = tempfile::tempdir().unwrap();
-        let not_a_directory = dir.path().join("root.rs");
-        std::fs::write(&not_a_directory, "pub fn a() {}\n").unwrap();
-
-        let build = SymbolIndex::build_cancellable(
-            &not_a_directory,
-            &["src/lib.rs".to_string()],
-            &CancellationToken::new(),
-        );
-
-        match build {
-            IndexBuild::Failed { message } => {
-                assert!(message.contains("is not a directory"), "{message}");
-                assert!(
-                    message.contains(&not_a_directory.display().to_string()),
-                    "{message}"
-                );
-            }
-            IndexBuild::Completed(index) => panic!(
-                "a non-directory root degraded into an empty index with {} symbols",
-                index.symbol_count()
-            ),
-            IndexBuild::Cancelled { .. } => panic!("nothing cancelled this build"),
-        }
-    }
-
-    #[test]
-    fn test_build_with_no_paths() {
-        let dir = tempfile::tempdir().unwrap();
-        let index = completed_index(SymbolIndex::build_cancellable(
+        let empty = completed_index(SymbolIndex::build_cancellable(
             dir.path(),
             &[],
             &CancellationToken::new(),
         ));
-        assert!(index.is_empty());
-        assert_eq!(index.file_count(), 0);
-    }
+        assert!(empty.is_empty());
 
-    #[test]
-    fn test_build_skips_oversized_files() {
-        let dir = tempfile::tempdir().unwrap();
         let huge = format!(
             "pub fn big() {{}}\n{}",
             "// filler filler filler filler\n".repeat(80_000)
         );
         assert!(huge.len() as u64 > MAX_INDEXED_FILE_BYTES);
-        std::fs::write(dir.path().join("big.rs"), &huge).unwrap();
+        std::fs::write(dir.path().join("big.rs"), huge).unwrap();
         std::fs::write(dir.path().join("small.rs"), "pub fn small() {}\n").unwrap();
-
         let index = completed_index(SymbolIndex::build_cancellable(
             dir.path(),
-            &["big.rs".to_string(), "small.rs".to_string()],
+            &["big.rs".to_owned(), "small.rs".to_owned()],
             &CancellationToken::new(),
         ));
         assert_eq!(index.definitions("small").len(), 1);
-        assert!(index.file_symbols("small.rs").is_some());
-        assert!(index.definitions("big").is_empty());
         assert!(index.file_symbols("big.rs").is_none());
     }
 }

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -10,8 +10,8 @@ use std::sync::LazyLock;
 
 use hearth_graph::{
     BuildOptions, FileSymbols as HearthFileSymbols, FsLoader, IndexBuild as HearthIndexBuild,
-    LanguageRegistry, LanguageSpec, Symbol as HearthSymbol, SymbolIndex as HearthSymbolIndex,
-    SymbolKind as HearthSymbolKind, SymbolRef as HearthSymbolRef,
+    LanguageId, LanguageRegistry, LanguageSpec, Symbol as HearthSymbol,
+    SymbolIndex as HearthSymbolIndex, SymbolKind as HearthSymbolKind, SymbolRef as HearthSymbolRef,
 };
 use rustc_hash::FxHashMap;
 
@@ -28,6 +28,16 @@ const MOONBIT_TAGS_QUERY: &str = include_str!("queries/moonbit/tags.scm");
 /// Hearth's bundled registry plus the host-owned MoonBit grammar.
 static SYMBOL_LANGUAGES: LazyLock<LanguageRegistry> = LazyLock::new(|| {
     let mut registry = LanguageRegistry::bundled();
+
+    // The former octorus extractor merged adjacent same-name definitions for
+    // every language. C needs that compatibility behavior for function-like
+    // macro declarations such as tree_sitter_external_scanner(reset), whose
+    // tags query captures the macro identifier for each generated function.
+    registry.register(
+        LanguageSpec::new("c", tree_sitter_c::LANGUAGE.into(), ["c", "h"])
+            .with_tags_query(tree_sitter_c::TAGS_QUERY)
+            .with_merge_adjacent_same_name_definitions(true),
+    );
     registry.register(
         LanguageSpec::new("moonbit", tree_sitter_moonbit::LANGUAGE.into(), ["mbt"])
             .with_tags_query(MOONBIT_TAGS_QUERY),
@@ -38,6 +48,24 @@ static SYMBOL_LANGUAGES: LazyLock<LanguageRegistry> = LazyLock::new(|| {
 /// Registry shared by the facade and the symbol parser cache.
 pub(crate) fn symbol_language_registry() -> &'static LanguageRegistry {
     &SYMBOL_LANGUAGES
+}
+
+/// Resolve an extension to its last-registered symbol language.
+///
+/// Iterating rather than constructing a synthetic path keeps compatibility
+/// accessors allocation-free while preserving the registry's last-wins rule.
+pub(crate) fn symbol_language_id(extension: &str) -> Option<LanguageId> {
+    let mut found = None;
+    for (id, spec) in SYMBOL_LANGUAGES.iter() {
+        if spec
+            .extensions
+            .iter()
+            .any(|candidate| candidate.as_str() == extension)
+        {
+            found = Some(id);
+        }
+    }
+    found
 }
 
 /// A cooperative cancellation signal used by octorus background work.
@@ -568,6 +596,32 @@ func (c *Config) Load() {}
 func main() {}
 ";
         assert_eq!(names(source, "main.go"), ["Config", "Load", "main"]);
+    }
+
+    #[test]
+    fn test_extract_c_merges_macro_generated_function_names() {
+        let scanner = include_str!("../crates/tree-sitter-moonbit/src/scanner.c");
+        let generated: Vec<_> = outline(scanner, "scanner.c")
+            .into_iter()
+            .filter(|(name, ..)| name == "tree_sitter_external_scanner")
+            .collect();
+
+        insta::assert_debug_snapshot!(generated, @r#"
+        [
+            (
+                "tree_sitter_external_scanner",
+                Function,
+                63,
+                0,
+            ),
+            (
+                "tree_sitter_external_scanner",
+                Function,
+                396,
+                0,
+            ),
+        ]
+        "#);
     }
 
     #[test]

--- a/src/syntax/parser_pool.rs
+++ b/src/syntax/parser_pool.rs
@@ -18,10 +18,10 @@ use crate::language::SupportedLanguage;
 /// This avoids the overhead of creating new parsers/compiling queries for each file.
 pub struct ParserPool {
     parsers: HashMap<SupportedLanguage, Parser>,
-    /// Cached compiled queries for highlight queries
+    /// Cached compiled queries for highlight queries.
     queries: HashMap<SupportedLanguage, Query>,
-    /// Cached compiled queries for tags (symbol) queries
-    tags_queries: HashMap<SupportedLanguage, Option<Query>>,
+    /// Hearth-owned parser and tags-query cache for symbol extraction.
+    symbol_parsers: hearth_graph::ParserPool<'static>,
 }
 
 impl Default for ParserPool {
@@ -36,24 +36,15 @@ impl ParserPool {
         Self {
             parsers: HashMap::new(),
             queries: HashMap::new(),
-            tags_queries: HashMap::new(),
+            symbol_parsers: hearth_graph::ParserPool::new(
+                crate::symbols::symbol_language_registry(),
+            ),
         }
     }
 
-    /// Get or create a compiled tags query for the given language.
-    ///
-    /// Returns `None` when the language has no tags query or the query fails to
-    /// compile. The failure is cached as `None` so a broken query is compiled
-    /// at most once per pool instead of on every file.
-    pub fn get_or_create_tags_query(&mut self, lang: SupportedLanguage) -> Option<&Query> {
-        if let Entry::Vacant(e) = self.tags_queries.entry(lang) {
-            let compiled = lang
-                .tags_query()
-                .and_then(|src| Query::new(&lang.ts_language(), src).ok());
-            e.insert(compiled);
-        }
-
-        self.tags_queries.get(&lang)?.as_ref()
+    /// Return the Hearth parser/query cache used by the symbol facade.
+    pub(crate) fn symbol_parser_pool(&mut self) -> &mut hearth_graph::ParserPool<'static> {
+        &mut self.symbol_parsers
     }
 
     /// Get or create a compiled highlight query for the given language.

--- a/src/syntax/parser_pool.rs
+++ b/src/syntax/parser_pool.rs
@@ -47,6 +47,15 @@ impl ParserPool {
         &mut self.symbol_parsers
     }
 
+    /// Get or create the compiled tags query for a supported symbol language.
+    ///
+    /// This preserves the public octorus API while delegating query ownership
+    /// and caching to Hearth. Languages without symbol support return `None`.
+    pub fn get_or_create_tags_query(&mut self, lang: SupportedLanguage) -> Option<&Query> {
+        let id = crate::symbols::symbol_language_id(lang.default_extension())?;
+        self.symbol_parsers.tags_query(id)
+    }
+
     /// Get or create a compiled highlight query for the given language.
     ///
     /// Queries are cached to avoid recompilation overhead on each use.

--- a/tests/public_symbol_api.rs
+++ b/tests/public_symbol_api.rs
@@ -1,0 +1,17 @@
+use octorus::{language::SupportedLanguage, ParserPool};
+
+#[test]
+fn public_tags_query_compatibility_api_remains_available() {
+    let source = SupportedLanguage::Rust
+        .tags_query()
+        .expect("Rust must expose its symbol tags query");
+    assert!(source.contains("@definition.function"));
+
+    let mut pool = ParserPool::new();
+    assert!(pool
+        .get_or_create_tags_query(SupportedLanguage::Rust)
+        .is_some());
+    assert!(pool
+        .get_or_create_tags_query(SupportedLanguage::Css)
+        .is_none());
+}


### PR DESCRIPTION
## Summary

- replace the octorus-owned symbol extraction and indexing internals with `hearth-graph = "=0.1.1"` behind the existing `String` / `usize` compatibility facade
- pin Rust 1.95.0 across package metadata, local toolchain, and CI workflows
- inject MoonBit through the public `LanguageSpec` builder API and reuse Hearth parser/query caches through the existing parser pool
- preserve cancellation, search, definitions, file lookup, and completed-build contracts while documenting intentional upstream differences
- migrate symbol benchmarks and technical documentation, and correct the stale margin-scrolling UI benchmark expectation exposed by the all-target gate

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets` — 1630 passed, 0 failed, 1 ignored in the library suite; all other target and benchmark test suites passed
- bounded `cargo bench --bench symbol_index` run completed
- confirmed one `tree-sitter 0.26.11` dependency and registry-only `hearth-graph 0.1.1`

Closes #177