### PR TITLE
feat: add repository module graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "assert_cmd"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,7 +562,7 @@ dependencies = [
  "document-features",
  "mio 1.1.1",
  "parking_lot",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -635,6 +641,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -761,6 +781,15 @@ dependencies = [
  "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "fast-glob"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cc9868289ee02952b341465ce66e67adec151227afedacf9137c0adb1e53943"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -930,6 +959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ed2f2edad8a14c8186b847909a41fbb9c3eafa44f88bd891114ed5019da09"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,8 +1006,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ec4cd2eb3541701be3c3bbc80d3ef2596d4d5759d96e28555716da4259e5e5d"
 dependencies = [
  "compact_str 0.10.0",
+ "json-strip-comments",
+ "oxc_resolver",
  "parking_lot",
  "rustc-hash",
+ "serde_json",
  "smallvec",
  "tree-sitter",
  "tree-sitter-bash",
@@ -1048,6 +1089,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1168,6 +1211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "json-strip-comments"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01ed659c5f428031b9c1fb7de6729af2eb491654d4bcd416a5b5b704986b9658"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,9 +1273,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libredox"
@@ -1259,9 +1311,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litrs"
@@ -1394,6 +1446,12 @@ dependencies = [
  "libc",
  "memoffset",
 ]
+
+[[package]]
+name = "nodejs-built-in-modules"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5eb86a92577833b75522336f210c49d9ebd7dd55a44d80a92e68c668a75f27c"
 
 [[package]]
 name = "nom"
@@ -1559,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1607,6 +1665,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxc_resolver"
+version = "11.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fa374d03b255c070a32ae65b8a05231b8e658104d6ef22034c09da8fa0c2fd9"
+dependencies = [
+ "compact_str 0.9.0",
+ "dashmap",
+ "fast-glob",
+ "indexmap",
+ "json-strip-comments",
+ "memchr",
+ "nodejs-built-in-modules",
+ "once_cell",
+ "percent-encoding",
+ "rustc-hash",
+ "rustix 1.1.4",
+ "self_cell",
+ "serde",
+ "serde_json",
+ "simd-json",
+ "simdutf8",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1719,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
@@ -2099,6 +2190,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,14 +2268,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -2211,6 +2322,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
+name = "self_cell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2248,9 +2365,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2365,6 +2482,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "simd-json"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e32d7ab2678282d21e53374fbead7119b7eacbede73685dcaac472870a29a11c"
+dependencies = [
+ "halfbrown",
+ "ref-cast",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2610,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syntect"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,7 +2662,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3136,6 +3282,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "value-trait"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f4b4a98dfe54bc9ed3641af7ffcb837240269627dbd5cb047d13daa39736cc"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3318,7 +3476,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fabb953106c3c8eea8306e4393700d7657561cb43122571b172bbfb7c7ba1d"
 dependencies = [
  "env_home",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "winsafe",
 ]
 
@@ -3354,6 +3512,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,6 +3543,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -3393,6 +3583,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -3468,6 +3668,15 @@ dependencies = [
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,13 @@ name = "or"
 path = "src/main.rs"
 
 [dependencies]
-hearth-graph = { version = "=0.1.1", default-features = false, features = ["bundled-languages", "fs"] }
+hearth-graph = { version = "=0.1.1", default-features = false, features = ["bundled-languages", "fs", "resolve-js", "resolve-rust"] }
 ratatui = { version = "0.30.0", features = ["unstable-rendered-line-info"] }
 crossterm = "0.28.1"
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "rt", "macros", "sync", "process", "io-util", "time"] }
 tokio-util = "0.7.18"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = "1.0.151"
 toml = "0.8.23"
 tempfile = "3.24.0"
 notify = "6.1.1"
@@ -103,6 +103,10 @@ harness = false
 
 [[bench]]
 name = "symbol_index"
+harness = false
+
+[[bench]]
+name = "module_graph"
 harness = false
 
 [[bench]]

--- a/README.md
+++ b/README.md
@@ -134,12 +134,15 @@ There is a second message ahead of that one. `o` and `gd` answer questions about
 |---------|-----|-------------|
 | File outline | `o` | Symbols of the open file, indented by nesting depth, with the cursor's enclosing symbol pre-selected. Nesting follows the tags query: a Python method inside a class indents, a Rust method inside `impl` does not, because an `impl` block is not itself a tagged definition |
 | Symbol search | `s` | Fuzzy search across every symbol in the repository, best 200 matches listed; `Enter` opens the file at the definition |
+| Imports / imported by | `i` | Show direct imports and reverse dependencies of the open Rust, JavaScript, or TypeScript file. `Tab` or `h/l` switches direction; `Enter` opens a listed local file |
 | Go to definition | `gd` | Resolve the cursor **line** against the index — a CST match, not a grep for `fn <name>` |
 | Jump back | `Ctrl-o` | Return to the position before the last jump |
 
 `gd` in the browser works at line granularity: the browser has a line cursor and no column cursor, so it reads the identifiers on the cursor line left to right and jumps to the first one the index knows. On `Config::helper()` that is `Config`. To land on `helper` instead, use `s` and search for it by name — and either way `Ctrl-o` puts you back, so a jump you did not mean costs one keystroke. (The diff view's `gd` does have a column-free candidate popup; the browser deliberately does not, because `s` already covers "not that one, the other one" across the whole repository rather than one line.)
 
 Symbol extraction covers Rust, TypeScript, TSX, JavaScript, JSX, Go, Python, Ruby, C, C++, Java, C#, Lua, PHP, Swift, Bash, Zig, Haskell, MoonBit, and Markdown (headings become the outline of a README).
+
+The same background parse pass also extracts imports for Rust, TypeScript, TSX, JavaScript, and JSX. JavaScript/TypeScript resolution handles relative paths, packages, and a root `tsconfig.json` or `jsconfig.json`; Rust module resolution is deliberately best-effort. Dependency queries run off the UI thread; each direction retains up to 200 rows and shows the full edge count when truncated. The overlay labels every answer `exact` or `approximate`. Rust answers are approximate, as are reverse dependencies when the repository listing was truncated, a non-UTF-8 path was omitted, or an import-supporting file could not be analyzed.
 
 #### Repository Browser Keybindings
 
@@ -168,6 +171,7 @@ Symbol extraction covers Rust, TypeScript, TSX, JavaScript, JSX, Go, Python, Rub
 | `gg` / `G` | Jump to first / last line |
 | `o` | File outline |
 | `s` | Repository symbol search |
+| `i` | Show imports / imported by |
 | `gb` | Toggle blame gutter |
 | `gc` | Open the blamed line's commit diff inside the browser |
 | `gp` | Open the PR that introduced the blamed line's commit |
@@ -185,6 +189,15 @@ Symbol extraction covers Rust, TypeScript, TSX, JavaScript, JSX, Go, Python, Rub
 | `Backspace` | Delete the last character of the query (symbol search) |
 | `Ctrl-u` | Clear the query |
 | `Enter` | Jump to the symbol |
+| `Esc` | Close |
+
+**Imports / imported by overlay:**
+
+| Key | Action |
+|-----|--------|
+| `Tab`, `h` / `l`, `←` / `→` | Switch between outgoing imports and incoming importers |
+| `j` / `k`, `↑` / `↓` | Move selection |
+| `Enter` | Open a listed local target/importer; external, unresolved, and unlisted targets stay visible but do not open |
 | `Esc` | Close |
 
 ### Pull Requests
@@ -1022,6 +1035,7 @@ go_to_definition = ["g", "d"]
 | `repo_browse` | `b` | Open the Repository Browser |
 | `symbol_outline` | `o` | File outline (browser only) |
 | `symbol_search` | `s` | Repository symbol search (browser only) |
+| `module_graph` | `i` | Show direct imports and reverse dependencies (browser file pane only) |
 | `toggle_blame` | `gb` | Toggle blame gutter (browser file pane only) |
 | `open_blame_commit` | `gc` | Open the blamed line's commit diff (browser file pane only) |
 | `open_blame_pr` | `gp` | Open the PR for the blamed line's commit (browser file pane only) |
@@ -1055,12 +1069,13 @@ Press `Space /` in the PR list or file list to activate keyword filtering. Type 
 
 ## Design Docs
 
-Two technical reference documents for the Repository Browser and its symbol
-engine live in [`docs/`](docs/):
+Technical reference documents for the Repository Browser and its code-intelligence
+engines live in [`docs/`](docs/):
 
 | Document | What it holds |
 |----------|---------------|
 | [docs/symbol-index.md](docs/symbol-index.md) | Technical reference for the tree-sitter tags symbol engine — language matrix, per-grammar quirks, how to add a language, measured cost |
+| [docs/module-graph.md](docs/module-graph.md) | Import extraction, JS/TS and Rust resolution, graph guarantees, path projection, and query behavior |
 | [docs/repo-browse-architecture.md](docs/repo-browse-architecture.md) | Architecture of the Repository Browser — state machine, module map, background tasks, extension points, known limitations |
 
 [`docs/README.md`](docs/README.md) indexes the same two documents from inside the directory.

--- a/benches/module_graph.rs
+++ b/benches/module_graph.rs
@@ -1,0 +1,111 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use octorus::code_index::{CodeIndex, CodeIndexBuild};
+use octorus::module_graph::SourceUniverse;
+use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
+
+fn fixture(file_count: usize) -> (TempDir, Vec<String>) {
+    let dir = tempfile::tempdir().expect("fixture directory");
+    std::fs::create_dir_all(dir.path().join("src")).expect("source directory");
+    let paths: Vec<_> = (0..file_count)
+        .map(|index| format!("src/module_{index:04}.ts"))
+        .collect();
+    for (index, path) in paths.iter().enumerate() {
+        let import = if index + 1 < file_count {
+            format!("import './module_{:04}';\n", index + 1)
+        } else {
+            String::new()
+        };
+        std::fs::write(
+            dir.path().join(path),
+            format!("{import}export function symbol_{index:04}() {{}}\n"),
+        )
+        .expect("fixture source");
+    }
+    (dir, paths)
+}
+
+fn fan_in_fixture(importer_count: usize) -> (TempDir, Vec<String>) {
+    let dir = tempfile::tempdir().expect("fixture directory");
+    std::fs::create_dir_all(dir.path().join("src")).expect("source directory");
+    let mut paths = Vec::with_capacity(importer_count + 1);
+    paths.push("src/center.ts".to_string());
+    std::fs::write(
+        dir.path().join("src/center.ts"),
+        "export const center = 1;\n",
+    )
+    .expect("center source");
+    for index in 0..importer_count {
+        let path = format!("src/importer_{index:04}.ts");
+        std::fs::write(
+            dir.path().join(&path),
+            format!("import './center';\nexport const value{index} = {index};\n"),
+        )
+        .expect("importer source");
+        paths.push(path);
+    }
+    (dir, paths)
+}
+
+fn completed(build: CodeIndexBuild) -> CodeIndex {
+    match build {
+        CodeIndexBuild::Completed(index) => *index,
+        CodeIndexBuild::Cancelled { scanned_files } => {
+            panic!("fixture build cancelled after {scanned_files} files")
+        }
+        CodeIndexBuild::Failed { message } => panic!("fixture build failed: {message}"),
+    }
+}
+
+fn module_graph_benches(c: &mut Criterion) {
+    let mut build_group = c.benchmark_group("module_graph/build");
+    build_group.sample_size(10);
+    for file_count in [100, 1_000] {
+        let (dir, paths) = fixture(file_count);
+        build_group.bench_with_input(
+            BenchmarkId::from_parameter(file_count),
+            &file_count,
+            |b, _| {
+                b.iter(|| {
+                    completed(CodeIndex::build_cancellable(
+                        black_box(dir.path()),
+                        black_box(&paths),
+                        SourceUniverse::Complete,
+                        &CancellationToken::new(),
+                    ))
+                });
+            },
+        );
+    }
+    build_group.finish();
+
+    let (dir, paths) = fixture(5_000);
+    let index = completed(CodeIndex::build_cancellable(
+        dir.path(),
+        &paths,
+        SourceUniverse::Complete,
+        &CancellationToken::new(),
+    ));
+    let mut query_group = c.benchmark_group("module_graph/query");
+    query_group.bench_function("dependencies", |b| {
+        b.iter(|| index.modules.dependencies(black_box("src/module_2500.ts")));
+    });
+    query_group.bench_function("dependents", |b| {
+        b.iter(|| index.modules.dependents(black_box("src/module_2500.ts")));
+    });
+
+    let (fan_in_dir, fan_in_paths) = fan_in_fixture(5_000);
+    let fan_in_index = completed(CodeIndex::build_cancellable(
+        fan_in_dir.path(),
+        &fan_in_paths,
+        SourceUniverse::Complete,
+        &CancellationToken::new(),
+    ));
+    query_group.bench_function("dependents_high_fan_in_5000", |b| {
+        b.iter(|| fan_in_index.modules.dependents(black_box("src/center.ts")));
+    });
+    query_group.finish();
+}
+
+criterion_group!(benches, module_graph_benches);
+criterion_main!(benches);

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,9 @@ written for maintainers and anyone who needs to change that code.
 | Document | What it holds |
 |----------|---------------|
 | [symbol-index.md](symbol-index.md) | Technical reference for the tree-sitter tags symbol engine — language matrix, per-grammar quirks, how to add a language, performance |
+| [module-graph.md](module-graph.md) | Import extraction, module resolution, graph guarantees, path projection, queries, and performance |
 | [repo-browse-architecture.md](repo-browse-architecture.md) | Architecture of the Repository Browser — state machine, module map, background tasks, extension points, known limitations |
 
-Start with `repo-browse-architecture.md` when changing the browser screen, and
-read `symbol-index.md` when the work touches symbol extraction or adds a language.
+Start with `repo-browse-architecture.md` when changing the browser screen. Read
+`symbol-index.md` for symbol extraction and `module-graph.md` for imports,
+resolvers, or dependency queries.

--- a/docs/module-graph.md
+++ b/docs/module-graph.md
@@ -1,0 +1,252 @@
+# Module Graph — Technical Reference
+
+The Repository Browser import engine is an octorus-owned compatibility facade
+over `hearth-graph = "=0.1.1"`. Read this document when changing import
+extraction, resolver setup, graph guarantees, or the `i` dependency overlay.
+Browser task/state/rendering architecture remains in
+[`repo-browse-architecture.md`](repo-browse-architecture.md); symbol-specific
+behavior remains in [`symbol-index.md`](symbol-index.md).
+
+## 1. Ownership and one-pass data flow
+
+Hearth owns parsing, import extraction, module resolution, graph storage,
+reverse-dependency maintenance, sorting, and exactness calculations. Octorus
+owns repository enumeration, cancellation, resolver configuration, path
+projection, browser state, and UI labels.
+
+```text
+git ls-files paths + repository root + CancelSignal
+    │
+    ▼
+hearth_graph::analyze_paths                 src/code_index.rs
+    │  one tree-sitter parse per source
+    ├─ symbols ────────────────► octorus SymbolIndex projection
+    └─ imports/language/hash ──► octorus ModuleGraph facade
+                                      │
+                                      ├─ dependencies(path)
+                                      └─ dependents(path)
+```
+
+The browser must use `CodeIndex::build_cancellable`; starting an independent
+`build_index` and `analyze_paths` would parse every supported file twice.
+`SymbolIndex::build_cancellable` remains as the public symbols-only
+compatibility API for existing external callers and benchmarks.
+
+The shared build keeps the existing limits:
+
+- maximum source size: 2 MiB;
+- maximum workers: 8;
+- maximum symbols per file: Hearth's 10,000 cap.
+
+Unsupported, oversized, sparse/missing, unreadable, and non-UTF-8 source files
+are skipped by Hearth. A root verification error or worker panic fails the
+whole build. A cancelled build publishes neither a partial symbol index nor a
+partial graph. Cancellation is checked before resolver setup, during repository
+completeness scans, between graph insertions, and during octorus symbol
+projection. Once an analysis's imports have been copied into compact graph
+edges, its original import vector is dropped before symbol projection to bound
+peak retained data.
+
+## 2. Import language matrix
+
+| Language | Extensions | Extraction | Resolution |
+|---|---|---|---|
+| Rust | `.rs` | custom Hearth use-tree / `mod` walker | Hearth best-effort Rust resolver |
+| TypeScript | `.ts`, `.mts`, `.cts` | JavaScript + TypeScript import queries | `oxc_resolver` |
+| TSX | `.tsx` | JavaScript + TypeScript import queries | `oxc_resolver` |
+| JavaScript | `.js`, `.mjs`, `.cjs` | JavaScript import query | `oxc_resolver` |
+| JSX | `.jsx` | JavaScript import query | `oxc_resolver` |
+
+All other symbol languages remain symbol-only. They are deliberately not
+inserted as analyzed graph nodes: an import-unsupported Python or Markdown file
+must not make every JavaScript reverse-dependency answer approximate.
+
+Extracted JavaScript forms are static imports, re-exports, literal dynamic
+imports, CommonJS `require`, and TypeScript `import = require`. A non-literal
+dynamic/CommonJS argument marks its file opaque and weakens guarantees.
+
+Rust grouped use-trees are flattened to one normalized leaf per edge. Rust
+resolution does not model `cfg`, `#[path]`, macros, inline-module trees, or
+Cargo targets completely, so its baseline completeness is always partial.
+
+## 3. Resolver setup
+
+`hearth-graph` is built with `bundled-languages`, `fs`, `resolve-js`, and
+`resolve-rust` and without default features.
+
+### JavaScript and TypeScript
+
+Octorus selects `<root>/tsconfig.json`; if it is absent, it selects
+`<root>/jsconfig.json`; if both are absent, no manual config is supplied.
+`oxc_resolver` handles extension probing, package imports/exports, CommonJS
+conditions, and configured path aliases. Hearth tracks config/package paths
+consulted by resolution, but octorus v1 has no watcher-driven re-resolution.
+
+Only the root config is selected explicitly. Package-local config behavior is
+whatever `oxc_resolver` derives from that setup; octorus does not enumerate and
+merge every workspace config.
+
+### Rust
+
+Listed paths ending in `src/lib.rs` or `src/main.rs` become explicit crate
+roots. Hearth recognizes files under `examples`, `tests`, and `src/bin` as
+implicit roots. The nearest applicable root wins, but every Rust outcome stays
+partial by design.
+
+## 4. Relative graph keys and absolute resolvers
+
+Git and Browser state use UTF-8 repository-relative paths with `/` separators.
+Both Hearth filesystem resolvers require an absolute referrer. The
+`RootedResolver` adapter is the only boundary between these forms:
+
+```text
+Graph key:       packages/app/src/main.ts
+Resolver input:  /canonical/root/packages/app/src/main.ts
+Resolver output: /canonical/root/packages/lib/src/index.ts
+Graph target:    packages/lib/src/index.ts
+```
+
+Resolved paths under the canonical repository root are stripped and rebuilt
+from path components with `/` separators. Paths outside the root stay absolute.
+The UI opens only targets present in the original Git listing; outside-root,
+ignored/unlisted, external, and unresolved targets remain visible but are not
+navigable. Membership includes listed non-source targets such as JSON and CSS,
+while reverse-dependency completeness still considers only import-supported
+source files.
+
+If the repository root cannot be represented as UTF-8, the rooted resolver
+returns a partial invalid-specifier failure instead of using a lossy path that
+could resolve the wrong file.
+
+## 5. Graph guarantees
+
+Every query returns `DependencyGuarantee::Exact` or `Approximate`, projected
+from Hearth's `Guarantee`.
+
+### Direct dependencies
+
+A file's `dependencies(path)` result is exact only when all of these hold:
+
+- import extraction supports the file;
+- no non-literal import made the file opaque;
+- the matching resolver is live;
+- every resolution is complete;
+- edges were resolved at the current resolver generation.
+
+A normal JS/TS file with no opaque imports can therefore be exact. Rust is
+always approximate because its resolver baseline is partial.
+
+### Reverse dependencies
+
+`dependents(path)` additionally needs a complete source universe and every
+graph node to be exact. Octorus marks the source universe complete only when:
+
+- the Git listing was not truncated at 200,000 entries;
+- no non-UTF-8 path was omitted; and
+- every listed import-supported path produced a `FileAnalysis`.
+
+An oversized, missing, unreadable, or sparse import-supporting file makes the
+universe partial. A resolved target absent from analysis remains a stub and also
+prevents exact reverse answers. Octorus does not expose a stub's empty outgoing
+edge vector as “No imports”: both query directions return unavailable for that
+path because its source was never analyzed. Any Rust analyzed node makes
+root-wide reverse answers approximate under Hearth 0.1.1.
+
+Guarantees describe structural completeness, not runtime freshness. The browser
+builds once per session and does not yet refresh after filesystem or resolver
+configuration changes.
+
+## 6. Browser state and interaction
+
+The graph lifecycle is independent state, although the same worker transitions
+it together with symbols:
+
+```text
+ModuleGraphState
+    Idle → Building → Ready(Arc<ModuleGraph>) | Failed
+```
+
+The `i` action checks conditions in this order:
+
+1. open file still loading → `Still opening this file`;
+2. graph idle/building → `Module graph is still building`;
+3. graph failed → `Module graph is unavailable`;
+4. unsupported file → `Import analysis is not supported for this file`;
+5. supported but skipped file → `Import analysis is unavailable for this file`;
+6. otherwise enter `BrowseOverlay::ModuleGraphLoading` and start a request-scoped
+   `spawn_blocking` query;
+7. install `BrowseOverlay::ModuleGraph` only when request id, requested path,
+   current open path, and browser context still match.
+
+`Esc`, a changed open path, or closing the browser cancels the request and drops
+its receiver. A late delivery therefore cannot replace the current overlay.
+Direct and reverse rows are materialized on the blocking worker, never on the
+input or draw thread. Octorus retains at most 200 rows per direction and keeps
+the pre-truncation total so the title reports, for example,
+`200/5000 edges shown`. Each component is capped at 512 Unicode scalars and each
+final label at 240 terminal cells before retention. Rendering borrows label
+spans from the visible slice; it neither clones labels nor queries/walks the
+graph per frame.
+
+| Key | Behavior |
+|---|---|
+| `i` | Open the graph overlay from browser file focus |
+| `Tab`, `h/l`, `←/→` | Switch Imports / Imported by |
+| `j/k`, `↑/↓` | Move selection |
+| `Enter` | Open a listed local target/importer |
+| `Esc` | Close |
+
+Outgoing jumps open the target at its first line. Incoming jumps open the
+importer at the extracted import line. Both push the existing browser jump
+stack, so `Ctrl-o` restores the exact source line and scroll position.
+
+## 7. Performance
+
+`benches/module_graph.rs` measures the octorus boundary:
+
+- combined symbol/import/graph build for 100 and 1,000 TypeScript files;
+- direct dependency query on a 5,000-file chain;
+- reverse dependency query on the same graph;
+- reverse dependency query for a 5,000-importer high-fan-in module.
+
+Run:
+
+```bash
+cargo bench --bench module_graph
+```
+
+The renderer is protected structurally rather than by this graph benchmark:
+`ModuleGraphPanel` owns at most 200 precomputed, 240-cell rows per direction;
+`render_module_graph` applies `skip(offset).take(viewport_height)` and borrows
+the retained labels.
+
+Hearth 0.1.1 has no bounded direct/reverse query API. It clones and sorts the
+full edge result before octorus can truncate it. Running that work in
+`spawn_blocking` prevents input/render stalls, and post-query truncation bounds
+labels and retained panel memory, but background CPU and temporary Hearth query
+memory still scale with actual fan-in. The high-fan-in benchmark tracks this
+upstream boundary explicitly.
+
+## 8. Tests
+
+| Location | Coverage |
+|---|---|
+| `src/module_graph.rs` | import kinds/spans, JS/TS aliases/packages, Rust resolution, direct/reverse guarantees, stub/listed non-source availability, high fan-in bounds, observable cancellation, import-vector release |
+| `src/code_index.rs` / `src/symbols.rs` | one completed result containing symbols and graph edges, empty files, cancellation through post-analysis projection |
+| `src/app/browse.rs` | listing completeness, combined/query failure lifecycles, actual 250-importer panel limits, Unicode label bounds |
+| `src/app/input_browse.rs` | loading/open/switch/jump/back/CJK JSON/non-navigable/empty/pending/cancel/stale scenarios, single and sequence bindings |
+| `src/ui/browse.rs` | loading/outgoing/truncated/incoming/long-CJK/approximate/empty/tiny-terminal inline snapshots |
+| `src/config/mod.rs` | default, serialization, overlap validation, one-diagnostic ownership, and round-trip |
+
+## 9. Known limitations
+
+- no visual node-link or transitive-neighborhood UI;
+- no import-aware symbol disambiguation for `gd`;
+- no alias or re-export chain mapped to an exact destination symbol;
+- no incremental upsert/removal from filesystem watcher events;
+- no resolver-cache clearing or graph re-resolution after config changes;
+- Rust resolution remains approximate until Hearth gains Cargo target/module-tree metadata;
+- only a root `tsconfig.json` / `jsconfig.json` is selected explicitly;
+- outside-root and unlisted resolved paths are displayed but cannot be opened;
+- Hearth 0.1.1 queries materialize and sort every matching edge before octorus can retain only the first 200; this work is off the UI thread but its temporary cost is not bounded;
+- the header still reports only symbol-index lifecycle; graph failures are exposed through the footer/action path.

--- a/docs/repo-browse-architecture.md
+++ b/docs/repo-browse-architecture.md
@@ -8,9 +8,11 @@ Read this before adding features.
 | File | Role |
 |------|------|
 | `src/app/browse.rs` | State definitions, file loading, spawning and collecting async tasks |
-| `src/symbols.rs` | octorus compatibility facade over the Hearth symbol engine (independent of the screen, see [symbol-index.md](symbol-index.md)) |
+| `src/code_index.rs` | One-pass Hearth symbol/import repository analysis |
+| `src/symbols.rs` | octorus compatibility facade over the Hearth symbol engine (see [symbol-index.md](symbol-index.md)) |
+| `src/module_graph.rs` | octorus compatibility facade over Hearth import resolution and graph queries (see [module-graph.md](module-graph.md)) |
 | `src/ui/browse.rs` | Rendering |
-| `src/app/input_browse.rs` | Key handling (2 panes + 2 overlays) |
+| `src/app/input_browse.rs` | Key handling (2 panes + 3 browser overlays, plus PR/discussion modals) |
 
 Do not put line counts in this table; they become stale whenever the browser or
 its compatibility facade changes. Count the current checkout when needed.
@@ -25,7 +27,7 @@ Changes to existing files are kept minimal:
 - `src/app/mod.rs` — module declarations for `browse` / `input_browse`, the `browse_state: Option<BrowseState>` field, `poll_browse_updates()` added to the polling loop
 - `src/app/input.rs` — 2 dispatch arms, the `b` branch in the file list
 - `src/ui/mod.rs` — module declaration and 1 dispatch line
-- `src/config/keybindings.rs` — `repo_browse` / `symbol_outline` / `symbol_search` / `toggle_blame` / `open_blame_commit` / `open_blame_pr` / `open_line_discussion`
+- `src/config/keybindings.rs` — `repo_browse` / `symbol_outline` / `symbol_search` / `module_graph` / `toggle_blame` / `open_blame_commit` / `open_blame_pr` / `open_line_discussion`
 - `src/main.rs` — the `--browse` flag
 - `src/ui/help.rs` — help entries
 - `src/app/cockpit.rs` / `src/ui/cockpit.rs` — the Cockpit menu item that opens the browser
@@ -37,9 +39,11 @@ Changes to existing files are kept minimal:
 - `benches/ui_rendering.rs` — the `browse_render` group / `benches/symbol_index.rs` — facade extraction, build, and query benchmarks
 - `tests/cli.rs` — e2e tests that launch the binary
 
-The symbol implementation depends on exact registry release `hearth-graph
-0.1.1` with only its `bundled-languages` and `fs` features. See
-[symbol-index.md](symbol-index.md) for ownership and compatibility boundaries.
+The code-intelligence implementation depends on exact registry release
+`hearth-graph 0.1.1` with `bundled-languages`, `fs`, `resolve-js`, and
+`resolve-rust`, with default features disabled. See
+[symbol-index.md](symbol-index.md) and [module-graph.md](module-graph.md) for
+ownership and compatibility boundaries.
 
 ## 2. State machine
 
@@ -69,6 +73,12 @@ paths:     LoadState<Vec<String>>
 index:     IndexState
            Idle → Building → Ready(Arc<SymbolIndex>) | Failed
 
+graph:     ModuleGraphState
+           Idle → Building → Ready(Arc<ModuleGraph>) | Failed
+
+universe:  SourceUniverse
+           Partial | Complete
+
 open_load: OpenLoad
            Idle → Pending { path, line, scroll, cancel } → Idle | Failed { path, message }
 
@@ -88,14 +98,21 @@ PR lookup: PrLookupState
 
 overlay:   BrowseOverlay
            None | Outline { selected } | SymbolSearch { query, selected }
+                | ModuleGraphLoading { request_id, path }
+                | ModuleGraph(ModuleGraphPanel)
 
 filter:    Option<ListFilter>   ← reuses the existing list filter
 ```
 
-The point is that `IndexState` is an independent enum: **the index is an
-accelerator, not a precondition**. While it is `Building`, tree browsing, file
-viewing, and filtering all keep working. Only the three index consumers —
-`o` / `s` / `gd` — put the reason into the footer instead of opening an overlay.
+`IndexState` and `ModuleGraphState` remain independent typed lifecycles even
+though one `CodeIndex` worker transitions them together. Code intelligence is
+an accelerator, not a precondition: while it is building, tree browsing, file
+viewing, and filtering all keep working. Symbol consumers `o` / `s` / `gd` and
+the graph consumer `i` put the reason into the footer instead of opening an
+overlay. A ready graph does not make a high-fan-in query synchronous:
+`i` transitions to `ModuleGraphLoading`, runs both directions in
+`spawn_blocking`, and installs `ModuleGraph` only when the request id and open
+path still match.
 
 More than one message can come out. `o` and `gd` **check `open_is_pending()`
 first**, so while a file is loading, `Still opening this file` wins regardless
@@ -113,6 +130,7 @@ does not carry this check.
 | `o` | `Still opening this file` | `Symbol index is still building` | `No symbols in this file` if the target file has none, otherwise opens the outline |
 | `s` | (not checked) | `Symbol index is still building` | opens the search overlay |
 | `gd` | `Still opening this file` | `Symbol index is still building` | `No definition found` when it cannot resolve |
+| `i` | `Still opening this file` | `Module graph is still building` | enters a cancellable loading overlay, or reports unsupported/unavailable analysis |
 
 `Symbol index is still building` is emitted on `index.ready().is_none()`.
 `IndexState::Failed` also satisfies that condition, so after a failed build the
@@ -156,10 +174,16 @@ AppState::RepoBrowseTree                                        poll_browse_upda
                                                                            │
                                                               start_symbol_index_build()
                                                                            │
-                                                     spawn_blocking: SymbolIndex::build_cancellable
+                                                       spawn_blocking: CodeIndex::build_cancellable
+                                                                           │
+                                                        hearth_graph::analyze_paths (one parse pass)
+                                                                   ┌───────┴────────┐
+                                                                   ▼                ▼
+                                                           SymbolIndex         ModuleGraph
+                                                                   └───────┬────────┘
                                                                            │ index_receiver
                                                                            ▼
-                                                                 IndexState::Ready(Arc<..>)
+                                                         IndexState::Ready + ModuleGraphState::Ready
                                                                            │
                                                                  refresh_open_file_symbols()
 ```
@@ -331,9 +355,13 @@ means:
 The same trick was already in use in `build_pr_description_patch()`, and this
 follows it.
 
-`paths_receiver` / `index_receiver` / `file_receiver` / `highlight_receiver` /
-`blame_receiver` / `commit_diff_receiver` are all drained with `try_recv()` in
-`poll_browse_updates()`. The draw loop never blocks.
+`paths_receiver` / `index_receiver` / `module_graph_query_receiver` /
+`file_receiver` / `highlight_receiver` / `blame_receiver` /
+`commit_diff_receiver` are all drained with `try_recv()` in
+`poll_browse_updates()`. `index_receiver` carries the combined symbol/module
+build result, so no second parser task or graph-build channel exists. The
+separate module-graph receiver carries only request-scoped, already-projected
+panels. The draw loop never blocks.
 
 ## 4. Key-handling layers
 
@@ -341,7 +369,7 @@ At the top of `handle_repo_browse_{tree,file}_input`, input is fed through the
 layers from the top down.
 
 ```
-1. Overlays (Outline / SymbolSearch)   ← modal; consume everything while open
+1. Overlays (Outline / SymbolSearch / ModuleGraphLoading / ModuleGraph) ← modal; consume everything while open
 2. commit diff mode (file pane only)   ← blocks the source-file actions
 3. Filter input bar (tree pane only)   ← consumes all character input while open
 4. Shared by both panes (s / ? / Z / Ctrl-o)
@@ -359,6 +387,12 @@ list / diff view.
 `Ctrl-n` (clear the whole query with `Ctrl-u`). A search UI where you cannot
 type `j` is infuriating, so this is deliberate.
 
+**Input rules for the module graph overlay**: while loading, only `Esc` / the
+configured quit key cancels the request. Once ready it has no text input. `j/k`
+and arrows move, `Tab` or `h/l` switches Imports / Imported by, and `Enter`
+opens only a target represented in the original Git listing. Rows without a
+jump stay visible and report why they cannot be opened.
+
 ## 5. Keybinding registration caveats
 
 `KeybindingsConfig::validate()` detects exact duplicates between single keys and
@@ -369,10 +403,16 @@ with existing ones easily:
 - `b` … collides with `rally_background`
 - `o` … collides with `filter_open`
 - `s` … collides with `suggestion` / `git_ops_stage_all`
+- `i` … is reserved for the browser module graph and may collide with future input actions
 
-All three are dodged by registering them in `is_context_compatible()`'s
-`SCREEN_SPECIFIC_KEYS` (the treatment for "keys that are only live on their own
-screen"). When adding a key, touch all of:
+The defaults are separated by registering screen-specific actions in
+`is_context_compatible()`'s `SCREEN_SPECIFIC_KEYS`. `module_graph` is not a
+wildcard inside the browser file pane: validation explicitly rejects overlaps
+with outline, search, movement, and active browser sequence prefixes. The
+single-key ownership map retains every primary and alternative owner, and every
+multi-key alternative contributes its prefix, so an earlier action from another
+context cannot hide a later same-pane collision. When adding a key, touch all
+of:
 
 1. the `KeybindingsConfig` field
 2. the `Default` impl
@@ -446,8 +486,8 @@ double-width glyph (CJK etc.), replaces that cell with a space. When a
 double-width glyph straddles the left border, ratatui's buffer diff skips the
 next cell and the border line never reaches the terminal. The right edge needs
 no such repair: overwriting the leading cell already leaves a space in the
-continuation cell. `render_outline` (60%×70%) and `render_symbol_search`
-(80%×70%) both go through it. Any new overlay added to `src/ui/browse.rs` must
+continuation cell. `render_outline` (60%×70%), `render_symbol_search`, and
+`render_module_graph` (both 80%×70%) all go through it. Any new overlay added to `src/ui/browse.rs` must
 also use `clear_overlay_area()` rather than a bare `Clear`. A continuation cell
 is a space at the text level, so text snapshots alone cannot catch this mistake.
 Removing the repair fails
@@ -456,9 +496,20 @@ Removing the repair fails
 `overlay_rect()`'s centring and staying in bounds are verified by
 `test_overlay_rect_is_centred_and_bounded`. On 100×40, an 80%×50% rect becomes
 80×20 at (10, 10), and even on 10×4 it stays inside the terminal.
-`test_symbol_search_overlay_is_reviewably_clipped_in_a_tiny_terminal` actually
-renders the symbol search overlay at 20×5 and pins the clipped result as a
-snapshot.
+`test_symbol_search_overlay_is_reviewably_clipped_in_a_tiny_terminal` and
+`test_empty_module_graph_overlay_clips_in_a_tiny_terminal` render their overlays
+at 20×5 and pin the clipped results as snapshots.
+
+The module graph overlay never queries Hearth from the input or draw path.
+`open_browse_module_graph()` starts a request-scoped blocking task; its delivery
+converts direct and reverse results into a `ModuleGraphPanel` only if the
+request/path context is still current. Each direction retains at most 200 rows
+plus the full edge count; components are capped at 512 Unicode scalars and final
+labels at 240 terminal cells. `render_module_graph()` borrows label spans from
+only `skip(offset).take(inner_height)`, preserving O(viewport) redraw cost even
+when the repository graph is large. Hearth 0.1.1 still materializes and sorts all
+matching edges inside the blocking task before octorus can truncate them; see
+[module-graph.md](module-graph.md).
 
 ## 7. Tests
 
@@ -471,10 +522,12 @@ is "where are the tests for what", so that table stays:
 
 | Where | What |
 |-------|------|
-| `src/app/browse.rs` | `git ls-files` parsing, pseudo-patch conversion, tree, filter, cursor/scroll, file loading and its cancellation |
+| `src/app/browse.rs` | `git ls-files` parsing, pseudo-patch conversion, tree, filter, cursor/scroll, file loading/cancellation, graph query failure/high-fan/label bounds |
 | `src/symbols.rs` | Hearth-registry extraction snapshots, compatibility boundaries (including C macro merging, empty files, duplicate paths, CJK and checked conversion), projected index refs, search, and build cancellation |
-| `src/ui/browse.rs` | inline rendering snapshots, tiny-terminal clipping, wide-glyph border repair |
-| `src/app/input_browse.rs` | **scenario tests** (tree navigation → open → scroll → back, filter → cancel, outline → jump → back, etc.) |
+| `src/code_index.rs` | one-pass combined symbol/import result and cancellation |
+| `src/module_graph.rs` | JS/TS/Rust import extraction and resolution, listed non-source navigation, path projection, direct/reverse guarantees, cancellation |
+| `src/ui/browse.rs` | inline rendering snapshots, graph loading/outgoing/incoming/truncated/long-CJK/empty/tiny states, wide-glyph border repair |
+| `src/app/input_browse.rs` | **scenario tests** (tree navigation, outline/search, graph cancel/stale/CJK JSON/empty/switch/jump/back, blame/history) |
 | `src/main.rs` | the flag set allowed to start without a repository (including `--browse`) |
 | `tests/cli.rs` | e2e launching the binary via `assert_cmd` (non-git directory, git repo without a GitHub remote) |
 
@@ -544,7 +597,10 @@ source — but that is not the default procedure.
 | No horizontal scrolling | Long lines are cut off | Add horizontal scroll to ratatui's `Paragraph` |
 | No intra-line wrapping | Same as above | Wrapping makes cursor-line arithmetic visual-line-based (the same problem as `pr_description`) |
 | `gd` jumps to the first identifier that resolves | Columns are ignored; identifiers are scanned from the start of the line, minus duplicates and common keywords. For `foo.bar()`, if `foo` has a definition it jumps there, otherwise it tries `bar` | Show the existing `SymbolPopupState` when there are several candidates |
-| symbol references unimplemented | The `@reference.*` captures present in the queries are dropped at extraction, because `SymbolKind::from_capture` handles only `definition.`. C/C++/Swift and the 6 queries bundled in the repo have no such captures at all | Rust/TS/JS/Go/Python/Ruby/Java/Lua/PHP can extend the same machinery with their existing captures. C/C++/Swift and the bundled `c_sharp`/`zig`/`bash`/`haskell`/`moonbit`/`markdown` need query extensions; until then support would cover only a subset of languages. `gr` is already taken by `open_line_discussion` (line-anchored review comments), so the feature also needs a different default key |
+| symbol references unimplemented | The `@reference.*` captures present in the tags queries are still dropped; the module graph models file imports, not arbitrary symbol references | Keep import navigation file-level, or add a separate reference index with explicit per-language coverage |
+| Module graph is built once | Imports and resolver configuration become stale after external edits; no watcher-driven upsert or re-resolution exists | Re-analyze changed files and use Hearth incremental graph APIs; clear resolver caches when config dependencies change |
+| Rust graph answers are approximate | Hearth 0.1.1 does not model Cargo targets, `cfg`, `#[path]`, macros, or inline modules completely | Supply Cargo metadata and a declaration-tree model upstream |
+| Only a root JS config is selected explicitly | Complex workspaces may need package-local tsconfig policy beyond current `oxc_resolver` behavior | Discover project configs and define deterministic ownership before building resolvers |
 | Only one file-contents cache | Going through `OpenLoad` keeps the UI thread free, but every revisit re-reads the whole file | Give it an LRU like `DiffCacheStore` |
 | `o` / `s` / `gd` keep saying "building" after a failed index build | All three test `index.ready().is_none()`, so `IndexState::Failed` falls into the same branch. The header shows `symbols: unavailable` in red, so two places on the same screen disagree | Match on `IndexState` in the footer too, and on `Failed` show the actual failure reason held in `BrowseState::status` |
 
@@ -669,7 +725,11 @@ test fails. Maintain this mapping when editing.
 
 - **A new overlay**: add a variant to `BrowseOverlay` and fill in the matches in
   `handle_browse_overlay_input` and `render_overlay`. The compiler reports what
-  you missed
+  you missed. Precompute graph-sized data before opening; rendering should own
+  only viewport work
+- **A new import language**: register its `ImportSpec` and resolver in Hearth or
+  the host registry, add facade projection/guarantee tests, and update
+  [module-graph.md](module-graph.md). Never infer exactness in the UI
 - **A new in-pane action**: add a `matches_single_key` branch to
   `handle_repo_browse_file_input`. The borrow of `self` and the mutable borrow
   of `browse_state` collide, so **decide into a bool first, then take the

--- a/docs/symbol-index.md
+++ b/docs/symbol-index.md
@@ -30,7 +30,7 @@ src/symbols.rs compatibility conversion
 Vec<octorus::symbols::Symbol>
 ```
 
-Repository construction follows the same boundary:
+The public symbols-only compatibility build follows the same boundary:
 
 ```text
 repo root + paths + local CancelSignal
@@ -46,6 +46,14 @@ Hearth SymbolIndex + octorus projection
     ├─ search(query, limit)
     └─ file_symbols(path)
 ```
+
+The Repository Browser itself uses `src/code_index.rs` instead: one
+`hearth_graph::analyze_paths` pass extracts symbols and imports from the same
+syntax trees, then feeds `SymbolIndex::from_analyses_cancellable` and the module
+graph.
+Never replace that path with separate `build_index` + `analyze_paths` calls;
+that would parse the repository twice. Import ownership and guarantees are in
+[`module-graph.md`](module-graph.md).
 
 The facade deliberately prevents Hearth storage choices from leaking into
 browser state, tests, or benchmarks. The previously public
@@ -154,8 +162,10 @@ queries. It now also contains a `hearth_graph::ParserPool<'static>` tied to the
 static symbol registry. `extract_symbols` borrows that cache rather than
 constructing a registry, parser, or query for each call.
 
-Repository builds use Hearth's worker-local parser pools. They remain blocking
-and CPU-bound and must be called from `spawn_blocking`, never from the draw loop.
+Repository builds use Hearth's worker-local parser pools. Both the public
+symbols-only build and the Browser's combined symbol/import build remain
+blocking and CPU-bound and must be called from `spawn_blocking`, never from the
+draw loop.
 
 ## 5. Extraction behavior and grammar quirks
 
@@ -249,6 +259,11 @@ Outcomes remain `Completed`, `Cancelled { scanned_files }`, and
 `Failed { message }`. Unsupported, oversized, missing, and unreadable individual
 files are skipped. Root verification and worker panics are failures.
 
+`CodeIndex::build_cancellable` adapts the same local cancellation seam to
+`analyze_paths`. It polls cancellation again while folding completed analyses
+into graph nodes. Cancellation at either stage publishes neither index; the UI
+channel has no partial-result variant.
+
 ## 8. Intentional compatibility differences
 
 These differences are accepted by issue #177 and must remain explicit:
@@ -283,6 +298,10 @@ Run:
 ```bash
 cargo bench --bench symbol_index
 ```
+
+The Browser's combined parse/build boundary and module queries are measured
+separately by `benches/module_graph.rs`; see
+[`module-graph.md`](module-graph.md#7-performance).
 
 Historic timings from the octorus-owned implementation are not baseline values
 for the facade because conversion and projection changed the measured boundary.

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -19,13 +19,17 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
+use crate::code_index::{CodeIndex, CodeIndexBuild};
 use crate::diff_store::{DiffScrollState, ScrollMode};
 use crate::filter::ListFilter;
 use crate::github::{
     blame_file, BlameError, BlameFile, BlameRef, CommitPrLookupError, CommitPrResolution,
     CommitPullRequest,
 };
-use crate::symbols::{CancelSignal, IndexBuild, Symbol, SymbolIndex, SymbolRef};
+use crate::module_graph::{
+    DependencyGuarantee, DependencyResult, DependencyTarget, ModuleGraph, SourceUniverse,
+};
+use crate::symbols::{CancelSignal, Symbol, SymbolIndex, SymbolRef};
 use crate::syntax::ParserPool;
 use crate::ui::common::truncate_with_width;
 
@@ -70,6 +74,14 @@ fn admit_commit_diff_for_cache(diff_text: String) -> Result<String, String> {
         Ok(diff_text)
     }
 }
+
+/// Maximum rows retained per direction in the module-graph overlay.
+///
+/// Hearth 0.1.1 materializes the full sorted query result, but bounding the
+/// octorus projection prevents unbounded labels and UI state for high fan-in.
+pub const MAX_MODULE_GRAPH_RESULTS: usize = 200;
+const MAX_MODULE_GRAPH_LABEL_WIDTH: usize = 240;
+const MAX_MODULE_GRAPH_COMPONENT_CHARS: usize = 512;
 
 /// Maximum rows shown in the symbol search overlay.
 pub const MAX_SYMBOL_SEARCH_RESULTS: usize = 200;
@@ -142,6 +154,26 @@ impl App {
         let mut completed_pr_lookup = None;
         let mut completed_line_discussion = None;
 
+        let module_graph_context_moved = match &state.overlay {
+            BrowseOverlay::ModuleGraphLoading { path, .. } => {
+                !browse_file_active
+                    || state
+                        .open
+                        .as_ref()
+                        .is_none_or(|open| open.path.as_str() != path)
+            }
+            BrowseOverlay::None
+            | BrowseOverlay::Outline { .. }
+            | BrowseOverlay::SymbolSearch { .. }
+            | BrowseOverlay::ModuleGraph(_) => false,
+        };
+        if module_graph_context_moved {
+            state.cancel_module_graph_query();
+            state.overlay = BrowseOverlay::None;
+            state.status =
+                Some("Dependency query abandoned because the open file changed".to_string());
+        }
+
         if let PrLookupState::Loading { .. } = &state.pr_lookup {
             if !browse_file_active || !state.pr_lookup_matches_current_context() {
                 state.cancel_pr_lookup_request();
@@ -170,6 +202,7 @@ impl App {
                     state.paths_receiver = None;
                     state.listing_status = repository_listing_status(&listing);
                     state.status = state.listing_status.clone();
+                    state.source_universe = listing.source_universe();
                     state.set_paths(listing.paths);
                     paths_ready = true;
                 }
@@ -193,14 +226,17 @@ impl App {
 
         if let Some(rx) = state.index_receiver.as_mut() {
             match rx.try_recv() {
-                Ok(IndexDelivery::Ready(index)) => {
+                Ok(IndexDelivery::Ready(code)) => {
                     state.index_receiver = None;
-                    state.index = IndexState::Ready(Arc::new(index));
+                    let CodeIndex { symbols, modules } = *code;
+                    state.index = IndexState::Ready(Arc::new(symbols));
+                    state.module_graph = ModuleGraphState::Ready(Arc::new(modules));
                     state.refresh_open_file_symbols();
                 }
                 Ok(IndexDelivery::Failed(message)) => {
                     state.index_receiver = None;
                     state.index = IndexState::Failed;
+                    state.module_graph = ModuleGraphState::Failed;
                     state.status = Some(message);
                 }
                 Err(mpsc::error::TryRecvError::Empty) => {}
@@ -208,7 +244,43 @@ impl App {
                     state.index_receiver = None;
                     if !state.cancel_token.is_cancelled() {
                         state.index = IndexState::Failed;
-                        state.status = Some("symbol indexing task ended".to_string());
+                        state.module_graph = ModuleGraphState::Failed;
+                        state.status = Some("code indexing task ended".to_string());
+                    }
+                }
+            }
+        }
+
+        if let Some(rx) = state.module_graph_query_receiver.as_mut() {
+            match rx.try_recv() {
+                Ok(delivery) => {
+                    state.module_graph_query_receiver = None;
+                    state.module_graph_query_cancel = None;
+                    let current = matches!(
+                        &state.overlay,
+                        BrowseOverlay::ModuleGraphLoading { request_id, path }
+                            if *request_id == delivery.request_id && path == &delivery.path
+                    ) && state
+                        .open
+                        .as_ref()
+                        .is_some_and(|open| open.path == delivery.path);
+                    if current {
+                        state.status = None;
+                        state.overlay = BrowseOverlay::ModuleGraph(delivery.panel);
+                    }
+                }
+                Err(mpsc::error::TryRecvError::Empty) => {}
+                Err(mpsc::error::TryRecvError::Disconnected) => {
+                    state.module_graph_query_receiver = None;
+                    let cancelled = state
+                        .module_graph_query_cancel
+                        .take()
+                        .is_some_and(|cancel| cancel.is_cancelled());
+                    if !cancelled
+                        && matches!(state.overlay, BrowseOverlay::ModuleGraphLoading { .. })
+                    {
+                        state.overlay = BrowseOverlay::None;
+                        state.status = Some("Dependency query task ended".to_string());
                     }
                 }
             }
@@ -501,7 +573,7 @@ impl App {
         }
     }
 
-    /// Kick off the repository-wide symbol index on a background thread.
+    /// Kick off one repository-wide symbol/import analysis on a background thread.
     fn start_symbol_index_build(&mut self) {
         let Some(state) = self.browse_state.as_mut() else {
             return;
@@ -514,24 +586,28 @@ impl App {
         // reuse installs no second receiver. A second build therefore cannot
         // start within one state today, and this guard keeps that invariant
         // safe if refresh support is added later.
-        if matches!(state.index, IndexState::Building) {
+        if matches!(state.index, IndexState::Building)
+            || matches!(state.module_graph, ModuleGraphState::Building)
+        {
             return;
         }
 
         let paths = paths.clone();
         let repo_root = state.repo_root.clone();
+        let universe = state.source_universe;
         let (tx, rx) = mpsc::channel(1);
         state.index = IndexState::Building;
+        state.module_graph = ModuleGraphState::Building;
         state.index_receiver = Some(rx);
         let cancel_token = state.cancel_token.clone();
 
         tokio::task::spawn_blocking(move || {
-            match SymbolIndex::build_cancellable(&repo_root, &paths, &cancel_token) {
-                IndexBuild::Completed(index) => {
-                    let _ = tx.blocking_send(IndexDelivery::Ready(index));
+            match CodeIndex::build_cancellable(&repo_root, &paths, universe, &cancel_token) {
+                CodeIndexBuild::Completed(code) => {
+                    let _ = tx.blocking_send(IndexDelivery::Ready(code));
                 }
-                IndexBuild::Cancelled { .. } => {}
-                IndexBuild::Failed { message } => {
+                CodeIndexBuild::Cancelled { .. } => {}
+                CodeIndexBuild::Failed { message } => {
                     let _ = tx.blocking_send(IndexDelivery::Failed(message));
                 }
             }
@@ -1658,6 +1734,25 @@ impl IndexState {
     }
 }
 
+/// Lifecycle of the repository module graph built in the symbol analysis pass.
+#[derive(Debug, Default)]
+pub enum ModuleGraphState {
+    #[default]
+    Idle,
+    Building,
+    Ready(Arc<ModuleGraph>),
+    Failed,
+}
+
+impl ModuleGraphState {
+    pub fn ready(&self) -> Option<&ModuleGraph> {
+        match self {
+            Self::Ready(graph) => Some(graph),
+            Self::Idle | Self::Building | Self::Failed => None,
+        }
+    }
+}
+
 /// Lifecycle of the blame annotation for the open browser file.
 #[derive(Debug, Default)]
 pub(crate) enum BlameState {
@@ -2019,6 +2114,61 @@ impl OpenFile {
     }
 }
 
+/// Direction shown by the module-graph overlay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModuleGraphDirection {
+    Dependencies,
+    Dependents,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleGraphJump {
+    pub path: String,
+    pub line: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleGraphRow {
+    pub label: String,
+    pub jump: Option<ModuleGraphJump>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleGraphRows {
+    pub rows: Vec<ModuleGraphRow>,
+    pub total: usize,
+    pub guarantee: DependencyGuarantee,
+}
+
+/// Precomputed dependency rows; drawing never walks the graph.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModuleGraphPanel {
+    pub direction: ModuleGraphDirection,
+    pub selected: usize,
+    pub dependencies: ModuleGraphRows,
+    pub dependents: ModuleGraphRows,
+}
+
+impl ModuleGraphPanel {
+    pub fn current(&self) -> &ModuleGraphRows {
+        match self.direction {
+            ModuleGraphDirection::Dependencies => &self.dependencies,
+            ModuleGraphDirection::Dependents => &self.dependents,
+        }
+    }
+
+    pub fn current_rows(&self) -> &[ModuleGraphRow] {
+        &self.current().rows
+    }
+
+    pub fn set_direction(&mut self, direction: ModuleGraphDirection) {
+        self.direction = direction;
+        self.selected = self
+            .selected
+            .min(self.current_rows().len().saturating_sub(1));
+    }
+}
+
 /// Which overlay is on top of the browser, if any.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub enum BrowseOverlay {
@@ -2028,6 +2178,10 @@ pub enum BrowseOverlay {
     Outline { selected: usize },
     /// Repository-wide fuzzy symbol search.
     SymbolSearch { query: String, selected: usize },
+    /// A request-scoped dependency panel build running off the UI thread.
+    ModuleGraphLoading { request_id: u64, path: String },
+    /// Direct imports and reverse dependencies of the open file.
+    ModuleGraph(ModuleGraphPanel),
 }
 
 /// Lifecycle of the file currently being opened.
@@ -2061,6 +2215,12 @@ pub(crate) struct CommitDiffLoadResult {
     request_id: u64,
     sha: String,
     result: Result<DiffCache, String>,
+}
+
+pub(crate) struct ModuleGraphPanelDelivery {
+    request_id: u64,
+    path: String,
+    panel: ModuleGraphPanel,
 }
 
 pub(crate) struct PrLookupLoadResult {
@@ -2208,7 +2368,7 @@ fn deliver_highlighted_cache<F>(
 /// `IndexBuild::Cancelled` is deliberately absent: a cancelled build sends
 /// nothing at all, so it cannot be observed here.
 pub(crate) enum IndexDelivery {
-    Ready(SymbolIndex),
+    Ready(Box<CodeIndex>),
     Failed(String),
 }
 
@@ -2232,6 +2392,10 @@ pub struct BrowseState {
     pub cursor_line: usize,
     pub scroll_offset: usize,
     pub index: IndexState,
+    pub module_graph: ModuleGraphState,
+    module_graph_query_generation: u64,
+    module_graph_query_cancel: Option<CancellationToken>,
+    pub source_universe: SourceUniverse,
     pub overlay: BrowseOverlay,
     pub jump_stack: Vec<BrowseJump>,
     /// Transient message shown in the footer (unreadable file, no definition, …).
@@ -2247,6 +2411,7 @@ pub struct BrowseState {
     pub return_state: AppState,
     pub(crate) paths_receiver: Option<mpsc::Receiver<Result<RepositoryFiles, String>>>,
     pub(crate) index_receiver: Option<mpsc::Receiver<IndexDelivery>>,
+    pub(crate) module_graph_query_receiver: Option<mpsc::Receiver<ModuleGraphPanelDelivery>>,
     pub(crate) file_receiver: Option<mpsc::Receiver<FileLoadResult>>,
     pub(crate) blame_receiver: Option<mpsc::Receiver<BlameLoadResult>>,
     pub(crate) commit_diff_receiver: Option<mpsc::Receiver<CommitDiffLoadResult>>,
@@ -2286,6 +2451,10 @@ impl BrowseState {
             cursor_line: 0,
             scroll_offset: 0,
             index: IndexState::Idle,
+            module_graph: ModuleGraphState::Idle,
+            module_graph_query_generation: 0,
+            module_graph_query_cancel: None,
+            source_universe: SourceUniverse::Partial,
             overlay: BrowseOverlay::None,
             jump_stack: Vec::new(),
             status: None,
@@ -2293,6 +2462,7 @@ impl BrowseState {
             return_state,
             paths_receiver: None,
             index_receiver: None,
+            module_graph_query_receiver: None,
             file_receiver: None,
             blame_receiver: None,
             commit_diff_receiver: None,
@@ -2300,6 +2470,44 @@ impl BrowseState {
             line_discussion_receiver: None,
             highlight_receiver: None,
         }
+    }
+
+    pub(crate) fn start_module_graph_query(&mut self, path: String, graph: Arc<ModuleGraph>) {
+        self.cancel_module_graph_query();
+        self.module_graph_query_generation = self.module_graph_query_generation.wrapping_add(1);
+        let request_id = self.module_graph_query_generation;
+        let cancel = self.cancel_token.child_token();
+        let task_cancel = cancel.clone();
+        let task_path = path.clone();
+        let (tx, rx) = mpsc::channel(1);
+        self.module_graph_query_cancel = Some(cancel);
+        self.module_graph_query_receiver = Some(rx);
+        self.overlay = BrowseOverlay::ModuleGraphLoading { request_id, path };
+
+        tokio::task::spawn_blocking(move || {
+            let Some(panel) = build_module_graph_panel(&graph, &task_path, &task_cancel) else {
+                return;
+            };
+            if !task_cancel.is_cancelled() {
+                let _ = tx.blocking_send(ModuleGraphPanelDelivery {
+                    request_id,
+                    path: task_path,
+                    panel,
+                });
+            }
+        });
+    }
+
+    pub(crate) fn cancel_module_graph_query(&mut self) {
+        if let Some(cancel) = self.module_graph_query_cancel.take() {
+            cancel.cancel();
+        }
+        self.module_graph_query_receiver = None;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn module_graph_query_token(&self) -> Option<CancellationToken> {
+        self.module_graph_query_cancel.clone()
     }
 
     fn cancel_blame_request(&mut self) {
@@ -2614,6 +2822,132 @@ impl BrowseState {
     }
 }
 
+fn build_module_graph_panel(
+    graph: &ModuleGraph,
+    path: &str,
+    cancel: &dyn CancelSignal,
+) -> Option<ModuleGraphPanel> {
+    let (dependencies, dependencies_total) =
+        graph.dependencies_bounded(path, MAX_MODULE_GRAPH_RESULTS)?;
+    if cancel.is_cancelled() {
+        return None;
+    }
+    let dependencies = module_graph_rows(
+        graph,
+        dependencies,
+        dependencies_total,
+        ModuleGraphDirection::Dependencies,
+        cancel,
+    )?;
+    let (dependents, dependents_total) =
+        graph.dependents_bounded(path, MAX_MODULE_GRAPH_RESULTS)?;
+    if cancel.is_cancelled() {
+        return None;
+    }
+    let dependents = module_graph_rows(
+        graph,
+        dependents,
+        dependents_total,
+        ModuleGraphDirection::Dependents,
+        cancel,
+    )?;
+    Some(ModuleGraphPanel {
+        direction: ModuleGraphDirection::Dependencies,
+        selected: 0,
+        dependencies,
+        dependents,
+    })
+}
+
+fn module_graph_rows(
+    graph: &ModuleGraph,
+    result: DependencyResult,
+    total: usize,
+    direction: ModuleGraphDirection,
+    cancel: &dyn CancelSignal,
+) -> Option<ModuleGraphRows> {
+    let guarantee = result.guarantee;
+    let mut rows = Vec::with_capacity(result.edges.len());
+    for (index, edge) in result.edges.into_iter().enumerate() {
+        if index.is_multiple_of(64) && cancel.is_cancelled() {
+            return None;
+        }
+        let row = match direction {
+            ModuleGraphDirection::Dependencies => {
+                let specifier = bounded_module_graph_text(&edge.specifier);
+                let (target, jump) = match edge.target {
+                    DependencyTarget::Path(path) => {
+                        let jump = graph.is_listed(&path).then(|| ModuleGraphJump {
+                            path: path.clone(),
+                            line: 0,
+                        });
+                        (bounded_module_graph_text(&path), jump)
+                    }
+                    DependencyTarget::External(package) => (
+                        format!("package {}", bounded_module_graph_text(&package)),
+                        None,
+                    ),
+                    DependencyTarget::Unresolved(reason) => (
+                        format!("unresolved ({})", bounded_module_graph_text(&reason)),
+                        None,
+                    ),
+                };
+                ModuleGraphRow {
+                    label: bounded_module_graph_text(&format!(
+                        "[{}] {} → {}  :{}",
+                        edge.kind.label(),
+                        specifier,
+                        target,
+                        edge.line
+                    )),
+                    jump,
+                }
+            }
+            ModuleGraphDirection::Dependents => {
+                let from = bounded_module_graph_text(&edge.from);
+                let specifier = bounded_module_graph_text(&edge.specifier);
+                ModuleGraphRow {
+                    label: bounded_module_graph_text(&format!(
+                        "[{}] {}:{}  {}",
+                        edge.kind.label(),
+                        from,
+                        edge.line,
+                        specifier
+                    )),
+                    jump: graph.is_listed(&edge.from).then(|| ModuleGraphJump {
+                        path: edge.from,
+                        line: edge.line.saturating_sub(1),
+                    }),
+                }
+            }
+        };
+        rows.push(row);
+    }
+    Some(ModuleGraphRows {
+        rows,
+        total,
+        guarantee,
+    })
+}
+
+pub(crate) fn bounded_module_graph_text(text: &str) -> String {
+    let end = text
+        .char_indices()
+        .nth(MAX_MODULE_GRAPH_COMPONENT_CHARS)
+        .map_or(text.len(), |(index, _)| index);
+    let character_truncated = end < text.len();
+    if character_truncated {
+        let mut marked = String::with_capacity(end + '…'.len_utf8());
+        marked.push_str(&text[..end]);
+        if !marked.ends_with('…') {
+            marked.push('…');
+        }
+        truncate_with_width(&marked, MAX_MODULE_GRAPH_LABEL_WIDTH).into_owned()
+    } else {
+        truncate_with_width(&text[..end], MAX_MODULE_GRAPH_LABEL_WIDTH).into_owned()
+    }
+}
+
 /// A bounded repository file listing plus its full de-duplicated size.
 #[derive(Debug, PartialEq, Eq)]
 pub struct RepositoryFiles {
@@ -2622,6 +2956,16 @@ pub struct RepositoryFiles {
     pub total: usize,
     /// Invalid UTF-8 paths omitted because the browser stores openable paths as `String`.
     pub skipped_non_utf8: usize,
+}
+
+impl RepositoryFiles {
+    pub fn source_universe(&self) -> SourceUniverse {
+        if self.total == self.paths.len() && self.skipped_non_utf8 == 0 {
+            SourceUniverse::Complete
+        } else {
+            SourceUniverse::Partial
+        }
+    }
 }
 
 /// List the repository's files: tracked plus untracked-but-not-ignored.
@@ -3311,6 +3655,111 @@ mod tests {
 
         assert_eq!(state.tree.row_count(), 0);
         assert!(state.selected_path().is_none());
+    }
+
+    #[test]
+    fn test_module_graph_labels_are_bounded_by_unicode_display_width() {
+        let bounded = bounded_module_graph_text(&"依存先".repeat(1_000));
+
+        assert!(
+            unicode_width::UnicodeWidthStr::width(bounded.as_str()) <= MAX_MODULE_GRAPH_LABEL_WIDTH
+        );
+        assert!(bounded.ends_with('…'));
+        assert!(bounded.chars().count() <= MAX_MODULE_GRAPH_COMPONENT_CHARS + 1);
+    }
+
+    #[test]
+    fn test_module_graph_label_reserves_width_for_a_character_cap_ellipsis() {
+        let text = format!("[import] {}{}tail", "a".repeat(231), "\u{301}".repeat(272));
+        let bounded = bounded_module_graph_text(&text);
+        let width = unicode_width::UnicodeWidthStr::width(bounded.as_str());
+
+        assert!(width <= MAX_MODULE_GRAPH_LABEL_WIDTH);
+        assert!(bounded.ends_with('…'));
+        insta::assert_snapshot!(format!("width={width} suffix={}", bounded.ends_with('…')), @"width=240 suffix=true");
+    }
+
+    struct CancelDuringPanelRows {
+        polls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl CancelSignal for CancelDuringPanelRows {
+        fn is_cancelled(&self) -> bool {
+            self.polls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) >= 2
+        }
+    }
+
+    #[test]
+    fn test_high_fan_in_panel_retains_the_limit_and_preserves_the_total() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/center.ts"),
+            "export const center = 1;\n",
+        )
+        .unwrap();
+        let mut paths = vec!["src/center.ts".to_string()];
+        for index in 0..250 {
+            let path = format!("src/importer_{index:03}.ts");
+            std::fs::write(
+                dir.path().join(&path),
+                format!("import './center';\nexport const value{index} = {index};\n"),
+            )
+            .unwrap();
+            paths.push(path);
+        }
+        let CodeIndexBuild::Completed(index) = CodeIndex::build_cancellable(
+            dir.path(),
+            &paths,
+            SourceUniverse::Complete,
+            &CancellationToken::new(),
+        ) else {
+            panic!("high fan-in fixture must build");
+        };
+
+        let cancel_during_rows = CancelDuringPanelRows {
+            polls: std::sync::atomic::AtomicUsize::new(0),
+        };
+        assert!(
+            build_module_graph_panel(&index.modules, "src/center.ts", &cancel_during_rows)
+                .is_none(),
+            "row projection ignored cancellation"
+        );
+        assert_eq!(
+            cancel_during_rows
+                .polls
+                .load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "cancellation must occur at the first dependent-row poll"
+        );
+
+        let mut panel =
+            build_module_graph_panel(&index.modules, "src/center.ts", &CancellationToken::new())
+                .expect("panel");
+
+        assert_eq!(panel.dependents.total, 250);
+        assert_eq!(panel.dependents.rows.len(), MAX_MODULE_GRAPH_RESULTS);
+        assert!(panel
+            .dependents
+            .rows
+            .iter()
+            .all(
+                |row| unicode_width::UnicodeWidthStr::width(row.label.as_str())
+                    <= MAX_MODULE_GRAPH_LABEL_WIDTH,
+            ));
+
+        panel.set_direction(ModuleGraphDirection::Dependents);
+        let mut app = App::new_for_test();
+        let mut state = BrowseState::new(dir.path().to_path_buf(), AppState::FileList);
+        state.set_paths(paths);
+        state.overlay = BrowseOverlay::ModuleGraph(panel);
+        app.browse_state = Some(state);
+        app.state = AppState::RepoBrowseFile;
+        let rendered = render_at(&mut app, 80, 12);
+        assert!(
+            rendered.contains("Imported by (200/250 edges shown, exact)"),
+            "{rendered}"
+        );
     }
 
     // ===== cursor and scrolling =====
@@ -6390,16 +6839,39 @@ mod tests {
         let mut state = BrowseState::new(PathBuf::from("/repo"), AppState::FileList);
         let (tx, rx) = mpsc::channel(1);
         state.index = IndexState::Building;
+        state.module_graph = ModuleGraphState::Building;
         state.index_receiver = Some(rx);
         app.browse_state = Some(state);
         drop(tx);
 
         app.poll_browse_updates();
 
-        assert!(matches!(
-            app.browse_state.as_ref().unwrap().index,
-            IndexState::Failed
-        ));
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(state.index, IndexState::Failed));
+        assert!(matches!(state.module_graph, ModuleGraphState::Failed));
+    }
+
+    #[test]
+    fn test_poll_browse_updates_reports_a_disconnected_module_graph_query() {
+        let mut app = App::new_for_test();
+        let mut state = state_with_open_file(1);
+        let (tx, rx) = mpsc::channel::<ModuleGraphPanelDelivery>(1);
+        state.module_graph_query_receiver = Some(rx);
+        state.module_graph_query_cancel = Some(CancellationToken::new());
+        state.overlay = BrowseOverlay::ModuleGraphLoading {
+            request_id: 9,
+            path: "src/a.rs".to_string(),
+        };
+        app.browse_state = Some(state);
+        app.state = AppState::RepoBrowseFile;
+        drop(tx);
+
+        app.poll_browse_updates();
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert_eq!(state.status.as_deref(), Some("Dependency query task ended"));
+        assert!(state.module_graph_query_receiver.is_none());
     }
 
     #[tokio::test]
@@ -6423,6 +6895,7 @@ mod tests {
 
         let state = app.browse_state.as_ref().unwrap();
         assert!(matches!(state.index, IndexState::Failed));
+        assert!(matches!(state.module_graph, ModuleGraphState::Failed));
         let message = state.status.as_deref().expect("failure reason in footer");
         assert!(message.contains("cannot build symbol index"), "{message}");
         assert!(message.contains("removed-worktree"), "{message}");
@@ -6457,6 +6930,80 @@ mod tests {
             panic!("completed build must become ready");
         };
         assert!(!index.search("searchable_alpha", 10).is_empty());
+    }
+
+    #[test]
+    fn test_repository_listing_completeness_controls_graph_universe() {
+        assert_eq!(
+            RepositoryFiles {
+                paths: vec!["src/app.ts".to_string()],
+                total: 1,
+                skipped_non_utf8: 0,
+            }
+            .source_universe(),
+            crate::module_graph::SourceUniverse::Complete
+        );
+        assert_eq!(
+            RepositoryFiles {
+                paths: vec!["src/app.ts".to_string()],
+                total: 2,
+                skipped_non_utf8: 0,
+            }
+            .source_universe(),
+            crate::module_graph::SourceUniverse::Partial
+        );
+        assert_eq!(
+            RepositoryFiles {
+                paths: vec!["src/app.ts".to_string()],
+                total: 1,
+                skipped_non_utf8: 1,
+            }
+            .source_universe(),
+            crate::module_graph::SourceUniverse::Partial
+        );
+    }
+
+    #[tokio::test]
+    async fn test_combined_index_build_makes_symbols_and_module_graph_ready_together() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        std::fs::write(
+            dir.path().join("src/app.ts"),
+            "import { helper } from './helper';\nexport function app() { return helper(); }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            dir.path().join("src/helper.ts"),
+            "export function helper() { return 1; }\n",
+        )
+        .unwrap();
+        let mut app = App::new_for_test();
+        let mut state = BrowseState::new(dir.path().to_path_buf(), AppState::FileList);
+        let (tx, rx) = mpsc::channel(1);
+        state.paths_receiver = Some(rx);
+        app.browse_state = Some(state);
+        tx.send(Ok(RepositoryFiles {
+            paths: vec!["src/app.ts".to_string(), "src/helper.ts".to_string()],
+            total: 2,
+            skipped_non_utf8: 0,
+        }))
+        .await
+        .unwrap();
+
+        settle_index(&mut app).await;
+
+        let state = app.browse_state.as_ref().unwrap();
+        let IndexState::Ready(symbols) = &state.index else {
+            panic!("symbols must become ready");
+        };
+        assert!(!symbols.search("helper", 10).is_empty());
+        let ModuleGraphState::Ready(modules) = &state.module_graph else {
+            panic!("module graph must become ready with symbols");
+        };
+        assert_eq!(
+            modules.dependencies("src/app.ts").unwrap().edges[0].target,
+            crate::module_graph::DependencyTarget::Path("src/helper.ts".to_string())
+        );
     }
 
     #[tokio::test]
@@ -6517,8 +7064,14 @@ mod tests {
                 depth: 0,
             }],
         }]);
+        let injected_code = CodeIndex {
+            symbols: injected_index,
+            modules: ModuleGraph::default(),
+        };
         assert!(
-            tx.send(IndexDelivery::Ready(injected_index)).await.is_ok(),
+            tx.send(IndexDelivery::Ready(Box::new(injected_code)))
+                .await
+                .is_ok(),
             "starting a second build must not replace and disconnect the in-flight receiver"
         );
         app.poll_browse_updates();

--- a/src/app/input_browse.rs
+++ b/src/app/input_browse.rs
@@ -1,18 +1,23 @@
 //! Key handling for the Repository Browser.
 //!
-//! Two focus states (tree / file) plus two overlays (outline / symbol search).
+//! Two focus states (tree / file) plus modal outline, search, and module overlays.
 //! Overlays are checked first so they behave as modal layers rather than as an
 //! extra set of conditionals sprinkled through the pane handlers.
 
 use anyhow::Result;
 use crossterm::event::{self, KeyCode, KeyModifiers};
 use ratatui::{backend::CrosstermBackend, Terminal};
+#[cfg(test)]
+use ratatui::{layout::Rect, TerminalOptions, Viewport};
 use std::io::Stdout;
 
 use crate::filter::ListFilter;
 use crate::keybinding::{event_to_keybinding, SequenceMatch};
 
-use super::browse::{BrowseCommitDiffState, BrowseOverlay, IndexState, PrLookupState};
+use super::browse::{
+    BrowseCommitDiffState, BrowseOverlay, IndexState, ModuleGraphDirection, ModuleGraphState,
+    PrLookupState,
+};
 use super::browse_discussion::{DiscussionView, LineDiscussionState};
 use super::{App, AppState, PrOpenSource};
 
@@ -135,6 +140,10 @@ impl App {
 
         if self.matches_single_key(&key, &kb.symbol_outline) {
             self.open_browse_outline();
+            return Ok(());
+        }
+        if self.matches_single_key(&key, &kb.module_graph) {
+            self.open_browse_module_graph();
             return Ok(());
         }
 
@@ -393,6 +402,11 @@ impl App {
                 self.open_browse_line_discussion();
                 return Ok(true);
             }
+            if self.try_match_sequence(&kb.module_graph) == SequenceMatch::Full {
+                self.clear_pending_keys();
+                self.open_browse_module_graph();
+                return Ok(true);
+            }
             if self.try_match_sequence(&kb.go_to_definition) == SequenceMatch::Full {
                 self.clear_pending_keys();
                 self.browse_run_go_to_definition();
@@ -419,6 +433,8 @@ impl App {
             || self.key_could_match_sequence(key, &kb.open_blame_commit)
             || self.key_could_match_sequence(key, &kb.open_blame_pr)
             || self.key_could_match_sequence(key, &kb.open_line_discussion)
+            || (!kb.module_graph.is_single()
+                && self.key_could_match_sequence(key, &kb.module_graph))
             || self.key_could_match_sequence(key, &kb.go_to_definition)
             || self.key_could_match_sequence(key, &kb.go_to_file)
             || self.key_could_match_sequence(key, &kb.jump_to_first);
@@ -640,6 +656,10 @@ impl App {
                 self.handle_browse_symbol_search_input(key);
                 true
             }
+            BrowseOverlay::ModuleGraphLoading { .. } | BrowseOverlay::ModuleGraph(_) => {
+                self.handle_browse_module_graph_input(key);
+                true
+            }
         }
     }
 
@@ -743,6 +763,101 @@ impl App {
         }
 
         state.clamp_symbol_search_selection();
+    }
+
+    fn handle_browse_module_graph_input(&mut self, key: event::KeyEvent) {
+        let kb = self.config.keybindings.clone();
+        let close = key.code == KeyCode::Esc || self.matches_single_key(&key, &kb.quit);
+        let down = self.matches_single_key(&key, &kb.move_down);
+        let up = self.matches_single_key(&key, &kb.move_up);
+        let confirm = self.matches_single_key(&key, &kb.open_panel);
+        let show_dependencies =
+            key.code == KeyCode::Left || self.matches_single_key(&key, &kb.move_left);
+        let show_dependents =
+            key.code == KeyCode::Right || self.matches_single_key(&key, &kb.move_right);
+        let toggle = key.code == KeyCode::Tab;
+        let mut jump = None;
+
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        if matches!(state.overlay, BrowseOverlay::ModuleGraphLoading { .. }) {
+            if close {
+                state.cancel_module_graph_query();
+                state.overlay = BrowseOverlay::None;
+            }
+            return;
+        }
+        let BrowseOverlay::ModuleGraph(panel) = &mut state.overlay else {
+            return;
+        };
+        if close {
+            state.overlay = BrowseOverlay::None;
+            return;
+        }
+        if toggle {
+            panel.set_direction(match panel.direction {
+                ModuleGraphDirection::Dependencies => ModuleGraphDirection::Dependents,
+                ModuleGraphDirection::Dependents => ModuleGraphDirection::Dependencies,
+            });
+        } else if show_dependencies {
+            panel.set_direction(ModuleGraphDirection::Dependencies);
+        } else if show_dependents {
+            panel.set_direction(ModuleGraphDirection::Dependents);
+        } else if down {
+            panel.selected = (panel.selected + 1).min(panel.current_rows().len().saturating_sub(1));
+        } else if up {
+            panel.selected = panel.selected.saturating_sub(1);
+        } else if confirm {
+            if let Some(row) = panel.current_rows().get(panel.selected) {
+                jump = row.jump.clone();
+                state.overlay = BrowseOverlay::None;
+                if jump.is_none() {
+                    state.status =
+                        Some("This dependency target is not a listed repository file".into());
+                }
+            }
+        }
+
+        if let Some(jump) = jump {
+            self.browse_push_jump();
+            self.browse_open_path(&jump.path, jump.line);
+        }
+    }
+
+    pub(crate) fn open_browse_module_graph(&mut self) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        if state.open_is_pending() {
+            state.status = Some("Still opening this file".to_string());
+            return;
+        }
+        let Some(path) = state.open.as_ref().map(|open| open.path.clone()) else {
+            state.status = Some("No file is open".to_string());
+            return;
+        };
+        let graph = match &state.module_graph {
+            ModuleGraphState::Idle | ModuleGraphState::Building => {
+                state.status = Some("Module graph is still building".to_string());
+                return;
+            }
+            ModuleGraphState::Failed => {
+                state.status = Some("Module graph is unavailable".to_string());
+                return;
+            }
+            ModuleGraphState::Ready(graph) => std::sync::Arc::clone(graph),
+        };
+        if !graph.is_analyzed(&path) {
+            state.status = Some(if crate::module_graph::supports_imports(&path) {
+                "Import analysis is unavailable for this file".to_string()
+            } else {
+                "Import analysis is not supported for this file".to_string()
+            });
+            return;
+        }
+        state.status = None;
+        state.start_module_graph_query(path, graph);
     }
 
     pub(crate) fn open_browse_outline(&mut self) {
@@ -925,6 +1040,25 @@ mod tests {
         state.refresh_open_file_symbols();
     }
 
+    fn attach_code_index(app: &mut App, root: &std::path::Path, paths: &[&str]) {
+        let paths: Vec<_> = paths.iter().map(|path| (*path).to_string()).collect();
+        let crate::code_index::CodeIndexBuild::Completed(code) =
+            crate::code_index::CodeIndex::build_cancellable(
+                root,
+                &paths,
+                crate::module_graph::SourceUniverse::Complete,
+                &tokio_util::sync::CancellationToken::new(),
+            )
+        else {
+            panic!("code index fixture must build");
+        };
+        let crate::code_index::CodeIndex { symbols, modules } = *code;
+        let state = app.browse_state.as_mut().expect("browse state");
+        state.index = IndexState::Ready(Arc::new(symbols));
+        state.module_graph = ModuleGraphState::Ready(Arc::new(modules));
+        state.refresh_open_file_symbols();
+    }
+
     /// A browser rooted at a real directory holding `files`.
     ///
     /// Jumps that land in a *different* file go through `browse_open_path`,
@@ -977,6 +1111,20 @@ mod tests {
             tokio::time::sleep(std::time::Duration::from_millis(1)).await;
         }
         panic!("browse load never settled");
+    }
+
+    async fn settle_module_graph(app: &mut App) {
+        for _ in 0..2_000 {
+            app.poll_browse_updates();
+            if !matches!(
+                app.browse_state.as_ref().map(|state| &state.overlay),
+                Some(BrowseOverlay::ModuleGraphLoading { .. })
+            ) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        panic!("module graph query never settled");
     }
 
     async fn settle_blame(app: &mut App) {
@@ -2646,8 +2794,342 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_module_graph_overlay_loads_outgoing_and_switches_to_incoming() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source =
+            "import { helper } from './helper';\nexport function app() { return helper(); }\n";
+        let helper_source = "export function helper() { return 1; }\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
+        app.state = AppState::RepoBrowseFile;
+
+        app.open_browse_module_graph();
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().overlay,
+            BrowseOverlay::ModuleGraphLoading { .. }
+        ));
+        settle_module_graph(&mut app).await;
+        let state = app.browse_state.as_ref().unwrap();
+        let BrowseOverlay::ModuleGraph(panel) = &state.overlay else {
+            panic!("module graph overlay must open");
+        };
+        assert_eq!(panel.direction, ModuleGraphDirection::Dependencies);
+        assert_eq!(panel.current_rows().len(), 1);
+        assert!(panel.current_rows()[0].label.contains("./helper"));
+
+        app.handle_repo_browse_file_input(press(KeyCode::Tab), &mut test_terminal())
+            .unwrap();
+        let state = app.browse_state.as_ref().unwrap();
+        let BrowseOverlay::ModuleGraph(panel) = &state.overlay else {
+            panic!("module graph overlay must stay open");
+        };
+        assert_eq!(panel.direction, ModuleGraphDirection::Dependents);
+        assert!(panel.current_rows().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_default_and_custom_sequence_module_graph_keys_open_the_overlay() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "import { helper } from './helper';\n";
+        let helper_source = "export const helper = 1;\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
+        app.state = AppState::RepoBrowseFile;
+
+        app.handle_repo_browse_file_input(press(KeyCode::Char('i')), &mut test_terminal())
+            .unwrap();
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().overlay,
+            BrowseOverlay::ModuleGraphLoading { .. }
+        ));
+        settle_module_graph(&mut app).await;
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().overlay,
+            BrowseOverlay::ModuleGraph(_)
+        ));
+
+        app.handle_repo_browse_file_input(press(KeyCode::Esc), &mut test_terminal())
+            .unwrap();
+        app.config.keybindings.module_graph =
+            KeySequence::double(KeyBinding::char('m'), KeyBinding::char('i'));
+        app.handle_repo_browse_file_input(press(KeyCode::Char('m')), &mut test_terminal())
+            .unwrap();
+        app.handle_repo_browse_file_input(press(KeyCode::Char('i')), &mut test_terminal())
+            .unwrap();
+        settle_module_graph(&mut app).await;
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().overlay,
+            BrowseOverlay::ModuleGraph(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_loading_module_graph_can_be_cancelled_without_installing_a_stale_panel() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "import './helper';\n";
+        let helper_source = "export const helper = 1;\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
+        app.state = AppState::RepoBrowseFile;
+
+        app.open_browse_module_graph();
+        let cancel = app
+            .browse_state
+            .as_ref()
+            .unwrap()
+            .module_graph_query_token()
+            .expect("query token");
+        assert!(!cancel.is_cancelled());
+        app.handle_repo_browse_file_input(press(KeyCode::Esc), &mut test_terminal())
+            .unwrap();
+        assert!(cancel.is_cancelled());
+        app.poll_browse_updates();
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert!(state.module_graph_query_receiver.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_loading_module_graph_is_abandoned_when_the_open_path_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "import './helper';\n";
+        let helper_source = "export const helper = 1;\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
+        app.state = AppState::RepoBrowseFile;
+
+        app.open_browse_module_graph();
+        let cancel = app
+            .browse_state
+            .as_ref()
+            .unwrap()
+            .module_graph_query_token()
+            .expect("query token");
+        attach_open_file(&mut app, "src/helper.ts", helper_source, Vec::new());
+        app.poll_browse_updates();
+
+        assert!(cancel.is_cancelled());
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert!(state.module_graph_query_receiver.is_none());
+        assert_eq!(
+            state.status.as_deref(),
+            Some("Dependency query abandoned because the open file changed")
+        );
+    }
+
+    #[test]
+    fn test_enter_on_an_empty_module_graph_direction_is_a_noop() {
+        let mut app = browsing_app(&["src/empty.ts"]);
+        attach_open_file(&mut app, "src/empty.ts", "export {};\n", Vec::new());
+        app.state = AppState::RepoBrowseFile;
+        app.browse_state.as_mut().unwrap().overlay =
+            BrowseOverlay::ModuleGraph(super::super::browse::ModuleGraphPanel {
+                direction: ModuleGraphDirection::Dependencies,
+                selected: 0,
+                dependencies: super::super::browse::ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: crate::module_graph::DependencyGuarantee::Exact,
+                },
+                dependents: super::super::browse::ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: crate::module_graph::DependencyGuarantee::Exact,
+                },
+            });
+
+        app.handle_repo_browse_file_input(press(KeyCode::Enter), &mut test_terminal())
+            .unwrap();
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(state.overlay, BrowseOverlay::ModuleGraph(_)));
+        assert!(state.status.is_none());
+        assert!(state.jump_stack.is_empty());
+    }
+
+    #[test]
+    fn test_non_navigable_module_graph_row_reports_instead_of_jumping() {
+        let mut app = browsing_app(&["src/app.ts"]);
+        attach_open_file(
+            &mut app,
+            "src/app.ts",
+            "import react from 'react';\n",
+            Vec::new(),
+        );
+        app.state = AppState::RepoBrowseFile;
+        app.browse_state.as_mut().unwrap().overlay =
+            BrowseOverlay::ModuleGraph(super::super::browse::ModuleGraphPanel {
+                direction: ModuleGraphDirection::Dependencies,
+                selected: 0,
+                dependencies: super::super::browse::ModuleGraphRows {
+                    rows: vec![super::super::browse::ModuleGraphRow {
+                        label: "[import] react → package react  :1".to_string(),
+                        jump: None,
+                    }],
+                    total: 1,
+                    guarantee: crate::module_graph::DependencyGuarantee::Exact,
+                },
+                dependents: super::super::browse::ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: crate::module_graph::DependencyGuarantee::Exact,
+                },
+            });
+
+        app.handle_repo_browse_file_input(press(KeyCode::Enter), &mut test_terminal())
+            .unwrap();
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert_eq!(
+            state.status.as_deref(),
+            Some("This dependency target is not a listed repository file")
+        );
+        assert!(state.jump_stack.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_module_graph_opens_a_listed_cjk_json_dependency() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "import data from './データ.json';\nexport { data };\n";
+        let json_source = "{\"value\":1}\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/データ.json", json_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/データ.json"]);
+        app.state = AppState::RepoBrowseFile;
+
+        app.open_browse_module_graph();
+        settle_module_graph(&mut app).await;
+        app.handle_repo_browse_file_input(press(KeyCode::Enter), &mut test_terminal())
+            .unwrap();
+        settle_browse(&mut app).await;
+
+        assert_eq!(open_path(&app), "src/データ.json");
+        assert!(app.browse_state.as_ref().unwrap().status.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_module_graph_overlay_jumps_to_local_dependency_and_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source =
+            "import { helper } from './helper';\nexport function app() { return helper(); }\n";
+        let helper_source = "export function helper() { return 1; }\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
+        app.state = AppState::RepoBrowseFile;
+        app.browse_state.as_mut().unwrap().cursor_line = 1;
+
+        app.open_browse_module_graph();
+        settle_module_graph(&mut app).await;
+        app.handle_repo_browse_file_input(press(KeyCode::Enter), &mut test_terminal())
+            .unwrap();
+        settle_browse(&mut app).await;
+        assert_eq!(open_path(&app), "src/helper.ts");
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().overlay,
+            BrowseOverlay::None
+        ));
+
+        app.handle_repo_browse_file_input(ctrl('o'), &mut test_terminal())
+            .unwrap();
+        settle_browse(&mut app).await;
+        assert_eq!(open_path(&app), "src/app.ts");
+        assert_eq!(app.browse_state.as_ref().unwrap().cursor_line, 1);
+    }
+
+    #[test]
+    fn test_failed_module_graph_action_reports_unavailable() {
+        let mut app = browsing_app(&["src/app.ts"]);
+        attach_open_file(&mut app, "src/app.ts", "export {};\n", Vec::new());
+        app.state = AppState::RepoBrowseFile;
+        app.browse_state.as_mut().unwrap().module_graph = ModuleGraphState::Failed;
+
+        app.open_browse_module_graph();
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert_eq!(state.status.as_deref(), Some("Module graph is unavailable"));
+    }
+
+    #[test]
+    fn test_module_graph_reports_unavailable_for_a_listed_unanalyzed_stub() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "import './oversized';\n";
+        let oversized = "x".repeat(crate::symbols::MAX_INDEXED_FILE_BYTES as usize + 1);
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[
+                ("src/app.ts", app_source),
+                ("src/oversized.ts", oversized.as_str()),
+            ],
+        );
+        attach_open_file(&mut app, "src/oversized.ts", "", Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/oversized.ts"]);
+        app.state = AppState::RepoBrowseFile;
+
+        app.open_browse_module_graph();
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert_eq!(
+            state.status.as_deref(),
+            Some("Import analysis is unavailable for this file")
+        );
+    }
+
+    #[test]
+    fn test_module_graph_action_prioritizes_a_pending_file_load() {
+        let mut app = browsing_app(&["src/app.ts"]);
+        attach_open_file(&mut app, "src/app.ts", "import './helper';\n", Vec::new());
+        let cancel = tokio_util::sync::CancellationToken::new();
+        app.browse_state.as_mut().unwrap().open_load = OpenLoad::Pending {
+            path: "src/app.ts".to_string(),
+            line: 0,
+            scroll: None,
+            cancel,
+        };
+
+        app.open_browse_module_graph();
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert_eq!(state.status.as_deref(), Some("Still opening this file"));
+        assert!(matches!(state.overlay, BrowseOverlay::None));
+    }
+
     /// A throwaway terminal for handlers that take one but do not draw.
     fn test_terminal() -> Terminal<CrosstermBackend<Stdout>> {
-        Terminal::new(CrosstermBackend::new(std::io::stdout())).expect("terminal")
+        Terminal::with_options(
+            CrosstermBackend::new(std::io::stdout()),
+            TerminalOptions {
+                viewport: Viewport::Fixed(Rect::new(0, 0, 120, 40)),
+            },
+        )
+        .expect("terminal")
     }
 }

--- a/src/code_index.rs
+++ b/src/code_index.rs
@@ -1,0 +1,208 @@
+//! One-pass repository analysis for browser symbols and module dependencies.
+
+use std::path::Path;
+
+use hearth_graph::{AnalyzeBuild, BuildOptions, FsLoader};
+
+use crate::module_graph::{ModuleGraph, SourceUniverse};
+use crate::symbols::{symbol_language_registry, CancelSignal, SymbolIndex, MAX_INDEXED_FILE_BYTES};
+
+/// Symbol and module indexes produced from one Hearth analysis pass.
+#[derive(Debug)]
+pub struct CodeIndex {
+    pub symbols: SymbolIndex,
+    pub modules: ModuleGraph,
+}
+
+/// Outcome of a cancellable combined repository analysis.
+#[derive(Debug)]
+pub enum CodeIndexBuild {
+    Completed(Box<CodeIndex>),
+    Cancelled { scanned_files: usize },
+    Failed { message: String },
+}
+
+impl CodeIndex {
+    /// Build both indexes without parsing a source file twice.
+    ///
+    /// Blocking and CPU-bound — call from `spawn_blocking`.
+    pub fn build_cancellable(
+        repo_root: &Path,
+        paths: &[String],
+        universe: SourceUniverse,
+        cancel: &dyn CancelSignal,
+    ) -> CodeIndexBuild {
+        let loader = FsLoader::new(repo_root);
+        let cancellation = || cancel.is_cancelled();
+        let options = BuildOptions {
+            max_file_bytes: MAX_INDEXED_FILE_BYTES,
+            max_workers: 8,
+        };
+
+        match hearth_graph::analyze_paths(
+            symbol_language_registry(),
+            &loader,
+            paths,
+            &cancellation,
+            &options,
+        ) {
+            AnalyzeBuild::Completed {
+                mut files,
+                scanned_files,
+            } => {
+                let Some(modules) =
+                    ModuleGraph::from_analyses(repo_root, paths, &mut files, universe, cancel)
+                else {
+                    return CodeIndexBuild::Cancelled { scanned_files };
+                };
+                let Some(symbols) = SymbolIndex::from_analyses_cancellable(files, cancel) else {
+                    return CodeIndexBuild::Cancelled { scanned_files };
+                };
+                CodeIndexBuild::Completed(Box::new(Self { symbols, modules }))
+            }
+            AnalyzeBuild::Cancelled { scanned_files } => {
+                CodeIndexBuild::Cancelled { scanned_files }
+            }
+            AnalyzeBuild::Failed { message } => CodeIndexBuild::Failed { message },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::module_graph::{DependencyGuarantee, DependencyTarget};
+
+    fn write(root: &Path, path: &str, source: &str) {
+        let absolute = root.join(path);
+        std::fs::create_dir_all(absolute.parent().unwrap()).unwrap();
+        std::fs::write(absolute, source).unwrap();
+    }
+
+    fn completed(build: CodeIndexBuild) -> CodeIndex {
+        match build {
+            CodeIndexBuild::Completed(index) => *index,
+            other => panic!("combined build did not complete: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_combined_build_produces_symbols_and_import_edges() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/app.ts",
+            "import { helper } from './helper';\nexport function app() { return helper(); }\n",
+        );
+        write(
+            dir.path(),
+            "src/helper.ts",
+            "export function helper() { return 1; }\n",
+        );
+        let paths = vec!["src/app.ts".to_owned(), "src/helper.ts".to_owned()];
+
+        let index = completed(CodeIndex::build_cancellable(
+            dir.path(),
+            &paths,
+            SourceUniverse::Complete,
+            &CancellationToken::new(),
+        ));
+
+        assert_eq!(index.symbols.definitions("app")[0].path, "src/app.ts");
+        assert_eq!(index.symbols.definitions("helper")[0].path, "src/helper.ts");
+        let deps = index.modules.dependencies("src/app.ts").unwrap();
+        assert_eq!(deps.guarantee, DependencyGuarantee::Exact);
+        assert_eq!(
+            deps.edges[0].target,
+            DependencyTarget::Path("src/helper.ts".into())
+        );
+    }
+
+    #[test]
+    fn test_combined_build_preserves_empty_symbol_files_for_import_queries() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/side_effect.ts", "import './target';\n");
+        write(dir.path(), "src/target.ts", "// no symbols\n");
+        let paths = vec!["src/side_effect.ts".to_owned(), "src/target.ts".to_owned()];
+
+        let index = completed(CodeIndex::build_cancellable(
+            dir.path(),
+            &paths,
+            SourceUniverse::Complete,
+            &CancellationToken::new(),
+        ));
+
+        assert_eq!(
+            index.symbols.file_symbols("src/target.ts"),
+            Some([].as_slice())
+        );
+        assert_eq!(
+            index
+                .modules
+                .dependencies("src/side_effect.ts")
+                .unwrap()
+                .edges
+                .len(),
+            1
+        );
+        assert!(index.modules.dependents("src/target.ts").is_some());
+    }
+
+    #[test]
+    fn test_precancelled_combined_build_scans_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/app.ts", "export const app = 1;\n");
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+
+        match CodeIndex::build_cancellable(
+            dir.path(),
+            &["src/app.ts".to_owned()],
+            SourceUniverse::Complete,
+            &cancel,
+        ) {
+            CodeIndexBuild::Cancelled { scanned_files } => assert_eq!(scanned_files, 0),
+            other => panic!("pre-cancelled build did not cancel: {other:?}"),
+        }
+    }
+
+    struct PollCancel {
+        limit: usize,
+        polls: AtomicUsize,
+    }
+
+    impl CancelSignal for PollCancel {
+        fn is_cancelled(&self) -> bool {
+            self.polls.fetch_add(1, Ordering::SeqCst) >= self.limit
+        }
+    }
+
+    #[test]
+    fn test_combined_build_cancellation_never_publishes_partial_indexes() {
+        let dir = tempfile::tempdir().unwrap();
+        let paths: Vec<_> = (0..1_000)
+            .map(|index| {
+                let path = format!("src/file_{index:04}.ts");
+                write(
+                    dir.path(),
+                    &path,
+                    &format!("export const value{index} = {index};\n"),
+                );
+                path
+            })
+            .collect();
+        let cancel = PollCancel {
+            limit: 50,
+            polls: AtomicUsize::new(0),
+        };
+
+        assert!(matches!(
+            CodeIndex::build_cancellable(dir.path(), &paths, SourceUniverse::Complete, &cancel,),
+            CodeIndexBuild::Cancelled { .. }
+        ));
+    }
+}

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -73,6 +73,7 @@ pub struct KeybindingsConfig {
     pub repo_browse: KeySequence,
     pub symbol_outline: KeySequence,
     pub symbol_search: KeySequence,
+    pub module_graph: KeySequence,
     pub toggle_blame: KeySequence,
     pub open_blame_commit: KeySequence,
     pub open_blame_pr: KeySequence,
@@ -158,6 +159,7 @@ impl Default for KeybindingsConfig {
             repo_browse: KeySequence::single(KeyBinding::char('b')),
             symbol_outline: KeySequence::single(KeyBinding::char('o')),
             symbol_search: KeySequence::single(KeyBinding::char('s')),
+            module_graph: KeySequence::single(KeyBinding::char('i')),
             toggle_blame: KeySequence::double(KeyBinding::char('g'), KeyBinding::char('b')),
             open_blame_commit: KeySequence::double(KeyBinding::char('g'), KeyBinding::char('c')),
             open_blame_pr: KeySequence::double(KeyBinding::char('g'), KeyBinding::char('p')),
@@ -187,7 +189,7 @@ impl KeybindingsConfig {
     /// - Duplicate keybindings for different actions
     pub fn validate(&self) -> Result<(), Vec<String>> {
         let mut errors = Vec::new();
-        let mut single_keys: HashMap<KeyBinding, &str> = HashMap::new();
+        let mut single_keys: HashMap<KeyBinding, Vec<&str>> = HashMap::new();
         let mut sequence_prefixes: HashMap<KeyBinding, Vec<&str>> = HashMap::new();
         let mut exact_sequences: HashMap<Vec<KeyBinding>, Vec<(&str, bool)>> = HashMap::new();
 
@@ -244,6 +246,7 @@ impl KeybindingsConfig {
             ("repo_browse", &self.repo_browse),
             ("symbol_outline", &self.symbol_outline),
             ("symbol_search", &self.symbol_search),
+            ("module_graph", &self.module_graph),
             ("toggle_blame", &self.toggle_blame),
             ("open_blame_commit", &self.open_blame_commit),
             ("open_blame_pr", &self.open_blame_pr),
@@ -267,15 +270,17 @@ impl KeybindingsConfig {
                 continue;
             }
 
-            for (sequence_index, keys) in seq.all_sequences().enumerate() {
+            for keys in seq.all_sequences() {
                 if keys.is_empty() {
                     errors.push(format!("keybinding '{}' has an empty alternative", name));
                     continue;
                 }
-                let is_primary_single = sequence_index == 0 && seq.is_single();
-                let owners = exact_sequences.entry(keys.to_vec()).or_default();
-                for (existing, existing_is_primary_single) in owners.iter() {
-                    if is_primary_single && *existing_is_primary_single {
+                let is_single = keys.len() == 1;
+                let exact_owners = exact_sequences.entry(keys.to_vec()).or_default();
+                for (existing, existing_is_single) in exact_owners.iter() {
+                    // Single-key duplicates are diagnosed once by `single_keys`,
+                    // including alternatives. Multi-key exact collisions stay here.
+                    if is_single && *existing_is_single {
                         continue;
                     }
                     if !is_context_compatible(name, existing) {
@@ -286,46 +291,45 @@ impl KeybindingsConfig {
                         ));
                     }
                 }
-                owners.push((name, is_primary_single));
-            }
+                exact_owners.push((name, is_single));
 
-            if seq.is_single() {
-                let key = seq.keys[0];
-                if let Some(existing) = single_keys.get(&key) {
-                    // Allow same key for different contexts (e.g., 'r' for reply and request_changes)
-                    // This is intentional - context determines which action is triggered
-                    if !is_context_compatible(name, existing) {
-                        errors.push(format!(
-                            "duplicate keybinding: '{}' and '{}' both use {}",
-                            name,
-                            existing,
-                            key.display()
-                        ));
+                if is_single {
+                    let key = keys[0];
+                    let owners = single_keys.entry(key).or_default();
+                    for existing in owners.iter() {
+                        // Tracking every primary and alternative owner prevents an
+                        // earlier disjoint-context action from hiding a later collision.
+                        if !is_context_compatible(name, existing) {
+                            errors.push(format!(
+                                "duplicate keybinding: '{}' and '{}' both use {}",
+                                name,
+                                existing,
+                                key.display()
+                            ));
+                        }
                     }
-                } else {
-                    single_keys.insert(key, name);
-                }
-            } else {
-                // For sequences, track the first key as a prefix
-                if let Some(first) = seq.first() {
+                    owners.push(name);
+                } else if let Some(first) = keys.first() {
                     sequence_prefixes.entry(*first).or_default().push(name);
                 }
             }
         }
 
         // Check for conflicts between single keys and sequence prefixes
-        for (key, single_name) in &single_keys {
+        for (key, single_names) in &single_keys {
             if let Some(seq_names) = sequence_prefixes.get(key) {
-                // Only warn if they're in the same context
-                for seq_name in seq_names {
-                    if !is_context_compatible(single_name, seq_name) {
-                        errors.push(format!(
-                            "keybinding conflict: '{}' ({}) conflicts with sequence prefix for '{}' ({})",
-                            single_name,
-                            key.display(),
-                            seq_name,
-                            key.display()
-                        ));
+                // Only warn if they're in the same context.
+                for single_name in single_names {
+                    for seq_name in seq_names {
+                        if !is_context_compatible(single_name, seq_name) {
+                            errors.push(format!(
+                                "keybinding conflict: '{}' ({}) conflicts with sequence prefix for '{}' ({})",
+                                single_name,
+                                key.display(),
+                                seq_name,
+                                key.display()
+                            ));
+                        }
                     }
                 }
             }
@@ -375,6 +379,7 @@ fn is_context_compatible(name1: &str, name2: &str) -> bool {
         "repo_browse",
         "symbol_outline",
         "symbol_search",
+        "module_graph",
     ];
 
     let context_groups: &[&[&str]] = &[
@@ -387,6 +392,40 @@ fn is_context_compatible(name1: &str, name2: &str) -> bool {
         &["retry", "reply", "request_changes"],
         &["confirm_no", "next_comment"],
     ];
+
+    // The module-graph action is file-pane specific, but these actions are
+    // active in that same pane. Treating every screen-specific key as a
+    // wildcard made valid-looking custom bindings unreachable at runtime.
+    const MODULE_GRAPH_OVERLAPS: &[&str] = &[
+        "move_down",
+        "move_up",
+        "move_left",
+        "move_right",
+        "page_down",
+        "page_up",
+        "jump_to_first",
+        "jump_to_last",
+        "jump_back",
+        "quit",
+        "help",
+        "go_to_definition",
+        "go_to_file",
+        "toggle_zen_mode",
+        "symbol_outline",
+        "symbol_search",
+        "toggle_blame",
+        "open_blame_commit",
+        "open_blame_pr",
+        "open_line_discussion",
+    ];
+    if name1 == "module_graph" || name2 == "module_graph" {
+        let other = if name1 == "module_graph" {
+            name2
+        } else {
+            name1
+        };
+        return !MODULE_GRAPH_OVERLAPS.contains(&other);
+    }
 
     // git ops 固有キーは git ops 画面でのみ有効なので、他の全キーと context compatible
     if SCREEN_SPECIFIC_KEYS.contains(&name1) || SCREEN_SPECIFIC_KEYS.contains(&name2) {
@@ -485,6 +524,7 @@ impl Serialize for KeybindingsConfig {
         map.serialize_entry("repo_browse", &seq_to_value(&self.repo_browse))?;
         map.serialize_entry("symbol_outline", &seq_to_value(&self.symbol_outline))?;
         map.serialize_entry("symbol_search", &seq_to_value(&self.symbol_search))?;
+        map.serialize_entry("module_graph", &seq_to_value(&self.module_graph))?;
         map.serialize_entry("toggle_blame", &seq_to_value(&self.toggle_blame))?;
         map.serialize_entry("open_blame_commit", &seq_to_value(&self.open_blame_commit))?;
         map.serialize_entry("open_blame_pr", &seq_to_value(&self.open_blame_pr))?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1304,6 +1304,7 @@ timeout_secs = 3600
             "mark_viewed",
             "mark_viewed_dir",
             "tree_toggle",
+            "module_graph",
             "toggle_blame",
             "open_blame_commit",
             "open_blame_pr",
@@ -1324,6 +1325,54 @@ timeout_secs = 3600
             serialized, reserialized,
             "Serialize roundtrip mismatch — a field may be missing from Serialize or Default impl"
         );
+    }
+
+    #[test]
+    fn test_module_graph_keybinding_defaults_and_roundtrips() {
+        let config = KeybindingsConfig::default();
+        assert_eq!(config.module_graph.display(), "i");
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(serialized.contains("module_graph"));
+        let parsed: KeybindingsConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(parsed.module_graph.display(), "i");
+        assert!(parsed.validate().is_ok());
+    }
+
+    #[test]
+    fn test_module_graph_rejects_overlapping_browser_bindings() {
+        for (binding, conflicting_name) in [
+            ("o", "symbol_outline"),
+            ("s", "symbol_search"),
+            ("g", "toggle_blame"),
+        ] {
+            let source = format!("[keybindings]\nmodule_graph = \"{binding}\"\n");
+            let config: Config = toml::from_str(&source).unwrap();
+            let errors = config.keybindings.validate().unwrap_err();
+            assert!(
+                errors.iter().any(|error| {
+                    error.contains("module_graph") && error.contains(conflicting_name)
+                }),
+                "{binding:?} did not conflict with {conflicting_name}: {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_module_graph_rejects_an_alternative_browser_sequence_prefix() {
+        let config: Config = toml::from_str(
+            r#"
+            [keybindings]
+            module_graph = "i/g"
+            "#,
+        )
+        .unwrap();
+
+        let errors = config.keybindings.validate().unwrap_err();
+        assert!(errors.iter().any(|error| {
+            error.contains("module_graph")
+                && error.contains("toggle_blame")
+                && error.contains("conflicts with sequence prefix")
+        }));
     }
 
     /// validate() の bindings リストが全フィールドを含むことを検証。

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 pub mod ai;
 pub mod app;
 pub mod cache;
+pub mod code_index;
 pub mod config;
 pub mod diff;
 pub mod diff_store;
@@ -16,6 +17,7 @@ pub mod headless;
 pub mod keybinding;
 pub mod language;
 pub mod loader;
+pub mod module_graph;
 pub mod symbol;
 pub mod symbols;
 pub mod syntax;

--- a/src/module_graph.rs
+++ b/src/module_graph.rs
@@ -1,0 +1,839 @@
+//! Compatibility facade over Hearth import analysis and module-graph queries.
+//!
+//! Graph keys remain repository-relative even though Hearth's filesystem
+//! resolvers require absolute referrer paths. [`RootedResolver`] owns that
+//! boundary so browser state never needs to know which path form a resolver
+//! consumes.
+
+use std::path::{Component, Path, PathBuf};
+
+use hearth_graph::graph::{
+    DepEdge as HearthDepEdge, DepsResult as HearthDepsResult, EdgeTargetOwned, Guarantee,
+    ModuleGraph as HearthModuleGraph, NodeState,
+};
+use hearth_graph::{
+    js_resolver, rust_resolver, FailedKind, FileAnalysis, ImportKind, JsResolveOptions, RawImport,
+    ResolutionCompleteness, ResolutionOutcome, Resolve, Resolved, ResolverSet, RustResolveOptions,
+    UnresolvedReason,
+};
+use rustc_hash::FxHashSet;
+
+use crate::symbols::{symbol_language_registry, CancelSignal};
+
+/// Whether the browser supplied every repository path to analysis.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SourceUniverse {
+    Complete,
+    #[default]
+    Partial,
+}
+
+/// Accuracy attached to a dependency answer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DependencyGuarantee {
+    Exact,
+    Approximate,
+}
+
+impl From<Guarantee> for DependencyGuarantee {
+    fn from(guarantee: Guarantee) -> Self {
+        match guarantee {
+            Guarantee::Exact => Self::Exact,
+            Guarantee::Approximate => Self::Approximate,
+        }
+    }
+}
+
+/// Octorus-owned import syntax kind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModuleImportKind {
+    EsStatic,
+    EsReexport,
+    EsDynamic,
+    CommonJs,
+    TsImportRequire,
+    RustUse,
+    RustMod,
+}
+
+impl ModuleImportKind {
+    /// Compact stable label used in dependency rows.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::EsStatic => "import",
+            Self::EsReexport => "re-export",
+            Self::EsDynamic => "dynamic",
+            Self::CommonJs => "require",
+            Self::TsImportRequire => "import=",
+            Self::RustUse => "use",
+            Self::RustMod => "mod",
+        }
+    }
+}
+
+impl From<ImportKind> for ModuleImportKind {
+    fn from(kind: ImportKind) -> Self {
+        match kind {
+            ImportKind::EsStatic => Self::EsStatic,
+            ImportKind::EsReexport => Self::EsReexport,
+            ImportKind::EsDynamic => Self::EsDynamic,
+            ImportKind::CommonJs => Self::CommonJs,
+            ImportKind::TsImportRequire => Self::TsImportRequire,
+            ImportKind::RustUse => Self::RustUse,
+            ImportKind::RustMod => Self::RustMod,
+        }
+    }
+}
+
+/// Resolved destination of one import.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DependencyTarget {
+    Path(String),
+    External(String),
+    Unresolved(String),
+}
+
+impl DependencyTarget {
+    /// One-line target text suitable for the browser overlay.
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Path(path) | Self::External(path) | Self::Unresolved(path) => path,
+        }
+    }
+}
+
+/// One module-graph edge projected into octorus-owned types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyEdge {
+    pub from: String,
+    pub target: DependencyTarget,
+    pub specifier: String,
+    pub kind: ModuleImportKind,
+    pub line: usize,
+    pub span: (usize, usize),
+}
+
+/// Direct dependencies or dependents of one repository file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DependencyResult {
+    pub edges: Vec<DependencyEdge>,
+    pub guarantee: DependencyGuarantee,
+}
+
+/// Repository module graph backed by Hearth.
+#[derive(Debug, Default)]
+pub struct ModuleGraph {
+    inner: HearthModuleGraph,
+    /// Listed paths that are not analyzed graph nodes. Analyzed nodes are
+    /// listed by construction; this exception set keeps JSON/CSS and skipped
+    /// source targets navigable without duplicating every analyzed path.
+    listed_non_analyzed_paths: FxHashSet<String>,
+}
+
+impl ModuleGraph {
+    pub(crate) fn from_analyses(
+        repo_root: &Path,
+        paths: &[String],
+        analyses: &mut [FileAnalysis],
+        universe: SourceUniverse,
+        cancel: &dyn CancelSignal,
+    ) -> Option<Self> {
+        if cancel.is_cancelled() {
+            return None;
+        }
+        let root = absolute_root(repo_root);
+        let resolvers = resolver_set(&root, paths, cancel)?;
+        let analyzed_import_paths: FxHashSet<&str> = analyses
+            .iter()
+            .filter(|analysis| supports_imports(analysis.path.as_str()))
+            .map(|analysis| analysis.path.as_str())
+            .collect();
+        let mut every_import_file_analyzed = true;
+        let mut listed_non_analyzed_paths = FxHashSet::default();
+        for (index, path) in paths.iter().enumerate() {
+            if index.is_multiple_of(1_024) && cancel.is_cancelled() {
+                return None;
+            }
+            if !analyzed_import_paths.contains(path.as_str()) {
+                if supports_imports(path) {
+                    every_import_file_analyzed = false;
+                }
+                listed_non_analyzed_paths.insert(path.clone());
+            }
+        }
+
+        let mut inner = fold_analyses_into_graph(analyses, &resolvers, cancel)?;
+        if cancel.is_cancelled() {
+            return None;
+        }
+        inner.set_universe_complete(
+            universe == SourceUniverse::Complete && every_import_file_analyzed,
+        );
+        Some(Self {
+            inner,
+            listed_non_analyzed_paths,
+        })
+    }
+
+    #[must_use]
+    pub fn dependencies(&self, path: &str) -> Option<DependencyResult> {
+        self.is_analyzed(path)
+            .then(|| self.inner.deps(path))
+            .flatten()
+            .map(project_result)
+    }
+
+    #[must_use]
+    pub fn dependents(&self, path: &str) -> Option<DependencyResult> {
+        self.is_analyzed(path)
+            .then(|| self.inner.rdeps(path))
+            .flatten()
+            .map(project_result)
+    }
+
+    pub(crate) fn dependencies_bounded(
+        &self,
+        path: &str,
+        limit: usize,
+    ) -> Option<(DependencyResult, usize)> {
+        self.is_analyzed(path)
+            .then(|| self.inner.deps(path))
+            .flatten()
+            .map(|result| project_result_bounded(result, limit))
+    }
+
+    pub(crate) fn dependents_bounded(
+        &self,
+        path: &str,
+        limit: usize,
+    ) -> Option<(DependencyResult, usize)> {
+        self.is_analyzed(path)
+            .then(|| self.inner.rdeps(path))
+            .flatten()
+            .map(|result| project_result_bounded(result, limit))
+    }
+
+    #[must_use]
+    pub(crate) fn is_listed(&self, path: &str) -> bool {
+        self.is_analyzed(path) || self.listed_non_analyzed_paths.contains(path)
+    }
+
+    pub(crate) fn is_analyzed(&self, path: &str) -> bool {
+        self.inner
+            .node(path)
+            .is_some_and(|node| matches!(node.state, NodeState::Analyzed { .. }))
+    }
+
+    #[must_use]
+    pub fn edge_count(&self) -> usize {
+        self.inner.edge_count()
+    }
+}
+
+#[must_use]
+pub fn supports_imports(path: &str) -> bool {
+    symbol_language_registry().supports_imports(Path::new(path))
+}
+
+fn fold_analyses_into_graph(
+    analyses: &mut [FileAnalysis],
+    resolvers: &ResolverSet,
+    cancel: &dyn CancelSignal,
+) -> Option<HearthModuleGraph> {
+    let mut inner = HearthModuleGraph::new();
+    for analysis in analyses
+        .iter_mut()
+        .filter(|analysis| supports_imports(analysis.path.as_str()))
+    {
+        if cancel.is_cancelled() {
+            return None;
+        }
+        inner.upsert_file(analysis, resolvers, true);
+        // Hearth copied each import into compact graph edges. Release the
+        // analysis-side vectors before symbol projection to bound peak RSS.
+        drop(std::mem::take(&mut analysis.imports));
+    }
+    Some(inner)
+}
+
+fn project_result(result: HearthDepsResult) -> DependencyResult {
+    DependencyResult {
+        edges: result.edges.into_iter().map(project_edge).collect(),
+        guarantee: result.guarantee.into(),
+    }
+}
+
+fn project_result_bounded(mut result: HearthDepsResult, limit: usize) -> (DependencyResult, usize) {
+    let total = result.edges.len();
+    result.edges.truncate(limit);
+    (project_result(result), total)
+}
+
+fn project_edge(edge: HearthDepEdge) -> DependencyEdge {
+    let target = match edge.to {
+        EdgeTargetOwned::Path(path) => DependencyTarget::Path(path.to_string()),
+        EdgeTargetOwned::External(package) => DependencyTarget::External(package.to_string()),
+        EdgeTargetOwned::Unresolved(reason) => {
+            DependencyTarget::Unresolved(unresolved_label(&reason))
+        }
+    };
+    DependencyEdge {
+        from: edge.from.to_string(),
+        target,
+        specifier: edge.specifier.to_string(),
+        kind: edge.kind.into(),
+        line: usize::try_from(edge.line)
+            .expect("hearth-graph import line does not fit octorus usize"),
+        span: (
+            usize::try_from(edge.span.0)
+                .expect("hearth-graph import span does not fit octorus usize"),
+            usize::try_from(edge.span.1)
+                .expect("hearth-graph import span does not fit octorus usize"),
+        ),
+    }
+}
+
+fn unresolved_label(reason: &UnresolvedReason) -> String {
+    match reason {
+        UnresolvedReason::NotFound => "not found".to_owned(),
+        UnresolvedReason::Unsupported => "unsupported".to_owned(),
+        UnresolvedReason::Failed { kind, detail } => {
+            let kind = match kind {
+                FailedKind::Config => "configuration error",
+                FailedKind::Io => "I/O error",
+                FailedKind::InvalidSpecifier => "invalid specifier",
+                FailedKind::Other => "resolver error",
+            };
+            format!("{kind}: {detail}")
+        }
+    }
+}
+
+/// Adapts repository-relative graph keys to resolvers that require absolute paths.
+struct RootedResolver {
+    root: PathBuf,
+    inner: Box<dyn Resolve>,
+}
+
+impl RootedResolver {
+    fn new(root: &Path, inner: Box<dyn Resolve>) -> Self {
+        Self {
+            root: root.to_path_buf(),
+            inner,
+        }
+    }
+}
+
+impl Resolve for RootedResolver {
+    fn baseline_completeness(&self) -> ResolutionCompleteness {
+        self.inner.baseline_completeness()
+    }
+
+    fn resolve(&self, from_file: &str, import: &RawImport) -> ResolutionOutcome {
+        let from_path = Path::new(from_file);
+        let absolute = if from_path.is_absolute() {
+            from_path.to_path_buf()
+        } else {
+            self.root.join(from_path)
+        };
+        let Some(absolute) = absolute.to_str() else {
+            return ResolutionOutcome {
+                resolved: Resolved::Unresolved(UnresolvedReason::Failed {
+                    kind: FailedKind::InvalidSpecifier,
+                    detail: "repository path is not valid UTF-8".into(),
+                }),
+                dependencies: Vec::new(),
+                notes: Vec::new(),
+                completeness: ResolutionCompleteness::Partial,
+            };
+        };
+
+        let mut outcome = self.inner.resolve(absolute, import);
+        if let Resolved::Path(target) = &outcome.resolved {
+            if let Some(relative) = relative_graph_path(&self.root, Path::new(target.as_str())) {
+                outcome.resolved = Resolved::Path(relative.into());
+            }
+        }
+        outcome
+    }
+
+    fn clear_cache(&self) {
+        self.inner.clear_cache();
+    }
+}
+
+fn resolver_set(root: &Path, paths: &[String], cancel: &dyn CancelSignal) -> Option<ResolverSet> {
+    let tsconfig = ["tsconfig.json", "jsconfig.json"]
+        .into_iter()
+        .map(|name| root.join(name))
+        .find(|path| path.is_file());
+    let js = js_resolver(JsResolveOptions {
+        tsconfig,
+        ..JsResolveOptions::default()
+    });
+    let mut crate_roots = Vec::new();
+    for (index, path) in paths.iter().enumerate() {
+        if index.is_multiple_of(1_024) && cancel.is_cancelled() {
+            return None;
+        }
+        if is_explicit_rust_crate_root(path) {
+            crate_roots.push(root.join(path).to_string_lossy().into_owned().into());
+        }
+    }
+    let rust = rust_resolver(RustResolveOptions { crate_roots });
+
+    Some(ResolverSet {
+        js: Some(Box::new(RootedResolver::new(root, js))),
+        rust: Some(Box::new(RootedResolver::new(root, rust))),
+    })
+}
+
+fn is_explicit_rust_crate_root(path: &str) -> bool {
+    path == "src/lib.rs"
+        || path == "src/main.rs"
+        || path.ends_with("/src/lib.rs")
+        || path.ends_with("/src/main.rs")
+}
+
+fn absolute_root(root: &Path) -> PathBuf {
+    std::fs::canonicalize(root).unwrap_or_else(|_| {
+        if root.is_absolute() {
+            root.to_path_buf()
+        } else {
+            std::env::current_dir().map_or_else(|_| root.to_path_buf(), |cwd| cwd.join(root))
+        }
+    })
+}
+
+fn relative_graph_path(root: &Path, target: &Path) -> Option<String> {
+    let relative = target.strip_prefix(root).ok()?;
+    let mut result = String::new();
+    for component in relative.components() {
+        let Component::Normal(component) = component else {
+            continue;
+        };
+        if !result.is_empty() {
+            result.push('/');
+        }
+        result.push_str(component.to_str()?);
+    }
+    (!result.is_empty()).then_some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use hearth_graph::{AnalyzeBuild, BuildOptions, FsLoader};
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::symbols::{symbol_language_registry, MAX_INDEXED_FILE_BYTES};
+
+    fn write(root: &Path, path: &str, source: &str) {
+        let absolute = root.join(path);
+        std::fs::create_dir_all(absolute.parent().unwrap()).unwrap();
+        std::fs::write(absolute, source).unwrap();
+    }
+
+    fn analyses(root: &Path, paths: &[String]) -> Vec<FileAnalysis> {
+        let loader = FsLoader::new(root);
+        match hearth_graph::analyze_paths(
+            symbol_language_registry(),
+            &loader,
+            paths,
+            &hearth_graph::NeverCancelled,
+            &BuildOptions {
+                max_file_bytes: MAX_INDEXED_FILE_BYTES,
+                max_workers: 2,
+            },
+        ) {
+            AnalyzeBuild::Completed { files, .. } => files,
+            other => panic!("analysis did not complete: {other:?}"),
+        }
+    }
+
+    fn graph(root: &Path, paths: &[&str], universe: SourceUniverse) -> ModuleGraph {
+        let paths: Vec<_> = paths.iter().map(|path| (*path).to_owned()).collect();
+        let mut analyses = analyses(root, &paths);
+        ModuleGraph::from_analyses(
+            root,
+            &paths,
+            &mut analyses,
+            universe,
+            &CancellationToken::new(),
+        )
+        .expect("graph build")
+    }
+
+    #[test]
+    fn test_javascript_dependencies_preserve_kinds_targets_and_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/app.ts",
+            "import { value } from './value';\nexport { other } from './other';\nconst lazy = import('./lazy');\nconst common = require('./common');\nimport missing from './missing';\n",
+        );
+        for path in ["value", "other", "lazy", "common"] {
+            write(
+                dir.path(),
+                &format!("src/{path}.ts"),
+                &format!("export const {path} = 1;\n"),
+            );
+        }
+        let graph = graph(
+            dir.path(),
+            &[
+                "src/app.ts",
+                "src/value.ts",
+                "src/other.ts",
+                "src/lazy.ts",
+                "src/common.ts",
+            ],
+            SourceUniverse::Complete,
+        );
+
+        insta::assert_debug_snapshot!(graph.dependencies("src/app.ts"), @r#"
+        Some(
+            DependencyResult {
+                edges: [
+                    DependencyEdge {
+                        from: "src/app.ts",
+                        target: Path(
+                            "src/value.ts",
+                        ),
+                        specifier: "./value",
+                        kind: EsStatic,
+                        line: 1,
+                        span: (
+                            22,
+                            31,
+                        ),
+                    },
+                    DependencyEdge {
+                        from: "src/app.ts",
+                        target: Path(
+                            "src/other.ts",
+                        ),
+                        specifier: "./other",
+                        kind: EsReexport,
+                        line: 2,
+                        span: (
+                            55,
+                            64,
+                        ),
+                    },
+                    DependencyEdge {
+                        from: "src/app.ts",
+                        target: Path(
+                            "src/lazy.ts",
+                        ),
+                        specifier: "./lazy",
+                        kind: EsDynamic,
+                        line: 3,
+                        span: (
+                            86,
+                            94,
+                        ),
+                    },
+                    DependencyEdge {
+                        from: "src/app.ts",
+                        target: Path(
+                            "src/common.ts",
+                        ),
+                        specifier: "./common",
+                        kind: CommonJs,
+                        line: 4,
+                        span: (
+                            120,
+                            130,
+                        ),
+                    },
+                    DependencyEdge {
+                        from: "src/app.ts",
+                        target: Unresolved(
+                            "not found",
+                        ),
+                        specifier: "./missing",
+                        kind: EsStatic,
+                        line: 5,
+                        span: (
+                            153,
+                            164,
+                        ),
+                    },
+                ],
+                guarantee: Exact,
+            },
+        )
+        "#);
+    }
+
+    #[test]
+    fn test_listed_non_source_target_remains_navigable() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/app.ts",
+            "import data from './データ.json';\nexport { data };\n",
+        );
+        write(dir.path(), "src/データ.json", "{\"value\":1}\n");
+        let graph = graph(
+            dir.path(),
+            &["src/app.ts", "src/データ.json"],
+            SourceUniverse::Complete,
+        );
+
+        let result = graph.dependencies("src/app.ts").unwrap();
+        assert_eq!(
+            result.edges[0].target,
+            DependencyTarget::Path("src/データ.json".into())
+        );
+        assert!(graph.is_listed("src/データ.json"));
+    }
+
+    #[test]
+    fn test_tsconfig_alias_and_external_package_resolution() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "tsconfig.json",
+            r##"{"compilerOptions":{"baseUrl":".","paths":{"#db/*":["db/*"]}}}"##,
+        );
+        write(
+            dir.path(),
+            "src/app.ts",
+            "import { db } from '#db/client';\nimport pkg from 'pkg';\n",
+        );
+        write(dir.path(), "db/client.ts", "export const db = 1;\n");
+        write(
+            dir.path(),
+            "node_modules/pkg/package.json",
+            r#"{"name":"pkg","main":"index.js"}"#,
+        );
+        write(
+            dir.path(),
+            "node_modules/pkg/index.js",
+            "module.exports = 1;\n",
+        );
+        let graph = graph(
+            dir.path(),
+            &["src/app.ts", "db/client.ts"],
+            SourceUniverse::Complete,
+        );
+        let result = graph.dependencies("src/app.ts").unwrap();
+
+        assert_eq!(
+            result.edges[0].target,
+            DependencyTarget::Path("db/client.ts".into())
+        );
+        assert_eq!(
+            result.edges[1].target,
+            DependencyTarget::External("pkg".into())
+        );
+        assert_eq!(result.guarantee, DependencyGuarantee::Exact);
+    }
+
+    #[test]
+    fn test_rust_dependencies_and_dependents_are_approximate() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "src/lib.rs",
+            "mod child;\nuse crate::child::Thing;\n",
+        );
+        write(dir.path(), "src/child.rs", "pub struct Thing;\n");
+        let graph = graph(
+            dir.path(),
+            &["src/lib.rs", "src/child.rs"],
+            SourceUniverse::Complete,
+        );
+
+        let deps = graph.dependencies("src/lib.rs").unwrap();
+        assert_eq!(deps.guarantee, DependencyGuarantee::Approximate);
+        assert!(deps
+            .edges
+            .iter()
+            .all(|edge| { edge.target == DependencyTarget::Path("src/child.rs".into()) }));
+        let rdeps = graph.dependents("src/child.rs").unwrap();
+        assert_eq!(rdeps.guarantee, DependencyGuarantee::Approximate);
+        assert_eq!(rdeps.edges.len(), 2);
+    }
+
+    #[test]
+    fn test_reverse_dependencies_require_a_complete_source_universe() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/a.ts", "import './b';\n");
+        write(dir.path(), "src/b.ts", "export const b = 1;\n");
+        write(dir.path(), "src/data.json", "{\"value\":1}\n");
+
+        let exact = graph(
+            dir.path(),
+            &["src/a.ts", "src/b.ts", "src/data.json"],
+            SourceUniverse::Complete,
+        );
+        assert_eq!(
+            exact.dependents("src/b.ts").unwrap().guarantee,
+            DependencyGuarantee::Exact
+        );
+
+        let partial = graph(
+            dir.path(),
+            &["src/a.ts", "src/b.ts"],
+            SourceUniverse::Partial,
+        );
+        assert_eq!(
+            partial.dependents("src/b.ts").unwrap().guarantee,
+            DependencyGuarantee::Approximate
+        );
+    }
+
+    #[test]
+    fn test_high_fan_in_query_reports_total_while_bounding_projected_edges() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/center.ts", "export const center = 1;\n");
+        let mut paths = vec!["src/center.ts".to_owned()];
+        for index in 0..250 {
+            let path = format!("src/importer_{index:03}.ts");
+            write(
+                dir.path(),
+                &path,
+                &format!("import './center';\nexport const value{index} = {index};\n"),
+            );
+            paths.push(path);
+        }
+        let mut analyses = analyses(dir.path(), &paths);
+        let graph = ModuleGraph::from_analyses(
+            dir.path(),
+            &paths,
+            &mut analyses,
+            SourceUniverse::Complete,
+            &CancellationToken::new(),
+        )
+        .expect("graph build");
+
+        let (result, total) = graph.dependents_bounded("src/center.ts", 20).unwrap();
+        assert_eq!(total, 250);
+        assert_eq!(result.edges.len(), 20);
+        assert_eq!(result.guarantee, DependencyGuarantee::Exact);
+    }
+
+    #[test]
+    fn test_missing_import_supported_analysis_makes_rdeps_approximate() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/a.ts", "import './b';\n");
+        write(dir.path(), "src/b.ts", "export const b = 1;\n");
+        let oversized = "x".repeat(MAX_INDEXED_FILE_BYTES as usize + 1);
+        write(dir.path(), "src/oversized.ts", &oversized);
+
+        let graph = graph(
+            dir.path(),
+            &["src/a.ts", "src/b.ts", "src/oversized.ts"],
+            SourceUniverse::Complete,
+        );
+        assert_eq!(
+            graph.dependents("src/b.ts").unwrap().guarantee,
+            DependencyGuarantee::Approximate
+        );
+    }
+
+    #[test]
+    fn test_unanalyzed_stub_does_not_claim_to_have_no_imports() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/app.ts", "import './oversized';\n");
+        write(
+            dir.path(),
+            "src/oversized.ts",
+            &"x".repeat(MAX_INDEXED_FILE_BYTES as usize + 1),
+        );
+
+        let graph = graph(
+            dir.path(),
+            &["src/app.ts", "src/oversized.ts"],
+            SourceUniverse::Complete,
+        );
+
+        assert!(graph.dependencies("src/oversized.ts").is_none());
+        assert!(graph.dependents("src/oversized.ts").is_none());
+    }
+
+    struct PollCancel {
+        remaining: AtomicUsize,
+    }
+
+    impl CancelSignal for PollCancel {
+        fn is_cancelled(&self) -> bool {
+            self.remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_err()
+        }
+    }
+
+    #[test]
+    fn test_graph_fold_releases_analysis_import_vectors_after_copying_edges() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/app.ts", "import './target';\n");
+        write(dir.path(), "src/target.ts", "export const target = 1;\n");
+        let paths = vec!["src/app.ts".to_owned(), "src/target.ts".to_owned()];
+        let mut analyses = analyses(dir.path(), &paths);
+        assert!(analyses.iter().any(|analysis| !analysis.imports.is_empty()));
+
+        let graph = ModuleGraph::from_analyses(
+            dir.path(),
+            &paths,
+            &mut analyses,
+            SourceUniverse::Complete,
+            &CancellationToken::new(),
+        )
+        .expect("graph build");
+
+        assert!(analyses.iter().all(|analysis| analysis.imports.is_empty()));
+        assert_eq!(graph.dependencies("src/app.ts").unwrap().edges.len(), 1);
+    }
+
+    #[test]
+    fn test_graph_fold_observes_cancellation_between_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "src/target.ts", "export const target = 1;\n");
+        let mut paths: Vec<_> = (0..20)
+            .map(|index| {
+                let path = format!("src/file_{index}.ts");
+                write(
+                    dir.path(),
+                    &path,
+                    &format!("import './target';\nexport const value{index} = {index};\n"),
+                );
+                path
+            })
+            .collect();
+        paths.push("src/target.ts".to_string());
+        let mut analyses = analyses(dir.path(), &paths);
+        let import_positions: Vec<_> = analyses
+            .iter()
+            .enumerate()
+            .filter_map(|(index, analysis)| (!analysis.imports.is_empty()).then_some(index))
+            .collect();
+        assert!(import_positions.len() >= 2);
+        let resolvers = resolver_set(dir.path(), &paths, &CancellationToken::new()).unwrap();
+        let cancel = PollCancel {
+            // Permit exactly one insertion, then cancel the next fold step.
+            remaining: AtomicUsize::new(1),
+        };
+
+        assert!(fold_analyses_into_graph(&mut analyses, &resolvers, &cancel).is_none());
+        assert!(analyses[import_positions[0]].imports.is_empty());
+        assert!(!analyses[import_positions[1]].imports.is_empty());
+    }
+
+    #[test]
+    fn test_import_support_matches_hearth_registry() {
+        for path in ["src/lib.rs", "src/app.ts", "src/app.tsx", "src/app.js"] {
+            assert!(supports_imports(path), "{path}");
+        }
+        for path in ["src/main.go", "README.md", "style.css"] {
+            assert!(!supports_imports(path), "{path}");
+        }
+    }
+}

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -9,9 +9,10 @@ use std::path::Path;
 use std::sync::LazyLock;
 
 use hearth_graph::{
-    BuildOptions, FileSymbols as HearthFileSymbols, FsLoader, IndexBuild as HearthIndexBuild,
-    LanguageId, LanguageRegistry, LanguageSpec, Symbol as HearthSymbol,
-    SymbolIndex as HearthSymbolIndex, SymbolKind as HearthSymbolKind, SymbolRef as HearthSymbolRef,
+    BuildOptions, FileAnalysis as HearthFileAnalysis, FileSymbols as HearthFileSymbols, FsLoader,
+    IndexBuild as HearthIndexBuild, LanguageId, LanguageRegistry, LanguageSpec,
+    Symbol as HearthSymbol, SymbolIndex as HearthSymbolIndex, SymbolKind as HearthSymbolKind,
+    SymbolRef as HearthSymbolRef,
 };
 use rustc_hash::FxHashMap;
 
@@ -305,6 +306,30 @@ impl SymbolIndex {
         ))
     }
 
+    /// Consume the symbol half of Hearth's shared symbol/import analyses.
+    pub(crate) fn from_analyses_cancellable(
+        files: Vec<HearthFileAnalysis>,
+        cancel: &dyn CancelSignal,
+    ) -> Option<Self> {
+        let mut symbol_files = Vec::with_capacity(files.len());
+        for (index, analysis) in files.into_iter().enumerate() {
+            if index.is_multiple_of(1_024) && cancel.is_cancelled() {
+                return None;
+            }
+            symbol_files.push(HearthFileSymbols {
+                path: analysis.path,
+                content_hash: analysis.content_hash,
+                symbols: analysis.symbols,
+            });
+        }
+        if cancel.is_cancelled() {
+            return None;
+        }
+        let inner =
+            HearthSymbolIndex::from_files(symbol_files, symbol_language_registry().generation());
+        Self::project_hearth(inner, Some(cancel))
+    }
+
     /// Build an index by reading and parsing repository-relative paths.
     ///
     /// Blocking and CPU-bound — call from `spawn_blocking`.
@@ -336,13 +361,22 @@ impl SymbolIndex {
     }
 
     fn from_hearth(inner: HearthSymbolIndex) -> Self {
+        Self::project_hearth(inner, None).expect("uncancellable symbol projection was cancelled")
+    }
+
+    fn project_hearth(inner: HearthSymbolIndex, cancel: Option<&dyn CancelSignal>) -> Option<Self> {
         let mut files = Vec::with_capacity(inner.file_count());
         let mut file_by_path = FxHashMap::default();
         file_by_path.reserve(inner.file_count());
         let mut symbol_projection = FxHashMap::default();
         symbol_projection.reserve(inner.symbol_count());
+        let mut projected_symbols = 0_usize;
 
-        for path in inner.paths() {
+        for (path_position, path) in inner.paths().enumerate() {
+            if path_position.is_multiple_of(1_024) && cancel.is_some_and(CancelSignal::is_cancelled)
+            {
+                return None;
+            }
             let hearth_symbols = inner
                 .file_symbols(path)
                 .expect("hearth-graph path iterator returned a missing file");
@@ -350,6 +384,12 @@ impl SymbolIndex {
             let mut symbols = Vec::with_capacity(hearth_symbols.len());
 
             for (symbol_position, symbol) in hearth_symbols.iter().enumerate() {
+                if projected_symbols.is_multiple_of(1_024)
+                    && cancel.is_some_and(CancelSignal::is_cancelled)
+                {
+                    return None;
+                }
+                projected_symbols += 1;
                 let key = std::ptr::from_ref(symbol) as usize;
                 let previous = symbol_projection.insert(key, (file_position, symbol_position));
                 assert!(
@@ -370,12 +410,15 @@ impl SymbolIndex {
             });
         }
 
-        Self {
+        if cancel.is_some_and(CancelSignal::is_cancelled) {
+            return None;
+        }
+        Some(Self {
             inner: Box::new(inner),
             files,
             file_by_path,
             symbol_projection,
-        }
+        })
     }
 
     /// Total number of indexed symbols.
@@ -463,6 +506,27 @@ mod tests {
         fn is_cancelled(&self) -> bool {
             self.polls.fetch_add(1, Ordering::SeqCst) >= self.limit
         }
+    }
+
+    #[test]
+    fn test_combined_symbol_projection_observes_cancellation_between_files() {
+        let files = (0..2_048)
+            .map(|index| HearthFileAnalysis {
+                path: format!("src/file_{index:04}.ts").into(),
+                content_hash: index as u64,
+                language: Some("typescript".into()),
+                symbols: Vec::new(),
+                imports: Vec::new(),
+                has_opaque_imports: false,
+            })
+            .collect();
+        let cancel = PollCountCancel {
+            limit: 1,
+            polls: AtomicUsize::new(0),
+        };
+
+        assert!(SymbolIndex::from_analyses_cancellable(files, &cancel).is_none());
+        assert!(cancel.polls.load(Ordering::SeqCst) >= 2);
     }
 
     fn outline(source: &str, filename: &str) -> Vec<(String, SymbolKind, usize, usize)> {

--- a/src/ui/browse.rs
+++ b/src/ui/browse.rs
@@ -17,7 +17,8 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::app::browse::{
     BlameCoverage, BlameGutter, BlameGutterWidth, BlameState, BrowseCommitDiffState, BrowseOverlay,
-    BrowseState, PrLookupState, BLAME_AUTHOR_WIDTH, BLAME_FULL_WIDTH, BLAME_IDENTITY_WIDTH,
+    BrowseState, ModuleGraphDirection, ModuleGraphPanel, PrLookupState, BLAME_AUTHOR_WIDTH,
+    BLAME_FULL_WIDTH, BLAME_IDENTITY_WIDTH,
 };
 use crate::app::browse_discussion::{
     DiscussionIndex, DiscussionView, LineDiscussionFailure, LineDiscussionState,
@@ -708,9 +709,10 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 " blame covers {blame_lines} lines, this file shows {buffer_lines} — reopen the file to refresh"
             )),
             Some(BlameCoverage::Exact) | None => std::borrow::Cow::Owned(format!(
-                " {} outline | {} search | {} blame | {} diff | {} PR | {} discuss | {} def | {} edit | {} back",
+                " {} outline | {} search | {} imports | {} blame | {} diff | {} PR | {} discuss | {} def | {} edit | {} back",
                 kb.symbol_outline.display(),
                 kb.symbol_search.display(),
+                kb.module_graph.display(),
                 kb.toggle_blame.display(),
                 kb.open_blame_commit.display(),
                 kb.open_blame_pr.display(),
@@ -763,6 +765,8 @@ fn render_overlay(frame: &mut Frame, app: &mut App) {
             ref query,
             selected,
         } => render_symbol_search(frame, state, query, selected),
+        BrowseOverlay::ModuleGraphLoading { .. } => render_module_graph_loading(frame),
+        BrowseOverlay::ModuleGraph(ref panel) => render_module_graph(frame, panel),
     }
 }
 
@@ -938,6 +942,90 @@ fn render_outline(frame: &mut Frame, state: &BrowseState, selected: usize) {
     frame.render_widget(list, area);
 }
 
+fn render_module_graph_loading(frame: &mut Frame) {
+    let area = overlay_rect(frame.area(), 80, 70);
+    clear_overlay_area(frame, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title("Imports (loading…)")
+        .title_bottom(Line::from(Span::styled(
+            " Esc cancel ",
+            Style::default().fg(Color::DarkGray),
+        )));
+    frame.render_widget(
+        Paragraph::new(" Resolving direct and reverse dependencies…").block(block),
+        area,
+    );
+}
+
+fn render_module_graph(frame: &mut Frame, panel: &ModuleGraphPanel) {
+    let area = overlay_rect(frame.area(), 80, 70);
+    clear_overlay_area(frame, area);
+
+    let current = panel.current();
+    let inner_height = area.height.saturating_sub(2) as usize;
+    let offset = scroll_offset(panel.selected, current.rows.len(), inner_height);
+    let items: Vec<ListItem> = if current.rows.is_empty() {
+        let empty = match panel.direction {
+            ModuleGraphDirection::Dependencies => " No imports.",
+            ModuleGraphDirection::Dependents => " No importers.",
+        };
+        vec![ListItem::new(Line::from(Span::styled(
+            empty,
+            Style::default().fg(Color::DarkGray),
+        )))]
+    } else {
+        current
+            .rows
+            .iter()
+            .enumerate()
+            .skip(offset)
+            .take(inner_height)
+            .map(|(index, row)| {
+                let style = if index == panel.selected {
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default()
+                };
+                ListItem::new(Line::from(vec![
+                    Span::styled(" ", style),
+                    Span::styled(row.label.as_str(), style),
+                ]))
+            })
+            .collect()
+    };
+
+    let direction = match panel.direction {
+        ModuleGraphDirection::Dependencies => "Imports",
+        ModuleGraphDirection::Dependents => "Imported by",
+    };
+    let guarantee = match current.guarantee {
+        crate::module_graph::DependencyGuarantee::Exact => "exact",
+        crate::module_graph::DependencyGuarantee::Approximate => "approximate",
+    };
+    let edge_noun = if current.total == 1 { "edge" } else { "edges" };
+    let count = if current.rows.len() < current.total {
+        format!("{}/{} {edge_noun} shown", current.rows.len(), current.total)
+    } else {
+        format!("{} {edge_noun}", current.total)
+    };
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Cyan))
+            .title(format!("{direction} ({count}, {guarantee})"))
+            .title_bottom(Line::from(Span::styled(
+                " Tab/h/l switch | j/k move | Enter open | Esc close ",
+                Style::default().fg(Color::DarkGray),
+            ))),
+    );
+    frame.render_widget(list, area);
+}
+
 fn outline_row(symbol: &Symbol, selected: bool) -> Line<'static> {
     let style = if selected {
         Style::default()
@@ -1052,7 +1140,8 @@ mod tests {
     use super::*;
     use crate::app::browse::{
         build_file_patch, BlameAnnotation, BrowseCommitDiffState, BrowseState, IndexState,
-        OpenFile, PrLookupState, MAX_SYMBOL_SEARCH_RESULTS, MAX_VIEWABLE_FILE_LINES,
+        ModuleGraphDirection, ModuleGraphPanel, ModuleGraphRow, ModuleGraphRows, OpenFile,
+        PrLookupState, MAX_SYMBOL_SEARCH_RESULTS, MAX_VIEWABLE_FILE_LINES,
     };
     use crate::app::browse_discussion::{
         DiscussionIndex, DiscussionOutcome, DiscussionView, LineDiscussionFailure,
@@ -1064,6 +1153,7 @@ mod tests {
     use crate::filter::ListFilter;
     use crate::github::{parse_porcelain, CommitPullRequest, CommitPullRequestState};
     use crate::keybinding::{KeyBinding, KeySequence};
+    use crate::module_graph::DependencyGuarantee;
     use crate::symbols::{FileSymbols, Symbol, SymbolIndex, SymbolKind};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use insta::assert_snapshot;
@@ -1275,7 +1365,7 @@ mod tests {
         │                          ││                                                  │
         │                          ││                                                  │
         └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd def | gf ed
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
         "#);
     }
 
@@ -1590,8 +1680,8 @@ mod tests {
                 footer_at(&mut app, 60)
             ),
             @"
-        80:  o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd def | gf ed
-        60:  o outline | s search | gb blame | gc diff | gp PR | gr disc
+        80:  o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+        60:  o outline | s search | i imports | gb blame | gc diff | gp
         "
         );
     }
@@ -1616,7 +1706,7 @@ mod tests {
         │                          ││                                                  │
         │                          ││                                                  │
         └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd def | gf ed
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
         ");
     }
 
@@ -1658,7 +1748,7 @@ mod tests {
         │  main.rs                               ││aaaaaaa Alice Example 2h ago        1 fn main() {}                          │
         │                                        ││                                                                            │
         └────────────────────────────────────────┘└────────────────────────────────────────────────────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc back
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc back
         --- no time (90) ---
         ┌────────────────────────────────────────────────────────────────────────────────────────┐
         │Repo Browse - demo  1 files  symbols: -                                                 │
@@ -1667,7 +1757,7 @@ mod tests {
         │  main.rs                     ││aaaaaaa Alice Example      1 fn main() {}               │
         │                              ││                                                        │
         └──────────────────────────────┘└────────────────────────────────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd def | gf
         --- identity (70) ---
         ┌────────────────────────────────────────────────────────────────────┐
         │Repo Browse - demo  1 files  symbols: -                             │
@@ -1676,7 +1766,7 @@ mod tests {
         │  main.rs              ││aaaaaaa         1 fn main() {}             │
         │                       ││                                           │
         └───────────────────────┘└───────────────────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd d
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr di
         --- hidden (50) ---
         ┌────────────────────────────────────────────────┐
         │Repo Browse - demo  1 files  symbols: -         │
@@ -1685,7 +1775,7 @@ mod tests {
         │  main.rs       ││    1 fn main() {}            │
         │                ││                              │
         └────────────────┘└──────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR
+         o outline | s search | i imports | gb blame | gc
         ");
     }
 
@@ -1818,7 +1908,7 @@ mod tests {
         │                                        ││Uncommitted                         3 third                                 │
         │                                        ││                                                                            │
         └────────────────────────────────────────┘└────────────────────────────────────────────────────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc back
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc back
         ");
     }
 
@@ -1910,7 +2000,7 @@ mod tests {
         │  empty.rs                ││                                                  │
         │                          ││                                                  │
         └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd def | gf ed
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
         ");
     }
 
@@ -1935,7 +2025,7 @@ mod tests {
         │                          ││   29 line 29                                     ║
         │                          ││   30 line 30                                     █
         └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | gb blame | gc diff | gp PR | gr discuss | gd def | gf ed
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
         ");
     }
 
@@ -2232,6 +2322,189 @@ mod tests {
         assert!(out.contains("Outline (2 symbols)"), "{out}");
         assert!(out.contains("C App"), "{out}");
         assert!(out.contains("m run"), "{out}");
+    }
+
+    #[test]
+    fn test_render_module_graph_loading_overlay() {
+        let mut app = app_with_browse(&["src/app.ts"]);
+        let state = app.browse_state.as_mut().unwrap();
+        open_file(state, "src/app.ts", "import './helper';\n");
+        state.overlay = BrowseOverlay::ModuleGraphLoading {
+            request_id: 7,
+            path: "src/app.ts".to_string(),
+        };
+        app.state = AppState::RepoBrowseFile;
+
+        assert_snapshot!(render_at(&mut app, 60, 8), @"
+        ┌──────────────────────────────────────────────────────────┐
+        │Repo ┌Imports (loading…)────────────────────────────┐     │
+        └─────│ Resolving direct and reverse dependencies…   │─────┘
+        ┌Files│                                              │─────┐
+        │▼ src│                                              │     │
+        │    a└ Esc cancel ──────────────────────────────────┘     │
+        └───────────────────┘└─────────────────────────────────────┘
+         o outline | s search | i imports | gb blame | gc diff | gp
+        ");
+    }
+
+    #[test]
+    fn test_render_module_graph_outgoing_overlay() {
+        let mut app = app_with_browse(&["src/app.ts", "src/helper.ts"]);
+        let state = app.browse_state.as_mut().unwrap();
+        open_file(state, "src/app.ts", "import './helper';\n");
+        state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+            direction: ModuleGraphDirection::Dependencies,
+            selected: 0,
+            dependencies: ModuleGraphRows {
+                rows: vec![
+                    ModuleGraphRow {
+                        label: "[import] ./helper → src/helper.ts  :1".to_string(),
+                        jump: None,
+                    },
+                    ModuleGraphRow {
+                        label: "[import] react → package react  :2".to_string(),
+                        jump: None,
+                    },
+                    ModuleGraphRow {
+                        label: "[dynamic] ./missing → unresolved (not found)  :3".to_string(),
+                        jump: None,
+                    },
+                ],
+                total: 300,
+                guarantee: DependencyGuarantee::Exact,
+            },
+            dependents: ModuleGraphRows {
+                rows: Vec::new(),
+                total: 0,
+                guarantee: DependencyGuarantee::Exact,
+            },
+        });
+        app.state = AppState::RepoBrowseFile;
+
+        assert_snapshot!(render_at(&mut app, 100, 16), @"
+        ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+        │Repo Browse - demo  2 files  symbols: -                                                           │
+        └─────────┌Imports (3/300 edges shown, exact)────────────────────────────────────────────┐─────────┘
+        ┌Files────│ [import] ./helper → src/helper.ts  :1                                        │─────────┐
+        │▼ src/   │ [import] react → package react  :2                                           │         │
+        │    app.t│ [dynamic] ./missing → unresolved (not found)  :3                             │         │
+        │    helpe│                                                                              │         │
+        │         │                                                                              │         │
+        │         │                                                                              │         │
+        │         │                                                                              │         │
+        │         │                                                                              │         │
+        │         │                                                                              │         │
+        │         └ Tab/h/l switch | j/k move | Enter open | Esc close ──────────────────────────┘         │
+        │                                 ││                                                               │
+        └─────────────────────────────────┘└───────────────────────────────────────────────────────────────┘
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/E
+        ");
+    }
+
+    #[test]
+    fn test_render_module_graph_bounded_long_cjk_label() {
+        let mut app = app_with_browse(&["src/app.ts"]);
+        let label = crate::app::browse::bounded_module_graph_text(&"依存先".repeat(1_000));
+        assert!(unicode_width::UnicodeWidthStr::width(label.as_str()) <= 240);
+        let state = app.browse_state.as_mut().unwrap();
+        state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+            direction: ModuleGraphDirection::Dependencies,
+            selected: 0,
+            dependencies: ModuleGraphRows {
+                rows: vec![ModuleGraphRow { label, jump: None }],
+                total: 1,
+                guarantee: DependencyGuarantee::Exact,
+            },
+            dependents: ModuleGraphRows {
+                rows: Vec::new(),
+                total: 0,
+                guarantee: DependencyGuarantee::Exact,
+            },
+        });
+        app.state = AppState::RepoBrowseFile;
+
+        assert_snapshot!(render_at(&mut app, 80, 8), @"
+        ┌──────────────────────────────────────────────────────────────────────────────┐
+        │Repo Br┌Imports (1 edge, exact)───────────────────────────────────────┐       │
+        └───────│ 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先  │───────┘
+        ┌Files──│                                                              │───────┐
+        │▼ src/ │                                                              │       │
+        │    app└ Tab/h/l switch | j/k move | Enter open | Esc close ──────────┘       │
+        └──────────────────────────┘└──────────────────────────────────────────────────┘
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+        ");
+    }
+
+    #[test]
+    fn test_render_module_graph_incoming_approximate_overlay() {
+        let mut app = app_with_browse(&["src/app.ts", "src/helper.ts"]);
+        let state = app.browse_state.as_mut().unwrap();
+        open_file(state, "src/helper.ts", "export const helper = 1;\n");
+        state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+            direction: ModuleGraphDirection::Dependents,
+            selected: 0,
+            dependencies: ModuleGraphRows {
+                rows: Vec::new(),
+                total: 0,
+                guarantee: DependencyGuarantee::Approximate,
+            },
+            dependents: ModuleGraphRows {
+                rows: vec![ModuleGraphRow {
+                    label: "[use] src/app.rs:4  crate::helper".to_string(),
+                    jump: None,
+                }],
+                total: 1,
+                guarantee: DependencyGuarantee::Approximate,
+            },
+        });
+        app.state = AppState::RepoBrowseFile;
+
+        assert_snapshot!(render_at(&mut app, 80, 14), @"
+        ┌──────────────────────────────────────────────────────────────────────────────┐
+        │Repo Browse - demo  2 files  symbols: -                                       │
+        └───────┌Imported by (1 edge, approximate)─────────────────────────────┐───────┘
+        ┌Files──│ [use] src/app.rs:4  crate::helper                            │───────┐
+        │▼ src/ │                                                              │       │
+        │    app│                                                              │       │
+        │    hel│                                                              │       │
+        │       │                                                              │       │
+        │       │                                                              │       │
+        │       │                                                              │       │
+        │       └ Tab/h/l switch | j/k move | Enter open | Esc close ──────────┘       │
+        │                          ││                                                  │
+        └──────────────────────────┘└──────────────────────────────────────────────────┘
+         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+        ");
+    }
+
+    #[test]
+    fn test_empty_module_graph_overlay_clips_in_a_tiny_terminal() {
+        let mut app = app_with_browse(&["src/empty.ts"]);
+        let state = app.browse_state.as_mut().unwrap();
+        open_file(state, "src/empty.ts", "export {};\n");
+        state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+            direction: ModuleGraphDirection::Dependencies,
+            selected: 0,
+            dependencies: ModuleGraphRows {
+                rows: Vec::new(),
+                total: 0,
+                guarantee: DependencyGuarantee::Exact,
+            },
+            dependents: ModuleGraphRows {
+                rows: Vec::new(),
+                total: 0,
+                guarantee: DependencyGuarantee::Exact,
+            },
+        });
+        app.state = AppState::RepoBrowseFile;
+
+        assert_snapshot!(render_at(&mut app, 20, 5), @"
+        ┌Imports (0 edges, ┐
+        │ No imports.      │
+        │                  │
+        │                  │
+        └ Tab/h/l switch | ┘
+        ");
     }
 
     #[test]
@@ -2660,8 +2933,8 @@ mod tests {
 
     /// The same repair, on the other overlay.
     ///
-    /// `clear_overlay_area` has two call sites and the sibling test above only
-    /// covers the outline's. The symbol-search overlay is wider, so its left
+    /// `clear_overlay_area` has multiple call sites and the sibling test above
+    /// covers only the outline's. The symbol-search overlay is wider, so its left
     /// border lands on a different column and needs its own fixture — swapping
     /// its call for a bare `Clear` is invisible to every other test.
     #[test]
@@ -2708,6 +2981,43 @@ mod tests {
                 matches!(border, "│" | "┌" | "└"),
                 "row {y}: the overlay's left border is {border:?}"
             );
+        }
+    }
+
+    #[test]
+    fn test_module_graph_left_border_survives_a_wide_glyph_straddling_it() {
+        let paths: Vec<String> = (0..8).map(|i| format!("{i:0>4}日本語")).collect();
+        let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
+        let mut app = app_with_browse(&refs);
+        let area = overlay_rect(Rect::new(0, 0, 80, 14), 80, 70);
+        let bare = render_buffer(&mut app, 80, 14);
+        let straddling_rows: Vec<u16> = (area.top()..area.bottom())
+            .filter(|&y| bare[(7, y)].symbol() == "日")
+            .collect();
+        assert!(straddling_rows.len() >= 5);
+
+        if let Some(state) = app.browse_state.as_mut() {
+            state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+                direction: ModuleGraphDirection::Dependencies,
+                selected: 0,
+                dependencies: ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: DependencyGuarantee::Exact,
+                },
+                dependents: ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: DependencyGuarantee::Exact,
+                },
+            });
+        }
+        let overlaid = render_buffer(&mut app, 80, 14);
+        for y in area.top()..area.bottom() {
+            assert!(overlaid[(area.x - 1, y)].symbol().width() <= 1);
+        }
+        for y in straddling_rows {
+            assert!(matches!(overlaid[(area.x, y)].symbol(), "│" | "┌" | "└"));
         }
     }
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -1017,6 +1017,10 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
             fmt_key(&kb.symbol_search.display(), key_width)
         )),
         Line::from(format!(
+            "{}  Show imports and importers",
+            fmt_key(&kb.module_graph.display(), key_width)
+        )),
+        Line::from(format!(
             "{}  Toggle blame gutter",
             fmt_key(&kb.toggle_blame.display(), key_width)
         )),


### PR DESCRIPTION
## Summary
- build the symbol index and import graph from one shared `hearth-graph` analysis pass
- add Repository Browser overlays for direct imports and reverse importers, including local navigation and jump-back support
- keep graph queries off the UI thread with cancellation, stale-request rejection, and bounded retained/rendered results
- add configurable keybindings, architecture documentation, scenario and snapshot coverage, and module-graph benchmarks

## Guarantees and limits
- JavaScript and TypeScript dependency results are exact when the supported source universe is complete
- Rust import resolution is reported as approximate
- octorus retains at most 200 rows per direction while preserving the full edge total
- Hearth 0.1.1 still clones and sorts the full query result, so temporary query CPU and memory scale with actual fan-in

## Validation
- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `cargo bench --bench module_graph -- --test`
- `git diff --check`