### PR TITLE
Add UML module graph pane to Repository Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ There is a second message ahead of that one. `o` and `gd` answer questions about
 |---------|-----|-------------|
 | File outline | `o` | Symbols of the open file, indented by nesting depth, with the cursor's enclosing symbol pre-selected. Nesting follows the tags query: a Python method inside a class indents, a Rust method inside `impl` does not, because an `impl` block is not itself a tagged definition |
 | Symbol search | `s` | Fuzzy search across every symbol in the repository, best 200 matches listed; `Enter` opens the file at the definition |
-| Imports / imported by | `i` | Show direct imports and reverse dependencies of the open Rust, JavaScript, or TypeScript file. `Tab` or `h/l` switches direction; `Enter` opens a listed local file |
+| UML module graph | `i` | Open a right-side graph pane for the current Rust, JavaScript, or TypeScript file. The current module and its direct imports/importers are drawn as boxes and arrows; `Enter` opens a listed local module |
 | Go to definition | `gd` | Resolve the cursor **line** against the index — a CST match, not a grep for `fn <name>` |
 | Jump back | `Ctrl-o` | Return to the position before the last jump |
 
@@ -142,7 +142,7 @@ There is a second message ahead of that one. `o` and `gd` answer questions about
 
 Symbol extraction covers Rust, TypeScript, TSX, JavaScript, JSX, Go, Python, Ruby, C, C++, Java, C#, Lua, PHP, Swift, Bash, Zig, Haskell, MoonBit, and Markdown (headings become the outline of a README).
 
-The same background parse pass also extracts imports for Rust, TypeScript, TSX, JavaScript, and JSX. JavaScript/TypeScript resolution handles relative paths, packages, and a root `tsconfig.json` or `jsconfig.json`; Rust module resolution is deliberately best-effort. Dependency queries run off the UI thread; each direction retains up to 200 rows and shows the full edge count when truncated. The overlay labels every answer `exact` or `approximate`. Rust answers are approximate, as are reverse dependencies when the repository listing was truncated, a non-UTF-8 path was omitted, or an import-supporting file could not be analyzed.
+The same background parse pass also extracts imports for Rust, TypeScript, TSX, JavaScript, and JSX. JavaScript/TypeScript resolution handles relative paths, packages, and a root `tsconfig.json` or `jsconfig.json`; Rust module resolution is deliberately best-effort. Dependency queries run off the UI thread; each direction retains up to 200 nodes and shows the full edge count when truncated. Pressing `i` adds a third pane to the right of the code view: the current module uses a double-line box, related modules use UML-like boxes and directional connectors, and every answer is labelled `exact` or `approximate`. The pane follows file navigation and refreshes asynchronously for the new current file. Rust answers are approximate, as are reverse dependencies when the repository listing was truncated, a non-UTF-8 path was omitted, or an import-supporting file could not be analyzed.
 
 #### Repository Browser Keybindings
 
@@ -171,13 +171,14 @@ The same background parse pass also extracts imports for Rust, TypeScript, TSX, 
 | `gg` / `G` | Jump to first / last line |
 | `o` | File outline |
 | `s` | Repository symbol search |
-| `i` | Show imports / imported by |
+| `i` | Open or focus the right-side UML module graph |
 | `gb` | Toggle blame gutter |
 | `gc` | Open the blamed line's commit diff inside the browser |
 | `gp` | Open the PR that introduced the blamed line's commit |
 | `gd` | Go to definition |
 | `gf` | Open file in your editor at the cursor line |
 | `Ctrl-o` | Jump back |
+| `l` / `→` | Focus the graph pane when it is visible |
 | `h` / `←` / `q` / `Esc` | Back to the tree |
 
 **Outline / Symbol search overlay:**
@@ -191,14 +192,15 @@ The same background parse pass also extracts imports for Rust, TypeScript, TSX, 
 | `Enter` | Jump to the symbol |
 | `Esc` | Close |
 
-**Imports / imported by overlay:**
+**Module Graph Focus:**
 
 | Key | Action |
 |-----|--------|
 | `Tab`, `h` / `l`, `←` / `→` | Switch between outgoing imports and incoming importers |
-| `j` / `k`, `↑` / `↓` | Move selection |
-| `Enter` | Open a listed local target/importer; external, unresolved, and unlisted targets stay visible but do not open |
-| `Esc` | Close |
+| `j` / `k`, `↑` / `↓` | Select a module node |
+| `Enter` | Open a listed local target/importer; external, unresolved, and unlisted nodes stay visible but do not open |
+| `i` | Close the graph pane and return to code |
+| `Esc` / `q` | Return focus to code while leaving the graph pane visible |
 
 ### Pull Requests
 
@@ -1035,7 +1037,7 @@ go_to_definition = ["g", "d"]
 | `repo_browse` | `b` | Open the Repository Browser |
 | `symbol_outline` | `o` | File outline (browser only) |
 | `symbol_search` | `s` | Repository symbol search (browser only) |
-| `module_graph` | `i` | Show direct imports and reverse dependencies (browser file pane only) |
+| `module_graph` | `i` | Open/focus the UML module graph pane (browser file/graph panes only) |
 | `toggle_blame` | `gb` | Toggle blame gutter (browser file pane only) |
 | `open_blame_commit` | `gc` | Open the blamed line's commit diff (browser file pane only) |
 | `open_blame_pr` | `gp` | Open the PR for the blamed line's commit (browser file pane only) |

--- a/docs/module-graph.md
+++ b/docs/module-graph.md
@@ -2,7 +2,7 @@
 
 The Repository Browser import engine is an octorus-owned compatibility facade
 over `hearth-graph = "=0.1.1"`. Read this document when changing import
-extraction, resolver setup, graph guarantees, or the `i` dependency overlay.
+extraction, resolver setup, graph guarantees, or the `i` dependency graph pane.
 Browser task/state/rendering architecture remains in
 [`repo-browse-architecture.md`](repo-browse-architecture.md); symbol-specific
 behavior remains in [`symbol-index.md`](symbol-index.md).
@@ -158,43 +158,75 @@ configuration changes.
 
 ## 6. Browser state and interaction
 
-The graph lifecycle is independent state, although the same worker transitions
-it together with symbols:
+The repository graph lifecycle is independent state, although the same worker
+transitions it together with symbols:
 
 ```text
 ModuleGraphState
     Idle → Building → Ready(Arc<ModuleGraph>) | Failed
 ```
 
-The `i` action checks conditions in this order:
+Visibility and request progress for the right-side pane are a second typed
+lifecycle. They are not modal overlays:
+
+```text
+ModuleGraphPaneState
+    Closed ── i ──→ Loading { request_id, path } → Ready(ModuleGraphPanel)
+       ▲                   ▲                            │
+       │                   └─ Waiting { path } ← path ─┘
+       └──────────── close/error from every visible state
+```
+
+`Waiting` coalesces rapid file navigation. It cancels the old graph request but
+does not start another until the latest background file load succeeds. The
+existing superseded-file cancellation therefore prevents intermediate paths
+from launching Hearth queries whose internal materialize/sort phase cannot be
+interrupted in 0.1.1.
+
+`AppState::RepoBrowseGraph` represents graph-pane focus. Tree and code remain
+visible while the pane is loading or ready. With a closed pane, the `i` action
+checks conditions in this order:
 
 1. open file still loading → `Still opening this file`;
 2. graph idle/building → `Module graph is still building`;
 3. graph failed → `Module graph is unavailable`;
 4. unsupported file → `Import analysis is not supported for this file`;
 5. supported but skipped file → `Import analysis is unavailable for this file`;
-6. otherwise enter `BrowseOverlay::ModuleGraphLoading` and start a request-scoped
-   `spawn_blocking` query;
-7. install `BrowseOverlay::ModuleGraph` only when request id, requested path,
-   current open path, and browser context still match.
+6. otherwise enter `ModuleGraphPaneState::Loading`, focus
+   `AppState::RepoBrowseGraph`, and start a request-scoped `spawn_blocking`
+   query;
+7. install `ModuleGraphPaneState::Ready` only when request id, requested path,
+   and current open path still match.
 
-`Esc`, a changed open path, or closing the browser cancels the request and drops
-its receiver. A late delivery therefore cannot replace the current overlay.
-Direct and reverse rows are materialized on the blocking worker, never on the
-input or draw thread. Octorus retains at most 200 rows per direction and keeps
-the pre-truncation total so the title reports, for example,
-`200/5000 edges shown`. Each component is capped at 512 Unicode scalars and each
-final label at 240 terminal cells before retention. Rendering borrows label
-spans from the visible slice; it neither clones labels nor queries/walks the
-graph per frame.
+Pressing `i` while the pane is already visible only focuses it; pressing `i`
+from graph focus closes it and cancels any request. `Esc`/`q` returns focus to
+code without hiding or cancelling the pane. Opening another file while the pane is visible cancels the old query and enters
+`Waiting`; only the final successfully loaded file starts a new query. A file
+load failure, unsupported path, or unavailable analysis closes the pane.
+Closing the browser cancels the browser session token, so a late delivery cannot
+be installed.
+
+Direct and reverse nodes are materialized on the blocking worker, never on the
+input or draw thread. Octorus retains at most 200 nodes per direction and keeps
+the pre-truncation total so the title can report `3/5000 exact`. Each source
+component is capped at 512 Unicode scalars. The precomputed node and edge labels
+are each capped at 240 terminal cells before retention.
+
+The pane visualizes one direction at a time. The current module uses a
+UML-style double-line box; each direct relationship uses a single-line module
+box and a directional connector (`├─▶` for imports, `▲─┤` for importers).
+Package, unresolved, and unlisted nodes remain in the diagram but are not
+navigable.
 
 | Key | Behavior |
 |---|---|
-| `i` | Open the graph overlay from browser file focus |
+| `i` from file | Open or focus the graph pane |
+| `l` / `→` from file | Focus an already-visible graph pane |
 | `Tab`, `h/l`, `←/→` | Switch Imports / Imported by |
-| `j/k`, `↑/↓` | Move selection |
+| `j/k`, `↑/↓` | Select a module node |
 | `Enter` | Open a listed local target/importer |
-| `Esc` | Close |
+| `Esc` / `q` | Return focus to code, keeping the pane visible |
+| `i` from graph | Close the pane and return to code |
 
 Outgoing jumps open the target at its first line. Incoming jumps open the
 importer at the extracted import line. Both push the existing browser jump
@@ -216,9 +248,10 @@ cargo bench --bench module_graph
 ```
 
 The renderer is protected structurally rather than by this graph benchmark:
-`ModuleGraphPanel` owns at most 200 precomputed, 240-cell rows per direction;
-`render_module_graph` applies `skip(offset).take(viewport_height)` and borrows
-the retained labels.
+`ModuleGraphPanel` owns at most 200 precomputed nodes per direction, with
+separately bounded 240-cell node and edge labels. `render_module_graph_ready_pane`
+applies `skip(offset).take(visible_nodes)` and allocates only the three UML text
+lines for each visible node; it never walks Hearth or formats hidden rows.
 
 Hearth 0.1.1 has no bounded direct/reverse query API. It clones and sorts the
 full edge result before octorus can truncate it. Running that work in
@@ -234,13 +267,13 @@ upstream boundary explicitly.
 | `src/module_graph.rs` | import kinds/spans, JS/TS aliases/packages, Rust resolution, direct/reverse guarantees, stub/listed non-source availability, high fan-in bounds, observable cancellation, import-vector release |
 | `src/code_index.rs` / `src/symbols.rs` | one completed result containing symbols and graph edges, empty files, cancellation through post-analysis projection |
 | `src/app/browse.rs` | listing completeness, combined/query failure lifecycles, actual 250-importer panel limits, Unicode label bounds |
-| `src/app/input_browse.rs` | loading/open/switch/jump/back/CJK JSON/non-navigable/empty/pending/cancel/stale scenarios, single and sequence bindings |
-| `src/ui/browse.rs` | loading/outgoing/truncated/incoming/long-CJK/approximate/empty/tiny-terminal inline snapshots |
+| `src/app/input_browse.rs` | waiting/loading/open/switch/jump/back/CJK JSON/non-navigable/empty/pending/cancel/stale/file-failure scenarios, single and sequence bindings |
+| `src/ui/browse.rs` | waiting/loading/outgoing/truncated/incoming/long-CJK/approximate/empty/tiny-terminal inline snapshots |
 | `src/config/mod.rs` | default, serialization, overlap validation, one-diagnostic ownership, and round-trip |
 
 ## 9. Known limitations
 
-- no visual node-link or transitive-neighborhood UI;
+- the UML pane shows only the current module and one direct direction at a time; there is no transitive neighborhood, pan, zoom, or automatic graph layout;
 - no import-aware symbol disambiguation for `gd`;
 - no alias or re-export chain mapped to an exact destination symbol;
 - no incremental upsert/removal from filesystem watcher events;

--- a/docs/repo-browse-architecture.md
+++ b/docs/repo-browse-architecture.md
@@ -12,7 +12,7 @@ Read this before adding features.
 | `src/symbols.rs` | octorus compatibility facade over the Hearth symbol engine (see [symbol-index.md](symbol-index.md)) |
 | `src/module_graph.rs` | octorus compatibility facade over Hearth import resolution and graph queries (see [module-graph.md](module-graph.md)) |
 | `src/ui/browse.rs` | Rendering |
-| `src/app/input_browse.rs` | Key handling (2 panes + 3 browser overlays, plus PR/discussion modals) |
+| `src/app/input_browse.rs` | Key handling (3 focusable panes + 2 browser overlays, plus PR/discussion modals) |
 
 Do not put line counts in this table; they become stale whenever the browser or
 its compatibility facade changes. Count the current checkout when needed.
@@ -60,8 +60,9 @@ stateless `CancelSignal` and Hearth returns an `IndexBuild` outcome.
 
 ```
 AppState
- ├ RepoBrowseTree   focus on the tree pane
- └ RepoBrowseFile   focus on the file content pane
+ ├ RepoBrowseTree    focus on the tree pane
+ ├ RepoBrowseFile    focus on the file content pane
+ └ RepoBrowseGraph   focus on the right-side module graph pane
 ```
 
 Inside `BrowseState`:
@@ -75,6 +76,11 @@ index:     IndexState
 
 graph:     ModuleGraphState
            Idle → Building → Ready(Arc<ModuleGraph>) | Failed
+
+graph pane: ModuleGraphPaneState
+            Closed → Loading { request_id, path } → Ready(ModuleGraphPanel)
+                          ↑                           │
+                          └──── Waiting { path } ←────┘
 
 universe:  SourceUniverse
            Partial | Complete
@@ -98,8 +104,6 @@ PR lookup: PrLookupState
 
 overlay:   BrowseOverlay
            None | Outline { selected } | SymbolSearch { query, selected }
-                | ModuleGraphLoading { request_id, path }
-                | ModuleGraph(ModuleGraphPanel)
 
 filter:    Option<ListFilter>   ← reuses the existing list filter
 ```
@@ -110,9 +114,16 @@ an accelerator, not a precondition: while it is building, tree browsing, file
 viewing, and filtering all keep working. Symbol consumers `o` / `s` / `gd` and
 the graph consumer `i` put the reason into the footer instead of opening an
 overlay. A ready graph does not make a high-fan-in query synchronous:
-`i` transitions to `ModuleGraphLoading`, runs both directions in
-`spawn_blocking`, and installs `ModuleGraph` only when the request id and open
-path still match.
+`i` transitions the right-side pane to `ModuleGraphPaneState::Loading`, runs
+both directions in `spawn_blocking`, and installs `Ready(ModuleGraphPanel)` only
+when the request id and open path still match. The pane lifecycle is independent
+of focus: `Esc` can return to `RepoBrowseFile` while the request continues.
+Opening another file while the pane is visible cancels that request and enters
+`Waiting`. Only the final successfully loaded file starts a new graph query, so
+superseded file-load cancellation coalesces rapid navigation instead of
+launching uninterruptible Hearth sort work for every intermediate path. `i`
+from graph focus closes the pane and cancels; closing the browser cancels the
+parent session token.
 
 More than one message can come out. `o` and `gd` **check `open_is_pending()`
 first**, so while a file is loading, `Still opening this file` wins regardless
@@ -130,7 +141,7 @@ does not carry this check.
 | `o` | `Still opening this file` | `Symbol index is still building` | `No symbols in this file` if the target file has none, otherwise opens the outline |
 | `s` | (not checked) | `Symbol index is still building` | opens the search overlay |
 | `gd` | `Still opening this file` | `Symbol index is still building` | `No definition found` when it cannot resolve |
-| `i` | `Still opening this file` | `Module graph is still building` | enters a cancellable loading overlay, or reports unsupported/unavailable analysis |
+| `i` | `Still opening this file` | `Module graph is still building` | opens/focuses a cancellable right-side pane, or reports unsupported/unavailable analysis |
 
 `Symbol index is still building` is emitted on `index.ready().is_none()`.
 `IndexState::Failed` also satisfies that condition, so after a failed build the
@@ -365,16 +376,16 @@ panels. The draw loop never blocks.
 
 ## 4. Key-handling layers
 
-At the top of `handle_repo_browse_{tree,file}_input`, input is fed through the
-layers from the top down.
+At the top of `handle_repo_browse_{tree,file,graph}_input`, input is fed through
+the layers from the top down.
 
 ```
-1. Overlays (Outline / SymbolSearch / ModuleGraphLoading / ModuleGraph) ← modal; consume everything while open
-2. commit diff mode (file pane only)   ← blocks the source-file actions
-3. Filter input bar (tree pane only)   ← consumes all character input while open
-4. Shared by both panes (s / ? / Z / Ctrl-o)
-5. Sequences (tree: Space / and gg / file: gb, gc, gp, gr, gd, gf, gg)
-6. Single keys
+1. Overlays (Outline / SymbolSearch)   ← modal; consume everything while open
+2. commit diff mode (file pane only)  ← blocks the source-file actions
+3. Filter input bar (tree pane only)  ← consumes all character input while open
+4. Shared browse actions (s / ? / Z / Ctrl-o)
+5. Sequences (tree: Space / and gg / file: gb, gc, gp, gr, gd, gf, gg / graph: configured i)
+6. Focus-specific single keys
 ```
 
 **Why the sequence layer exists**: the default for `filter` is the two-key
@@ -387,11 +398,14 @@ list / diff view.
 `Ctrl-n` (clear the whole query with `Ctrl-u`). A search UI where you cannot
 type `j` is infuriating, so this is deliberate.
 
-**Input rules for the module graph overlay**: while loading, only `Esc` / the
-configured quit key cancels the request. Once ready it has no text input. `j/k`
-and arrows move, `Tab` or `h/l` switches Imports / Imported by, and `Enter`
-opens only a target represented in the original Git listing. Rows without a
-jump stay visible and report why they cannot be opened.
+**Input rules for the module graph pane**: `i` from file focus opens or focuses
+the pane; `l` / `→` also focuses an already-visible pane. While waiting/loading,
+graph navigation is ignored, but `Esc` / `q` can return to code without cancelling and
+`i` closes and cancels. Once ready, `j/k` and arrows move, `Tab` or `h/l`
+switches Imports / Imported by, and `Enter` opens only a target represented in
+the original Git listing. Nodes without a jump stay visible and report why they
+cannot be opened. Opening a node returns focus to code and refreshes the still
+visible pane for that new current file.
 
 ## 5. Keybinding registration caveats
 
@@ -437,10 +451,15 @@ before the sequence layer.
 ## 6. Rendering
 
 `src/ui/browse.rs`. In zen mode the header and footer are dropped and the whole
-frame becomes the two panes.
+frame becomes the active panes.
 
 - Tree pane: "loading spinner", "error", or "tree" according to `LoadState`
 - Content pane: nothing selected / the binary or oversized-file notice / the contents
+- Graph pane: absent when `Closed`; otherwise the remaining non-tree width is
+  split evenly between code and graph. `Waiting` shows the target module while
+  its file load settles; `Loading` shows an explicit dependency-resolving state.
+  `Ready` shows the double-line current module plus
+  three-line single-border relationship boxes and directional connectors
 - The content pane cursor scrolls with the diff view's margin behaviour:
   `clamp_scroll` calls the shared `margin_scroll_offset` (`src/diff_store.rs`),
   so the cursor rides the viewport centre and only walks to the edge at file
@@ -486,9 +505,11 @@ double-width glyph (CJK etc.), replaces that cell with a space. When a
 double-width glyph straddles the left border, ratatui's buffer diff skips the
 next cell and the border line never reaches the terminal. The right edge needs
 no such repair: overwriting the leading cell already leaves a space in the
-continuation cell. `render_outline` (60%×70%), `render_symbol_search`, and
-`render_module_graph` (both 80%×70%) all go through it. Any new overlay added to `src/ui/browse.rs` must
-also use `clear_overlay_area()` rather than a bare `Clear`. A continuation cell
+continuation cell. `render_outline` (60%×70%) and `render_symbol_search`
+(80%×70%) both go through it. The module graph is a real pane and deliberately
+does not clear or cover adjacent panes. Any new overlay added to
+`src/ui/browse.rs` must also use `clear_overlay_area()` rather than a bare
+`Clear`. A continuation cell
 is a space at the text level, so text snapshots alone cannot catch this mistake.
 Removing the repair fails
 `test_overlay_left_border_survives_a_wide_glyph_straddling_it`.
@@ -497,18 +518,19 @@ Removing the repair fails
 `test_overlay_rect_is_centred_and_bounded`. On 100×40, an 80%×50% rect becomes
 80×20 at (10, 10), and even on 10×4 it stays inside the terminal.
 `test_symbol_search_overlay_is_reviewably_clipped_in_a_tiny_terminal` and
-`test_empty_module_graph_overlay_clips_in_a_tiny_terminal` render their overlays
-at 20×5 and pin the clipped results as snapshots.
+`test_empty_module_graph_pane_clips_in_a_tiny_terminal` pin both overlay and pane
+clipping at 20×5.
 
-The module graph overlay never queries Hearth from the input or draw path.
+The module graph pane never queries Hearth from the input or draw path.
 `open_browse_module_graph()` starts a request-scoped blocking task; its delivery
 converts direct and reverse results into a `ModuleGraphPanel` only if the
-request/path context is still current. Each direction retains at most 200 rows
-plus the full edge count; components are capped at 512 Unicode scalars and final
-labels at 240 terminal cells. `render_module_graph()` borrows label spans from
-only `skip(offset).take(inner_height)`, preserving O(viewport) redraw cost even
-when the repository graph is large. Hearth 0.1.1 still materializes and sorts all
-matching edges inside the blocking task before octorus can truncate them; see
+request/path context is still current. Each direction retains at most 200 nodes
+plus the full edge count; components are capped at 512 Unicode scalars and both
+final node and edge labels at 240 terminal cells. `render_module_graph_ready_pane()`
+formats only `skip(offset).take(visible_nodes)`, three lines per visible UML
+node, preserving O(viewport) redraw cost even when the repository graph is
+large. Hearth 0.1.1 still materializes and sorts all matching edges inside the
+blocking task before octorus can truncate them; see
 [module-graph.md](module-graph.md).
 
 ## 7. Tests
@@ -526,8 +548,8 @@ is "where are the tests for what", so that table stays:
 | `src/symbols.rs` | Hearth-registry extraction snapshots, compatibility boundaries (including C macro merging, empty files, duplicate paths, CJK and checked conversion), projected index refs, search, and build cancellation |
 | `src/code_index.rs` | one-pass combined symbol/import result and cancellation |
 | `src/module_graph.rs` | JS/TS/Rust import extraction and resolution, listed non-source navigation, path projection, direct/reverse guarantees, cancellation |
-| `src/ui/browse.rs` | inline rendering snapshots, graph loading/outgoing/incoming/truncated/long-CJK/empty/tiny states, wide-glyph border repair |
-| `src/app/input_browse.rs` | **scenario tests** (tree navigation, outline/search, graph cancel/stale/CJK JSON/empty/switch/jump/back, blame/history) |
+| `src/ui/browse.rs` | inline rendering snapshots, graph-pane loading/outgoing/incoming/truncated/long-CJK/empty/tiny states, focus borders, wide-glyph overlay repair |
+| `src/app/input_browse.rs` | **scenario tests** (tree navigation, outline/search, graph focus/close/cancel/restart/CJK JSON/empty/switch/jump/back, blame/history) |
 | `src/main.rs` | the flag set allowed to start without a repository (including `--browse`) |
 | `tests/cli.rs` | e2e launching the binary via `assert_cmd` (non-git directory, git repo without a GitHub remote) |
 

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -75,7 +75,7 @@ fn admit_commit_diff_for_cache(diff_text: String) -> Result<String, String> {
     }
 }
 
-/// Maximum rows retained per direction in the module-graph overlay.
+/// Maximum rows retained per direction in the module-graph pane.
 ///
 /// Hearth 0.1.1 materializes the full sorted query result, but bounding the
 /// octorus projection prevents unbounded labels and UI state for high fan-in.
@@ -143,7 +143,10 @@ impl App {
     /// Drain background browse channels: file list, symbol index, highlighting.
     pub(crate) fn poll_browse_updates(&mut self) {
         let tab_width = self.config.diff.tab_width;
-        let browse_file_active = self.state == AppState::RepoBrowseFile;
+        let browse_file_active = matches!(
+            self.state,
+            AppState::RepoBrowseFile | AppState::RepoBrowseGraph
+        );
         let Some(state) = self.browse_state.as_mut() else {
             return;
         };
@@ -154,24 +157,28 @@ impl App {
         let mut completed_pr_lookup = None;
         let mut completed_line_discussion = None;
 
-        let module_graph_context_moved = match &state.overlay {
-            BrowseOverlay::ModuleGraphLoading { path, .. } => {
-                !browse_file_active
-                    || state
-                        .open
-                        .as_ref()
-                        .is_none_or(|open| open.path.as_str() != path)
+        let module_graph_refresh_path = state
+            .module_graph_pane
+            .path()
+            .and_then(|pane_path| {
+                state
+                    .open
+                    .as_ref()
+                    .map(|open| open.path.as_str())
+                    .filter(|open_path| *open_path != pane_path)
+            })
+            .map(str::to_string);
+        if let Some(path) = module_graph_refresh_path {
+            if state.open_is_pending() {
+                state.cancel_module_graph_query();
+                state.module_graph_pane = ModuleGraphPaneState::Waiting { path };
+            } else if let Err(message) = state.start_module_graph_query_for_path(path) {
+                state.close_module_graph_pane();
+                state.status = Some(message.to_string());
+                if self.state == AppState::RepoBrowseGraph {
+                    self.state = AppState::RepoBrowseFile;
+                }
             }
-            BrowseOverlay::None
-            | BrowseOverlay::Outline { .. }
-            | BrowseOverlay::SymbolSearch { .. }
-            | BrowseOverlay::ModuleGraph(_) => false,
-        };
-        if module_graph_context_moved {
-            state.cancel_module_graph_query();
-            state.overlay = BrowseOverlay::None;
-            state.status =
-                Some("Dependency query abandoned because the open file changed".to_string());
         }
 
         if let PrLookupState::Loading { .. } = &state.pr_lookup {
@@ -257,16 +264,15 @@ impl App {
                     state.module_graph_query_receiver = None;
                     state.module_graph_query_cancel = None;
                     let current = matches!(
-                        &state.overlay,
-                        BrowseOverlay::ModuleGraphLoading { request_id, path }
+                        &state.module_graph_pane,
+                        ModuleGraphPaneState::Loading { request_id, path }
                             if *request_id == delivery.request_id && path == &delivery.path
                     ) && state
                         .open
                         .as_ref()
                         .is_some_and(|open| open.path == delivery.path);
                     if current {
-                        state.status = None;
-                        state.overlay = BrowseOverlay::ModuleGraph(delivery.panel);
+                        state.module_graph_pane = ModuleGraphPaneState::Ready(delivery.panel);
                     }
                 }
                 Err(mpsc::error::TryRecvError::Empty) => {}
@@ -277,10 +283,16 @@ impl App {
                         .take()
                         .is_some_and(|cancel| cancel.is_cancelled());
                     if !cancelled
-                        && matches!(state.overlay, BrowseOverlay::ModuleGraphLoading { .. })
+                        && matches!(
+                            state.module_graph_pane,
+                            ModuleGraphPaneState::Loading { .. }
+                        )
                     {
-                        state.overlay = BrowseOverlay::None;
+                        state.module_graph_pane = ModuleGraphPaneState::Closed;
                         state.status = Some("Dependency query task ended".to_string());
+                        if self.state == AppState::RepoBrowseGraph {
+                            self.state = AppState::RepoBrowseFile;
+                        }
                     }
                 }
             }
@@ -328,6 +340,20 @@ impl App {
                         install_file_load_failure(state, path, message, tab_width);
                     }
                 }
+            }
+        }
+
+        let waiting_graph_file_failed = matches!(
+            (&state.module_graph_pane, &state.open_load),
+            (
+                ModuleGraphPaneState::Waiting { path: waiting },
+                OpenLoad::Failed { path: failed, .. }
+            ) if waiting == failed
+        );
+        if waiting_graph_file_failed {
+            state.close_module_graph_pane();
+            if self.state == AppState::RepoBrowseGraph {
+                self.state = AppState::RepoBrowseFile;
             }
         }
 
@@ -552,6 +578,24 @@ impl App {
             }
         }
 
+        if file_ready {
+            let waiting_path = match (&state.module_graph_pane, &state.open) {
+                (ModuleGraphPaneState::Waiting { path }, Some(open)) if path == &open.path => {
+                    Some(path.clone())
+                }
+                _ => None,
+            };
+            if let Some(path) = waiting_path {
+                if let Err(message) = state.start_module_graph_query_for_path(path) {
+                    state.close_module_graph_pane();
+                    state.status = Some(message.to_string());
+                    if self.state == AppState::RepoBrowseGraph {
+                        self.state = AppState::RepoBrowseFile;
+                    }
+                }
+            }
+        }
+
         if paths_ready {
             self.start_symbol_index_build();
         }
@@ -657,6 +701,7 @@ impl App {
         let Some(state) = self.browse_state.as_mut() else {
             return;
         };
+        let module_graph_visible = state.module_graph_pane.is_visible();
         state.cancel_commit_diff_request();
         state.commit_diff = BrowseCommitDiffState::Off;
 
@@ -734,6 +779,12 @@ impl App {
             deliver_file_load(load, delivery_path, &request, &tx);
         });
 
+        if module_graph_visible {
+            state.cancel_module_graph_query();
+            state.module_graph_pane = ModuleGraphPaneState::Waiting {
+                path: path.to_string(),
+            };
+        }
         self.state = AppState::RepoBrowseFile;
     }
 
@@ -2114,7 +2165,7 @@ impl OpenFile {
     }
 }
 
-/// Direction shown by the module-graph overlay.
+/// Direction selected in the module-graph pane.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModuleGraphDirection {
     Dependencies,
@@ -2127,9 +2178,11 @@ pub struct ModuleGraphJump {
     pub line: usize,
 }
 
+/// Precomputed UML node text for one direct relationship.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleGraphRow {
-    pub label: String,
+    pub node: String,
+    pub edge: String,
     pub jump: Option<ModuleGraphJump>,
 }
 
@@ -2140,9 +2193,13 @@ pub struct ModuleGraphRows {
     pub guarantee: DependencyGuarantee,
 }
 
-/// Precomputed dependency rows; drawing never walks the graph.
+/// Precomputed dependency nodes; drawing never walks the graph.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ModuleGraphPanel {
+    /// Full repository-relative path used to validate request context.
+    pub path: String,
+    /// Bounded current-module label used by the renderer.
+    pub display_path: String,
     pub direction: ModuleGraphDirection,
     pub selected: usize,
     pub dependencies: ModuleGraphRows,
@@ -2169,7 +2226,37 @@ impl ModuleGraphPanel {
     }
 }
 
-/// Which overlay is on top of the browser, if any.
+/// Visibility and request lifecycle of the right-side module-graph pane.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub enum ModuleGraphPaneState {
+    #[default]
+    Closed,
+    /// A new file is still loading; query only the last successfully opened path.
+    Waiting {
+        path: String,
+    },
+    Loading {
+        request_id: u64,
+        path: String,
+    },
+    Ready(ModuleGraphPanel),
+}
+
+impl ModuleGraphPaneState {
+    pub fn is_visible(&self) -> bool {
+        !matches!(self, Self::Closed)
+    }
+
+    pub fn path(&self) -> Option<&str> {
+        match self {
+            Self::Closed => None,
+            Self::Waiting { path } | Self::Loading { path, .. } => Some(path),
+            Self::Ready(panel) => Some(&panel.path),
+        }
+    }
+}
+
+/// Which modal overlay is on top of the browser, if any.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub enum BrowseOverlay {
     #[default]
@@ -2178,10 +2265,6 @@ pub enum BrowseOverlay {
     Outline { selected: usize },
     /// Repository-wide fuzzy symbol search.
     SymbolSearch { query: String, selected: usize },
-    /// A request-scoped dependency panel build running off the UI thread.
-    ModuleGraphLoading { request_id: u64, path: String },
-    /// Direct imports and reverse dependencies of the open file.
-    ModuleGraph(ModuleGraphPanel),
 }
 
 /// Lifecycle of the file currently being opened.
@@ -2393,6 +2476,7 @@ pub struct BrowseState {
     pub scroll_offset: usize,
     pub index: IndexState,
     pub module_graph: ModuleGraphState,
+    pub module_graph_pane: ModuleGraphPaneState,
     module_graph_query_generation: u64,
     module_graph_query_cancel: Option<CancellationToken>,
     pub source_universe: SourceUniverse,
@@ -2452,6 +2536,7 @@ impl BrowseState {
             scroll_offset: 0,
             index: IndexState::Idle,
             module_graph: ModuleGraphState::Idle,
+            module_graph_pane: ModuleGraphPaneState::Closed,
             module_graph_query_generation: 0,
             module_graph_query_cancel: None,
             source_universe: SourceUniverse::Partial,
@@ -2482,7 +2567,7 @@ impl BrowseState {
         let (tx, rx) = mpsc::channel(1);
         self.module_graph_query_cancel = Some(cancel);
         self.module_graph_query_receiver = Some(rx);
-        self.overlay = BrowseOverlay::ModuleGraphLoading { request_id, path };
+        self.module_graph_pane = ModuleGraphPaneState::Loading { request_id, path };
 
         tokio::task::spawn_blocking(move || {
             let Some(panel) = build_module_graph_panel(&graph, &task_path, &task_cancel) else {
@@ -2498,11 +2583,38 @@ impl BrowseState {
         });
     }
 
+    pub(crate) fn start_module_graph_query_for_path(
+        &mut self,
+        path: String,
+    ) -> Result<(), &'static str> {
+        let graph = match &self.module_graph {
+            ModuleGraphState::Idle | ModuleGraphState::Building => {
+                return Err("Module graph is still building");
+            }
+            ModuleGraphState::Failed => return Err("Module graph is unavailable"),
+            ModuleGraphState::Ready(graph) => Arc::clone(graph),
+        };
+        if !graph.is_analyzed(&path) {
+            return Err(if crate::module_graph::supports_imports(&path) {
+                "Import analysis is unavailable for this file"
+            } else {
+                "Import analysis is not supported for this file"
+            });
+        }
+        self.start_module_graph_query(path, graph);
+        Ok(())
+    }
+
     pub(crate) fn cancel_module_graph_query(&mut self) {
         if let Some(cancel) = self.module_graph_query_cancel.take() {
             cancel.cancel();
         }
         self.module_graph_query_receiver = None;
+    }
+
+    pub(crate) fn close_module_graph_pane(&mut self) {
+        self.cancel_module_graph_query();
+        self.module_graph_pane = ModuleGraphPaneState::Closed;
     }
 
     #[cfg(test)]
@@ -2852,6 +2964,8 @@ fn build_module_graph_panel(
         cancel,
     )?;
     Some(ModuleGraphPanel {
+        path: path.to_string(),
+        display_path: bounded_module_graph_text(path),
         direction: ModuleGraphDirection::Dependencies,
         selected: 0,
         dependencies,
@@ -2893,11 +3007,11 @@ fn module_graph_rows(
                     ),
                 };
                 ModuleGraphRow {
-                    label: bounded_module_graph_text(&format!(
-                        "[{}] {} → {}  :{}",
+                    node: bounded_module_graph_text(&target),
+                    edge: bounded_module_graph_text(&format!(
+                        "[{}] {}  :{}",
                         edge.kind.label(),
                         specifier,
-                        target,
                         edge.line
                     )),
                     jump,
@@ -2907,12 +3021,12 @@ fn module_graph_rows(
                 let from = bounded_module_graph_text(&edge.from);
                 let specifier = bounded_module_graph_text(&edge.specifier);
                 ModuleGraphRow {
-                    label: bounded_module_graph_text(&format!(
-                        "[{}] {}:{}  {}",
+                    node: bounded_module_graph_text(&from),
+                    edge: bounded_module_graph_text(&format!(
+                        "[{}] {}  :{}",
                         edge.kind.label(),
-                        from,
-                        edge.line,
-                        specifier
+                        specifier,
+                        edge.line
                     )),
                     jump: graph.is_listed(&edge.from).then(|| ModuleGraphJump {
                         path: edge.from,
@@ -3739,27 +3853,21 @@ mod tests {
 
         assert_eq!(panel.dependents.total, 250);
         assert_eq!(panel.dependents.rows.len(), MAX_MODULE_GRAPH_RESULTS);
-        assert!(panel
-            .dependents
-            .rows
-            .iter()
-            .all(
-                |row| unicode_width::UnicodeWidthStr::width(row.label.as_str())
-                    <= MAX_MODULE_GRAPH_LABEL_WIDTH,
-            ));
+        assert!(panel.dependents.rows.iter().all(|row| {
+            unicode_width::UnicodeWidthStr::width(row.node.as_str()) <= MAX_MODULE_GRAPH_LABEL_WIDTH
+                && unicode_width::UnicodeWidthStr::width(row.edge.as_str())
+                    <= MAX_MODULE_GRAPH_LABEL_WIDTH
+        }));
 
         panel.set_direction(ModuleGraphDirection::Dependents);
         let mut app = App::new_for_test();
         let mut state = BrowseState::new(dir.path().to_path_buf(), AppState::FileList);
         state.set_paths(paths);
-        state.overlay = BrowseOverlay::ModuleGraph(panel);
+        state.module_graph_pane = ModuleGraphPaneState::Ready(panel);
         app.browse_state = Some(state);
-        app.state = AppState::RepoBrowseFile;
+        app.state = AppState::RepoBrowseGraph;
         let rendered = render_at(&mut app, 80, 12);
-        assert!(
-            rendered.contains("Imported by (200/250 edges shown, exact)"),
-            "{rendered}"
-        );
+        assert!(rendered.contains("Importers 200/250 exact"), "{rendered}");
     }
 
     // ===== cursor and scrolling =====
@@ -6852,25 +6960,74 @@ mod tests {
     }
 
     #[test]
+    fn test_module_graph_delivery_preserves_a_newer_status() {
+        let mut app = App::new_for_test();
+        let mut state = state_with_open_file(1);
+        let (tx, rx) = mpsc::channel(1);
+        state.module_graph_query_receiver = Some(rx);
+        state.module_graph_query_cancel = Some(CancellationToken::new());
+        state.module_graph_pane = ModuleGraphPaneState::Loading {
+            request_id: 9,
+            path: "src/a.rs".to_string(),
+        };
+        state.status = Some("No position to jump back to".to_string());
+        app.browse_state = Some(state);
+        tx.try_send(ModuleGraphPanelDelivery {
+            request_id: 9,
+            path: "src/a.rs".to_string(),
+            panel: ModuleGraphPanel {
+                path: "src/a.rs".to_string(),
+                display_path: "src/a.rs".to_string(),
+                direction: ModuleGraphDirection::Dependencies,
+                selected: 0,
+                dependencies: ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: DependencyGuarantee::Exact,
+                },
+                dependents: ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: DependencyGuarantee::Exact,
+                },
+            },
+        })
+        .unwrap();
+
+        app.poll_browse_updates();
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Ready(_)
+        ));
+        assert_eq!(state.status.as_deref(), Some("No position to jump back to"));
+    }
+
+    #[test]
     fn test_poll_browse_updates_reports_a_disconnected_module_graph_query() {
         let mut app = App::new_for_test();
         let mut state = state_with_open_file(1);
         let (tx, rx) = mpsc::channel::<ModuleGraphPanelDelivery>(1);
         state.module_graph_query_receiver = Some(rx);
         state.module_graph_query_cancel = Some(CancellationToken::new());
-        state.overlay = BrowseOverlay::ModuleGraphLoading {
+        state.module_graph_pane = ModuleGraphPaneState::Loading {
             request_id: 9,
             path: "src/a.rs".to_string(),
         };
         app.browse_state = Some(state);
-        app.state = AppState::RepoBrowseFile;
+        app.state = AppState::RepoBrowseGraph;
         drop(tx);
 
         app.poll_browse_updates();
 
         let state = app.browse_state.as_ref().unwrap();
-        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Closed
+        ));
         assert_eq!(state.status.as_deref(), Some("Dependency query task ended"));
+        assert_eq!(app.state, AppState::RepoBrowseFile);
         assert!(state.module_graph_query_receiver.is_none());
     }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -165,6 +165,7 @@ impl App {
                     AppState::RepoBrowseFile => {
                         self.handle_repo_browse_file_input(key, terminal)?
                     }
+                    AppState::RepoBrowseGraph => self.handle_repo_browse_graph_input(key),
                 }
             }
         }

--- a/src/app/input_browse.rs
+++ b/src/app/input_browse.rs
@@ -1,6 +1,6 @@
 //! Key handling for the Repository Browser.
 //!
-//! Two focus states (tree / file) plus modal outline, search, and module overlays.
+//! Three focus states (tree / file / graph) plus modal outline and search overlays.
 //! Overlays are checked first so they behave as modal layers rather than as an
 //! extra set of conditionals sprinkled through the pane handlers.
 
@@ -14,8 +14,10 @@ use std::io::Stdout;
 use crate::filter::ListFilter;
 use crate::keybinding::{event_to_keybinding, SequenceMatch};
 
+#[cfg(test)]
+use super::browse::ModuleGraphState;
 use super::browse::{
-    BrowseCommitDiffState, BrowseOverlay, IndexState, ModuleGraphDirection, ModuleGraphState,
+    BrowseCommitDiffState, BrowseOverlay, IndexState, ModuleGraphDirection, ModuleGraphPaneState,
     PrLookupState,
 };
 use super::browse_discussion::{DiscussionView, LineDiscussionState};
@@ -144,6 +146,17 @@ impl App {
         }
         if self.matches_single_key(&key, &kb.module_graph) {
             self.open_browse_module_graph();
+            return Ok(());
+        }
+
+        let graph_visible = self
+            .browse_state
+            .as_ref()
+            .is_some_and(|state| state.module_graph_pane.is_visible());
+        if graph_visible
+            && (key.code == KeyCode::Right || self.matches_single_key(&key, &kb.move_right))
+        {
+            self.state = AppState::RepoBrowseGraph;
             return Ok(());
         }
 
@@ -656,10 +669,6 @@ impl App {
                 self.handle_browse_symbol_search_input(key);
                 true
             }
-            BrowseOverlay::ModuleGraphLoading { .. } | BrowseOverlay::ModuleGraph(_) => {
-                self.handle_browse_module_graph_input(key);
-                true
-            }
         }
     }
 
@@ -765,9 +774,36 @@ impl App {
         state.clamp_symbol_search_selection();
     }
 
-    fn handle_browse_module_graph_input(&mut self, key: event::KeyEvent) {
+    pub(crate) fn handle_repo_browse_graph_input(&mut self, key: event::KeyEvent) {
+        if self.handle_line_discussion_input(&key) {
+            return;
+        }
+        if self.handle_pr_lookup_selection_input(&key) {
+            return;
+        }
+        if self.handle_browse_overlay_input(key) {
+            return;
+        }
+        if self.handle_browse_shared_input(&key) {
+            return;
+        }
+        if self.handle_browse_graph_module_sequence(&key) {
+            return;
+        }
+
         let kb = self.config.keybindings.clone();
-        let close = key.code == KeyCode::Esc || self.matches_single_key(&key, &kb.quit);
+        if self.matches_single_key(&key, &kb.module_graph) {
+            if let Some(state) = self.browse_state.as_mut() {
+                state.close_module_graph_pane();
+            }
+            self.state = AppState::RepoBrowseFile;
+            return;
+        }
+        if key.code == KeyCode::Esc || self.matches_single_key(&key, &kb.quit) {
+            self.state = AppState::RepoBrowseFile;
+            return;
+        }
+
         let down = self.matches_single_key(&key, &kb.move_down);
         let up = self.matches_single_key(&key, &kb.move_up);
         let confirm = self.matches_single_key(&key, &kb.open_panel);
@@ -781,20 +817,12 @@ impl App {
         let Some(state) = self.browse_state.as_mut() else {
             return;
         };
-        if matches!(state.overlay, BrowseOverlay::ModuleGraphLoading { .. }) {
-            if close {
-                state.cancel_module_graph_query();
-                state.overlay = BrowseOverlay::None;
+        let ModuleGraphPaneState::Ready(panel) = &mut state.module_graph_pane else {
+            if matches!(state.module_graph_pane, ModuleGraphPaneState::Closed) {
+                self.state = AppState::RepoBrowseFile;
             }
             return;
-        }
-        let BrowseOverlay::ModuleGraph(panel) = &mut state.overlay else {
-            return;
         };
-        if close {
-            state.overlay = BrowseOverlay::None;
-            return;
-        }
         if toggle {
             panel.set_direction(match panel.direction {
                 ModuleGraphDirection::Dependencies => ModuleGraphDirection::Dependents,
@@ -811,7 +839,6 @@ impl App {
         } else if confirm {
             if let Some(row) = panel.current_rows().get(panel.selected) {
                 jump = row.jump.clone();
-                state.overlay = BrowseOverlay::None;
                 if jump.is_none() {
                     state.status =
                         Some("This dependency target is not a listed repository file".into());
@@ -825,10 +852,44 @@ impl App {
         }
     }
 
+    fn handle_browse_graph_module_sequence(&mut self, key: &event::KeyEvent) -> bool {
+        self.check_sequence_timeout();
+        let binding = self.config.keybindings.module_graph.clone();
+        if binding.is_single() {
+            return false;
+        }
+        let Some(keybinding) = event_to_keybinding(key) else {
+            return false;
+        };
+
+        if !self.pending_keys.is_empty() {
+            self.push_pending_key(keybinding);
+            let close = self.try_match_sequence(&binding) == SequenceMatch::Full;
+            self.clear_pending_keys();
+            if close {
+                if let Some(state) = self.browse_state.as_mut() {
+                    state.close_module_graph_pane();
+                }
+                self.state = AppState::RepoBrowseFile;
+            }
+            return close;
+        }
+
+        if self.key_could_match_sequence(key, &binding) {
+            self.push_pending_key(keybinding);
+            return true;
+        }
+        false
+    }
+
     pub(crate) fn open_browse_module_graph(&mut self) {
         let Some(state) = self.browse_state.as_mut() else {
             return;
         };
+        if state.module_graph_pane.is_visible() {
+            self.state = AppState::RepoBrowseGraph;
+            return;
+        }
         if state.open_is_pending() {
             state.status = Some("Still opening this file".to_string());
             return;
@@ -837,27 +898,13 @@ impl App {
             state.status = Some("No file is open".to_string());
             return;
         };
-        let graph = match &state.module_graph {
-            ModuleGraphState::Idle | ModuleGraphState::Building => {
-                state.status = Some("Module graph is still building".to_string());
-                return;
+        match state.start_module_graph_query_for_path(path) {
+            Ok(()) => {
+                state.status = None;
+                self.state = AppState::RepoBrowseGraph;
             }
-            ModuleGraphState::Failed => {
-                state.status = Some("Module graph is unavailable".to_string());
-                return;
-            }
-            ModuleGraphState::Ready(graph) => std::sync::Arc::clone(graph),
-        };
-        if !graph.is_analyzed(&path) {
-            state.status = Some(if crate::module_graph::supports_imports(&path) {
-                "Import analysis is unavailable for this file".to_string()
-            } else {
-                "Import analysis is not supported for this file".to_string()
-            });
-            return;
+            Err(message) => state.status = Some(message.to_string()),
         }
-        state.status = None;
-        state.start_module_graph_query(path, graph);
     }
 
     pub(crate) fn open_browse_outline(&mut self) {
@@ -935,6 +982,7 @@ mod tests {
     use crate::app::browse::{
         build_file_patch, BlameGutter, BlameState, BrowseState, OpenFile, OpenLoad, PrLookupState,
     };
+    use crate::app::browse_discussion::{DiscussionIndex, DiscussionOutcome};
     use crate::app::{PrOpenSource, RepositoryAvailability};
     use crate::diff_store::{DiffScrollState, ScrollMode};
     use crate::github::{
@@ -1117,8 +1165,10 @@ mod tests {
         for _ in 0..2_000 {
             app.poll_browse_updates();
             if !matches!(
-                app.browse_state.as_ref().map(|state| &state.overlay),
-                Some(BrowseOverlay::ModuleGraphLoading { .. })
+                app.browse_state
+                    .as_ref()
+                    .map(|state| &state.module_graph_pane),
+                Some(ModuleGraphPaneState::Waiting { .. } | ModuleGraphPaneState::Loading { .. })
             ) {
                 return;
             }
@@ -2795,45 +2845,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_module_graph_overlay_loads_outgoing_and_switches_to_incoming() {
-        let dir = tempfile::tempdir().unwrap();
-        let app_source =
-            "import { helper } from './helper';\nexport function app() { return helper(); }\n";
-        let helper_source = "export function helper() { return 1; }\n";
-        let mut app = browsing_app_on_disk(
-            dir.path(),
-            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
-        );
-        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
-        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
-        app.state = AppState::RepoBrowseFile;
-
-        app.open_browse_module_graph();
-        assert!(matches!(
-            app.browse_state.as_ref().unwrap().overlay,
-            BrowseOverlay::ModuleGraphLoading { .. }
-        ));
-        settle_module_graph(&mut app).await;
-        let state = app.browse_state.as_ref().unwrap();
-        let BrowseOverlay::ModuleGraph(panel) = &state.overlay else {
-            panic!("module graph overlay must open");
-        };
-        assert_eq!(panel.direction, ModuleGraphDirection::Dependencies);
-        assert_eq!(panel.current_rows().len(), 1);
-        assert!(panel.current_rows()[0].label.contains("./helper"));
-
-        app.handle_repo_browse_file_input(press(KeyCode::Tab), &mut test_terminal())
-            .unwrap();
-        let state = app.browse_state.as_ref().unwrap();
-        let BrowseOverlay::ModuleGraph(panel) = &state.overlay else {
-            panic!("module graph overlay must stay open");
-        };
-        assert_eq!(panel.direction, ModuleGraphDirection::Dependents);
-        assert!(panel.current_rows().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_default_and_custom_sequence_module_graph_keys_open_the_overlay() {
+    async fn test_module_graph_key_opens_and_focuses_a_right_side_pane() {
         let dir = tempfile::tempdir().unwrap();
         let app_source = "import { helper } from './helper';\n";
         let helper_source = "export const helper = 1;\n";
@@ -2847,18 +2859,284 @@ mod tests {
 
         app.handle_repo_browse_file_input(press(KeyCode::Char('i')), &mut test_terminal())
             .unwrap();
+
+        assert_eq!(app.state, AppState::RepoBrowseGraph);
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            super::super::browse::ModuleGraphPaneState::Loading { .. }
+        ));
         assert!(matches!(
             app.browse_state.as_ref().unwrap().overlay,
-            BrowseOverlay::ModuleGraphLoading { .. }
+            BrowseOverlay::None
+        ));
+    }
+
+    #[test]
+    fn test_escape_returns_to_code_without_hiding_the_module_graph_pane() {
+        let mut app = browsing_app(&["src/app.ts"]);
+        attach_open_file(&mut app, "src/app.ts", "export {};\n", Vec::new());
+        app.state = AppState::RepoBrowseGraph;
+        app.browse_state.as_mut().unwrap().module_graph_pane =
+            super::super::browse::ModuleGraphPaneState::Loading {
+                request_id: 7,
+                path: "src/app.ts".to_string(),
+            };
+
+        app.handle_repo_browse_graph_input(press(KeyCode::Esc));
+
+        assert_eq!(app.state, AppState::RepoBrowseFile);
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            super::super::browse::ModuleGraphPaneState::Loading { .. }
+        ));
+    }
+
+    #[test]
+    fn test_discussion_modal_handles_escape_before_graph_focus_controls() {
+        let mut app = browsing_app(&["src/app.ts"]);
+        attach_open_file(&mut app, "src/app.ts", "export {};\n", Vec::new());
+        app.state = AppState::RepoBrowseGraph;
+        let state = app.browse_state.as_mut().unwrap();
+        state.module_graph_pane = ModuleGraphPaneState::Loading {
+            request_id: 7,
+            path: "src/app.ts".to_string(),
+        };
+        state.line_discussion = LineDiscussionState::Ready {
+            path: "src/app.ts".to_string(),
+            pr_numbers: vec![42],
+            index: DiscussionIndex {
+                comments: Vec::new(),
+                threads: Vec::new(),
+                line_threads: vec![Default::default()],
+                file_thread_count: 0,
+                comment_paths: Vec::new(),
+                outcome: DiscussionOutcome::Complete,
+            },
+            view: DiscussionView::ThreadList {
+                line: 0,
+                selected: 0,
+                scroll: 0,
+            },
+        };
+
+        app.handle_repo_browse_graph_input(press(KeyCode::Esc));
+
+        assert_eq!(app.state, AppState::RepoBrowseGraph);
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().line_discussion,
+            LineDiscussionState::Ready {
+                view: DiscussionView::Closed,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_right_from_code_refocuses_a_visible_module_graph_pane() {
+        let mut app = browsing_app(&["src/app.ts"]);
+        attach_open_file(&mut app, "src/app.ts", "export {};\n", Vec::new());
+        app.state = AppState::RepoBrowseFile;
+        app.browse_state.as_mut().unwrap().module_graph_pane = ModuleGraphPaneState::Loading {
+            request_id: 7,
+            path: "src/app.ts".to_string(),
+        };
+
+        app.handle_repo_browse_file_input(press(KeyCode::Right), &mut test_terminal())
+            .unwrap();
+
+        assert_eq!(app.state, AppState::RepoBrowseGraph);
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            ModuleGraphPaneState::Loading { .. }
+        ));
+    }
+
+    #[test]
+    fn test_graph_selection_and_direction_are_clamped_to_visible_nodes() {
+        let mut app = browsing_app(&["src/app.ts"]);
+        attach_open_file(&mut app, "src/app.ts", "export {};\n", Vec::new());
+        app.state = AppState::RepoBrowseGraph;
+        let row = |name: &str| super::super::browse::ModuleGraphRow {
+            node: name.to_string(),
+            edge: "[import] ./node  :1".to_string(),
+            jump: None,
+        };
+        app.browse_state.as_mut().unwrap().module_graph_pane =
+            ModuleGraphPaneState::Ready(super::super::browse::ModuleGraphPanel {
+                path: "src/app.ts".to_string(),
+                display_path: "src/app.ts".to_string(),
+                direction: ModuleGraphDirection::Dependencies,
+                selected: 0,
+                dependencies: super::super::browse::ModuleGraphRows {
+                    rows: vec![row("first"), row("second")],
+                    total: 2,
+                    guarantee: crate::module_graph::DependencyGuarantee::Exact,
+                },
+                dependents: super::super::browse::ModuleGraphRows {
+                    rows: vec![row("importer")],
+                    total: 1,
+                    guarantee: crate::module_graph::DependencyGuarantee::Exact,
+                },
+            });
+
+        app.config.keybindings.module_graph =
+            KeySequence::double(KeyBinding::char('m'), KeyBinding::char('i'));
+        app.handle_repo_browse_graph_input(press(KeyCode::Char('m')));
+        app.handle_repo_browse_graph_input(press(KeyCode::Down));
+        let ModuleGraphPaneState::Ready(panel) =
+            &app.browse_state.as_ref().unwrap().module_graph_pane
+        else {
+            panic!("graph pane must stay ready");
+        };
+        assert_eq!(panel.selected, 1);
+
+        app.handle_repo_browse_graph_input(press(KeyCode::Tab));
+        let ModuleGraphPaneState::Ready(panel) =
+            &app.browse_state.as_ref().unwrap().module_graph_pane
+        else {
+            panic!("graph pane must stay ready");
+        };
+        assert_eq!(panel.direction, ModuleGraphDirection::Dependents);
+        assert_eq!(panel.selected, 0);
+    }
+
+    #[tokio::test]
+    async fn test_visible_module_graph_refreshes_when_the_open_file_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "import './helper';\n";
+        let helper_source = "export const helper = 1;\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
+        app.state = AppState::RepoBrowseFile;
+        app.open_browse_module_graph();
+        settle_module_graph(&mut app).await;
+
+        app.browse_open_path("src/helper.ts", 0);
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert!(matches!(
+            &state.module_graph_pane,
+            super::super::browse::ModuleGraphPaneState::Waiting { path }
+                if path == "src/helper.ts"
+        ));
+        assert!(state.module_graph_query_receiver.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_waiting_module_graph_closes_when_the_new_file_fails_to_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "export {};\n";
+        let mut app = browsing_app_on_disk(dir.path(), &[("src/app.ts", app_source)]);
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        app.state = AppState::RepoBrowseFile;
+        app.browse_state.as_mut().unwrap().module_graph_pane =
+            ModuleGraphPaneState::Ready(super::super::browse::ModuleGraphPanel {
+                path: "src/app.ts".to_string(),
+                display_path: "src/app.ts".to_string(),
+                direction: ModuleGraphDirection::Dependencies,
+                selected: 0,
+                dependencies: super::super::browse::ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: crate::module_graph::DependencyGuarantee::Exact,
+                },
+                dependents: super::super::browse::ModuleGraphRows {
+                    rows: Vec::new(),
+                    total: 0,
+                    guarantee: crate::module_graph::DependencyGuarantee::Exact,
+                },
+            });
+
+        app.browse_open_path("src/missing.ts", 0);
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            ModuleGraphPaneState::Waiting { .. }
+        ));
+        app.state = AppState::RepoBrowseGraph;
+        settle_browse(&mut app).await;
+
+        let state = app.browse_state.as_ref().unwrap();
+        assert_eq!(app.state, AppState::RepoBrowseFile);
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Closed
+        ));
+        assert!(
+            state
+                .status
+                .as_deref()
+                .is_some_and(|message| message.contains("missing.ts")),
+            "file-load error must survive graph-pane cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_module_graph_pane_loads_outgoing_and_switches_to_incoming() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source =
+            "import { helper } from './helper';\nexport function app() { return helper(); }\n";
+        let helper_source = "export function helper() { return 1; }\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
+        app.state = AppState::RepoBrowseFile;
+
+        app.open_browse_module_graph();
+        assert_eq!(app.state, AppState::RepoBrowseGraph);
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            ModuleGraphPaneState::Loading { .. }
         ));
         settle_module_graph(&mut app).await;
+        let state = app.browse_state.as_ref().unwrap();
+        let ModuleGraphPaneState::Ready(panel) = &state.module_graph_pane else {
+            panic!("module graph pane must become ready");
+        };
+        assert_eq!(panel.direction, ModuleGraphDirection::Dependencies);
+        assert_eq!(panel.current_rows().len(), 1);
+        assert!(panel.current_rows()[0].edge.contains("./helper"));
+        assert_eq!(panel.current_rows()[0].node, "src/helper.ts");
+
+        app.handle_repo_browse_graph_input(press(KeyCode::Tab));
+        let state = app.browse_state.as_ref().unwrap();
+        let ModuleGraphPaneState::Ready(panel) = &state.module_graph_pane else {
+            panic!("module graph pane must stay open");
+        };
+        assert_eq!(panel.direction, ModuleGraphDirection::Dependents);
+        assert!(panel.current_rows().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_default_and_custom_sequence_module_graph_keys_open_the_pane() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "import { helper } from './helper';\n";
+        let helper_source = "export const helper = 1;\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[("src/app.ts", app_source), ("src/helper.ts", helper_source)],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(&mut app, dir.path(), &["src/app.ts", "src/helper.ts"]);
+        app.state = AppState::RepoBrowseFile;
+
+        app.handle_repo_browse_file_input(press(KeyCode::Char('i')), &mut test_terminal())
+            .unwrap();
+        settle_module_graph(&mut app).await;
+        assert_eq!(app.state, AppState::RepoBrowseGraph);
         assert!(matches!(
-            app.browse_state.as_ref().unwrap().overlay,
-            BrowseOverlay::ModuleGraph(_)
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            ModuleGraphPaneState::Ready(_)
         ));
 
-        app.handle_repo_browse_file_input(press(KeyCode::Esc), &mut test_terminal())
-            .unwrap();
+        app.handle_repo_browse_graph_input(press(KeyCode::Char('i')));
+        assert_eq!(app.state, AppState::RepoBrowseFile);
         app.config.keybindings.module_graph =
             KeySequence::double(KeyBinding::char('m'), KeyBinding::char('i'));
         app.handle_repo_browse_file_input(press(KeyCode::Char('m')), &mut test_terminal())
@@ -2866,9 +3144,10 @@ mod tests {
         app.handle_repo_browse_file_input(press(KeyCode::Char('i')), &mut test_terminal())
             .unwrap();
         settle_module_graph(&mut app).await;
+        assert_eq!(app.state, AppState::RepoBrowseGraph);
         assert!(matches!(
-            app.browse_state.as_ref().unwrap().overlay,
-            BrowseOverlay::ModuleGraph(_)
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            ModuleGraphPaneState::Ready(_)
         ));
     }
 
@@ -2893,18 +3172,21 @@ mod tests {
             .module_graph_query_token()
             .expect("query token");
         assert!(!cancel.is_cancelled());
-        app.handle_repo_browse_file_input(press(KeyCode::Esc), &mut test_terminal())
-            .unwrap();
+        app.handle_repo_browse_graph_input(press(KeyCode::Char('i')));
         assert!(cancel.is_cancelled());
         app.poll_browse_updates();
 
         let state = app.browse_state.as_ref().unwrap();
-        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Closed
+        ));
         assert!(state.module_graph_query_receiver.is_none());
+        assert_eq!(app.state, AppState::RepoBrowseFile);
     }
 
     #[tokio::test]
-    async fn test_loading_module_graph_is_abandoned_when_the_open_path_changes() {
+    async fn test_loading_module_graph_restarts_when_the_open_path_changes() {
         let dir = tempfile::tempdir().unwrap();
         let app_source = "import './helper';\n";
         let helper_source = "export const helper = 1;\n";
@@ -2928,21 +3210,23 @@ mod tests {
 
         assert!(cancel.is_cancelled());
         let state = app.browse_state.as_ref().unwrap();
-        assert!(matches!(state.overlay, BrowseOverlay::None));
-        assert!(state.module_graph_query_receiver.is_none());
-        assert_eq!(
-            state.status.as_deref(),
-            Some("Dependency query abandoned because the open file changed")
-        );
+        assert!(matches!(
+            &state.module_graph_pane,
+            ModuleGraphPaneState::Loading { path, .. } if path == "src/helper.ts"
+        ));
+        assert!(state.module_graph_query_receiver.is_some());
+        assert!(state.status.is_none());
     }
 
     #[test]
     fn test_enter_on_an_empty_module_graph_direction_is_a_noop() {
         let mut app = browsing_app(&["src/empty.ts"]);
         attach_open_file(&mut app, "src/empty.ts", "export {};\n", Vec::new());
-        app.state = AppState::RepoBrowseFile;
-        app.browse_state.as_mut().unwrap().overlay =
-            BrowseOverlay::ModuleGraph(super::super::browse::ModuleGraphPanel {
+        app.state = AppState::RepoBrowseGraph;
+        app.browse_state.as_mut().unwrap().module_graph_pane =
+            ModuleGraphPaneState::Ready(super::super::browse::ModuleGraphPanel {
+                path: "src/empty.ts".to_string(),
+                display_path: "src/empty.ts".to_string(),
                 direction: ModuleGraphDirection::Dependencies,
                 selected: 0,
                 dependencies: super::super::browse::ModuleGraphRows {
@@ -2957,11 +3241,13 @@ mod tests {
                 },
             });
 
-        app.handle_repo_browse_file_input(press(KeyCode::Enter), &mut test_terminal())
-            .unwrap();
+        app.handle_repo_browse_graph_input(press(KeyCode::Enter));
 
         let state = app.browse_state.as_ref().unwrap();
-        assert!(matches!(state.overlay, BrowseOverlay::ModuleGraph(_)));
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Ready(_)
+        ));
         assert!(state.status.is_none());
         assert!(state.jump_stack.is_empty());
     }
@@ -2975,14 +3261,17 @@ mod tests {
             "import react from 'react';\n",
             Vec::new(),
         );
-        app.state = AppState::RepoBrowseFile;
-        app.browse_state.as_mut().unwrap().overlay =
-            BrowseOverlay::ModuleGraph(super::super::browse::ModuleGraphPanel {
+        app.state = AppState::RepoBrowseGraph;
+        app.browse_state.as_mut().unwrap().module_graph_pane =
+            ModuleGraphPaneState::Ready(super::super::browse::ModuleGraphPanel {
+                path: "src/app.ts".to_string(),
+                display_path: "src/app.ts".to_string(),
                 direction: ModuleGraphDirection::Dependencies,
                 selected: 0,
                 dependencies: super::super::browse::ModuleGraphRows {
                     rows: vec![super::super::browse::ModuleGraphRow {
-                        label: "[import] react → package react  :1".to_string(),
+                        node: "package react".to_string(),
+                        edge: "[import] react  :1".to_string(),
                         jump: None,
                     }],
                     total: 1,
@@ -2995,11 +3284,13 @@ mod tests {
                 },
             });
 
-        app.handle_repo_browse_file_input(press(KeyCode::Enter), &mut test_terminal())
-            .unwrap();
+        app.handle_repo_browse_graph_input(press(KeyCode::Enter));
 
         let state = app.browse_state.as_ref().unwrap();
-        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Ready(_)
+        ));
         assert_eq!(
             state.status.as_deref(),
             Some("This dependency target is not a listed repository file")
@@ -3022,16 +3313,23 @@ mod tests {
 
         app.open_browse_module_graph();
         settle_module_graph(&mut app).await;
-        app.handle_repo_browse_file_input(press(KeyCode::Enter), &mut test_terminal())
-            .unwrap();
+        app.handle_repo_browse_graph_input(press(KeyCode::Enter));
         settle_browse(&mut app).await;
 
+        assert_eq!(app.state, AppState::RepoBrowseFile);
         assert_eq!(open_path(&app), "src/データ.json");
-        assert!(app.browse_state.as_ref().unwrap().status.is_none());
+        assert_eq!(
+            app.browse_state.as_ref().unwrap().status.as_deref(),
+            Some("Import analysis is not supported for this file")
+        );
+        assert!(matches!(
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            ModuleGraphPaneState::Closed
+        ));
     }
 
     #[tokio::test]
-    async fn test_module_graph_overlay_jumps_to_local_dependency_and_back() {
+    async fn test_module_graph_pane_jumps_to_local_dependency_and_back() {
         let dir = tempfile::tempdir().unwrap();
         let app_source =
             "import { helper } from './helper';\nexport function app() { return helper(); }\n";
@@ -3047,18 +3345,19 @@ mod tests {
 
         app.open_browse_module_graph();
         settle_module_graph(&mut app).await;
-        app.handle_repo_browse_file_input(press(KeyCode::Enter), &mut test_terminal())
-            .unwrap();
+        app.handle_repo_browse_graph_input(press(KeyCode::Enter));
         settle_browse(&mut app).await;
+        settle_module_graph(&mut app).await;
         assert_eq!(open_path(&app), "src/helper.ts");
         assert!(matches!(
-            app.browse_state.as_ref().unwrap().overlay,
-            BrowseOverlay::None
+            app.browse_state.as_ref().unwrap().module_graph_pane,
+            ModuleGraphPaneState::Ready(_)
         ));
 
         app.handle_repo_browse_file_input(ctrl('o'), &mut test_terminal())
             .unwrap();
         settle_browse(&mut app).await;
+        settle_module_graph(&mut app).await;
         assert_eq!(open_path(&app), "src/app.ts");
         assert_eq!(app.browse_state.as_ref().unwrap().cursor_line, 1);
     }
@@ -3073,7 +3372,10 @@ mod tests {
         app.open_browse_module_graph();
 
         let state = app.browse_state.as_ref().unwrap();
-        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Closed
+        ));
         assert_eq!(state.status.as_deref(), Some("Module graph is unavailable"));
     }
 
@@ -3096,7 +3398,10 @@ mod tests {
         app.open_browse_module_graph();
 
         let state = app.browse_state.as_ref().unwrap();
-        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Closed
+        ));
         assert_eq!(
             state.status.as_deref(),
             Some("Import analysis is unavailable for this file")
@@ -3119,7 +3424,10 @@ mod tests {
 
         let state = app.browse_state.as_ref().unwrap();
         assert_eq!(state.status.as_deref(), Some("Still opening this file"));
-        assert!(matches!(state.overlay, BrowseOverlay::None));
+        assert!(matches!(
+            state.module_graph_pane,
+            ModuleGraphPaneState::Closed
+        ));
     }
 
     /// A throwaway terminal for handlers that take one but do not draw.

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -173,6 +173,8 @@ pub enum AppState {
     RepoBrowseTree,
     /// Repository Browser, file content pane focused.
     RepoBrowseFile,
+    /// Repository Browser, module graph pane focused.
+    RepoBrowseGraph,
 }
 
 impl AppState {
@@ -193,12 +195,16 @@ impl AppState {
                 | Self::Cockpit
                 | Self::RepoBrowseTree
                 | Self::RepoBrowseFile
+                | Self::RepoBrowseGraph
         )
     }
 
     /// Whether this is a Repository Browser screen.
     pub fn is_repo_browse(self) -> bool {
-        matches!(self, Self::RepoBrowseTree | Self::RepoBrowseFile)
+        matches!(
+            self,
+            Self::RepoBrowseTree | Self::RepoBrowseFile | Self::RepoBrowseGraph
+        )
     }
 
     /// Whether this is an Issue-related screen.

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -264,6 +264,18 @@ impl KeybindingsConfig {
             ("confirm_no", &self.confirm_no),
         ];
 
+        let tab = KeyBinding::named(NamedKey::Tab);
+        if self
+            .module_graph
+            .all_sequences()
+            .any(|keys| keys.first() == Some(&tab))
+        {
+            errors.push(
+                "keybinding 'module_graph' cannot use the reserved Tab graph control or start with it"
+                    .to_string(),
+            );
+        }
+
         for (name, seq) in &bindings {
             if seq.keys.is_empty() {
                 errors.push(format!("keybinding '{}' is empty", name));
@@ -408,6 +420,7 @@ fn is_context_compatible(name1: &str, name2: &str) -> bool {
         "jump_back",
         "quit",
         "help",
+        "open_panel",
         "go_to_definition",
         "go_to_file",
         "toggle_zen_mode",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1344,6 +1344,7 @@ timeout_secs = 3600
             ("o", "symbol_outline"),
             ("s", "symbol_search"),
             ("g", "toggle_blame"),
+            ("Enter", "open_panel"),
         ] {
             let source = format!("[keybindings]\nmodule_graph = \"{binding}\"\n");
             let config: Config = toml::from_str(&source).unwrap();
@@ -1353,6 +1354,21 @@ timeout_secs = 3600
                     error.contains("module_graph") && error.contains(conflicting_name)
                 }),
                 "{binding:?} did not conflict with {conflicting_name}: {errors:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_module_graph_rejects_tab_and_tab_prefixed_sequences() {
+        for binding in ["\"Tab\"", "[\"Tab\", \"i\"]"] {
+            let source = format!("[keybindings]\nmodule_graph = {binding}\n");
+            let config: Config = toml::from_str(&source).unwrap();
+            let errors = config.keybindings.validate().unwrap_err();
+            assert!(
+                errors.iter().any(|error| {
+                    error.contains("module_graph") && error.contains("reserved Tab")
+                }),
+                "{binding} did not reject Tab: {errors:?}"
             );
         }
     }

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -353,9 +353,14 @@ impl KeySequence {
         std::iter::once(self.keys.as_slice()).chain(self.alt.iter().map(|v| v.as_slice()))
     }
 
+    /// Display only the primary sequence for compact, context-specific hints.
+    pub fn display_primary(&self) -> String {
+        self.keys.iter().map(KeyBinding::display).collect()
+    }
+
     /// Display string for help screen (shows primary | alt)
     pub fn display(&self) -> String {
-        let primary: String = self.keys.iter().map(|k| k.display()).collect();
+        let primary = self.display_primary();
         if self.alt.is_empty() {
             primary
         } else {

--- a/src/ui/browse.rs
+++ b/src/ui/browse.rs
@@ -17,8 +17,8 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::app::browse::{
     BlameCoverage, BlameGutter, BlameGutterWidth, BlameState, BrowseCommitDiffState, BrowseOverlay,
-    BrowseState, ModuleGraphDirection, ModuleGraphPanel, PrLookupState, BLAME_AUTHOR_WIDTH,
-    BLAME_FULL_WIDTH, BLAME_IDENTITY_WIDTH,
+    BrowseState, ModuleGraphDirection, ModuleGraphPaneState, ModuleGraphPanel, ModuleGraphRow,
+    PrLookupState, BLAME_AUTHOR_WIDTH, BLAME_FULL_WIDTH, BLAME_IDENTITY_WIDTH,
 };
 use crate::app::browse_discussion::{
     DiscussionIndex, DiscussionView, LineDiscussionFailure, LineDiscussionState,
@@ -27,6 +27,7 @@ use crate::app::{App, AppState, CachedDiffLine, DiffCache, LoadState, TreeRow};
 use crate::diff::LineType;
 use crate::github::{CommitPullRequest, CommitPullRequestState};
 use crate::symbols::Symbol;
+use crate::ui::common::truncate_with_width;
 
 /// Narrowest the line-number gutter ever gets.
 ///
@@ -59,6 +60,11 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
 
     let tree_focused = app.state == AppState::RepoBrowseTree;
+    let graph_focused = app.state == AppState::RepoBrowseGraph;
+    let graph_visible = app
+        .browse_state
+        .as_ref()
+        .is_some_and(|state| state.module_graph_pane.is_visible());
     let left_width = app.config.layout.left_panel_width;
     let panes = Layout::default()
         .direction(Direction::Horizontal)
@@ -69,7 +75,40 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         .split(body);
 
     render_tree(frame, app, panes[0], tree_focused);
-    render_content(frame, app, panes[1], !tree_focused);
+    if graph_visible {
+        let right_panes = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(panes[1]);
+        render_content(
+            frame,
+            app,
+            right_panes[0],
+            app.state == AppState::RepoBrowseFile,
+        );
+        if let Some(state) = app.browse_state.as_ref() {
+            let kb = &app.config.keybindings;
+            let graph_help = if graph_focused {
+                format!(
+                    " Tab/{}/{} dir | {}/{} node | {} open | {} close | Esc/{} code ",
+                    kb.move_left.display_primary(),
+                    kb.move_right.display_primary(),
+                    kb.move_down.display_primary(),
+                    kb.move_up.display_primary(),
+                    kb.open_panel.display_primary(),
+                    kb.module_graph.display_primary(),
+                    kb.quit.display_primary(),
+                )
+            } else if app.state == AppState::RepoBrowseFile {
+                format!(" {}/→ focus ", kb.module_graph.display_primary())
+            } else {
+                String::new()
+            };
+            render_module_graph_pane(frame, state, right_panes[1], graph_focused, &graph_help);
+        }
+    } else {
+        render_content(frame, app, panes[1], !tree_focused);
+    }
 
     if !zen {
         render_footer(frame, app, chunks[2]);
@@ -695,6 +734,16 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
             kb.symbol_search.display(),
             kb.quit.display(),
         )),
+        None if app.state == AppState::RepoBrowseGraph => std::borrow::Cow::Owned(format!(
+            " Tab/{}/{} direction | {}/{} node | {} open | {} close graph | Esc/{} code",
+            kb.move_left.display_primary(),
+            kb.move_right.display_primary(),
+            kb.move_down.display_primary(),
+            kb.move_up.display_primary(),
+            kb.open_panel.display_primary(),
+            kb.module_graph.display_primary(),
+            kb.quit.display_primary(),
+        )),
         None => match coverage {
             Some(
                 BlameCoverage::ShorterThanBuffer {
@@ -709,7 +758,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
                 " blame covers {blame_lines} lines, this file shows {buffer_lines} — reopen the file to refresh"
             )),
             Some(BlameCoverage::Exact) | None => std::borrow::Cow::Owned(format!(
-                " {} outline | {} search | {} imports | {} blame | {} diff | {} PR | {} discuss | {} def | {} edit | {} back",
+                " {} outline | {} search | {} graph | {} blame | {} diff | {} PR | {} discuss | {} def | {} edit | {} back",
                 kb.symbol_outline.display(),
                 kb.symbol_search.display(),
                 kb.module_graph.display(),
@@ -765,8 +814,6 @@ fn render_overlay(frame: &mut Frame, app: &mut App) {
             ref query,
             selected,
         } => render_symbol_search(frame, state, query, selected),
-        BrowseOverlay::ModuleGraphLoading { .. } => render_module_graph_loading(frame),
-        BrowseOverlay::ModuleGraph(ref panel) => render_module_graph(frame, panel),
     }
 }
 
@@ -942,88 +989,248 @@ fn render_outline(frame: &mut Frame, state: &BrowseState, selected: usize) {
     frame.render_widget(list, area);
 }
 
-fn render_module_graph_loading(frame: &mut Frame) {
-    let area = overlay_rect(frame.area(), 80, 70);
-    clear_overlay_area(frame, area);
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan))
-        .title("Imports (loading…)")
-        .title_bottom(Line::from(Span::styled(
-            " Esc cancel ",
-            Style::default().fg(Color::DarkGray),
-        )));
-    frame.render_widget(
-        Paragraph::new(" Resolving direct and reverse dependencies…").block(block),
-        area,
-    );
+fn render_module_graph_pane(
+    frame: &mut Frame,
+    state: &BrowseState,
+    area: Rect,
+    focused: bool,
+    graph_help: &str,
+) {
+    match &state.module_graph_pane {
+        ModuleGraphPaneState::Closed => {}
+        ModuleGraphPaneState::Waiting { path } => {
+            render_module_graph_loading_pane(
+                frame,
+                area,
+                path,
+                "Graph (opening…)",
+                " Waiting for the current file…",
+                focused,
+                graph_help,
+            );
+        }
+        ModuleGraphPaneState::Loading { path, .. } => {
+            render_module_graph_loading_pane(
+                frame,
+                area,
+                path,
+                "Graph (loading…)",
+                " Resolving imports and importers…",
+                focused,
+                graph_help,
+            );
+        }
+        ModuleGraphPaneState::Ready(panel) => {
+            render_module_graph_ready_pane(frame, area, panel, focused, graph_help);
+        }
+    }
 }
 
-fn render_module_graph(frame: &mut Frame, panel: &ModuleGraphPanel) {
-    let area = overlay_rect(frame.area(), 80, 70);
-    clear_overlay_area(frame, area);
-
-    let current = panel.current();
-    let inner_height = area.height.saturating_sub(2) as usize;
-    let offset = scroll_offset(panel.selected, current.rows.len(), inner_height);
-    let items: Vec<ListItem> = if current.rows.is_empty() {
-        let empty = match panel.direction {
-            ModuleGraphDirection::Dependencies => " No imports.",
-            ModuleGraphDirection::Dependents => " No importers.",
-        };
-        vec![ListItem::new(Line::from(Span::styled(
-            empty,
-            Style::default().fg(Color::DarkGray),
-        )))]
+fn render_module_graph_loading_pane(
+    frame: &mut Frame,
+    area: Rect,
+    path: &str,
+    title: &str,
+    message: &str,
+    focused: bool,
+    graph_help: &str,
+) {
+    let border_style = if focused {
+        Style::default().fg(Color::Yellow)
     } else {
-        current
-            .rows
-            .iter()
-            .enumerate()
-            .skip(offset)
-            .take(inner_height)
-            .map(|(index, row)| {
-                let style = if index == panel.selected {
-                    Style::default()
-                        .fg(Color::Black)
-                        .bg(Color::Cyan)
-                        .add_modifier(Modifier::BOLD)
-                } else {
-                    Style::default()
-                };
-                ListItem::new(Line::from(vec![
-                    Span::styled(" ", style),
-                    Span::styled(row.label.as_str(), style),
-                ]))
-            })
-            .collect()
+        Style::default()
     };
+    let block = module_graph_block(title, border_style, graph_help);
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let mut lines = module_graph_box_lines("current module", path, inner_width, true)
+        .into_iter()
+        .map(|text| {
+            Line::from(Span::styled(
+                text,
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ))
+        })
+        .collect::<Vec<_>>();
+    lines.push(Line::from(Span::styled(
+        message,
+        Style::default().fg(Color::DarkGray),
+    )));
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
 
+fn render_module_graph_ready_pane(
+    frame: &mut Frame,
+    area: Rect,
+    panel: &ModuleGraphPanel,
+    focused: bool,
+    graph_help: &str,
+) {
+    let current = panel.current();
     let direction = match panel.direction {
-        ModuleGraphDirection::Dependencies => "Imports",
-        ModuleGraphDirection::Dependents => "Imported by",
+        ModuleGraphDirection::Dependencies => "Imports →",
+        ModuleGraphDirection::Dependents => "Importers",
     };
     let guarantee = match current.guarantee {
         crate::module_graph::DependencyGuarantee::Exact => "exact",
         crate::module_graph::DependencyGuarantee::Approximate => "approximate",
     };
-    let edge_noun = if current.total == 1 { "edge" } else { "edges" };
     let count = if current.rows.len() < current.total {
-        format!("{}/{} {edge_noun} shown", current.rows.len(), current.total)
+        format!("{}/{}", current.rows.len(), current.total)
     } else {
-        format!("{} {edge_noun}", current.total)
+        current.total.to_string()
     };
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan))
-            .title(format!("{direction} ({count}, {guarantee})"))
-            .title_bottom(Line::from(Span::styled(
-                " Tab/h/l switch | j/k move | Enter open | Esc close ",
-                Style::default().fg(Color::DarkGray),
-            ))),
+    let title = format!("{direction} {count} {guarantee}");
+    let border_style = if focused {
+        Style::default().fg(Color::Yellow)
+    } else {
+        Style::default()
+    };
+    let block = module_graph_block(title, border_style, graph_help);
+    let inner_width = area.width.saturating_sub(2) as usize;
+    let inner_height = area.height.saturating_sub(2) as usize;
+    let current_style = Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD);
+    let mut lines =
+        module_graph_box_lines("current module", &panel.display_path, inner_width, true)
+            .into_iter()
+            .map(|text| Line::from(Span::styled(text, current_style)))
+            .collect::<Vec<_>>();
+
+    if current.rows.is_empty() {
+        let empty = match panel.direction {
+            ModuleGraphDirection::Dependencies => " No imports.",
+            ModuleGraphDirection::Dependents => " No importers.",
+        };
+        lines.push(Line::from(Span::styled(
+            empty,
+            Style::default().fg(Color::DarkGray),
+        )));
+    } else {
+        let visible_nodes = inner_height.saturating_sub(3) / 3;
+        let offset = scroll_offset(panel.selected, current.rows.len(), visible_nodes);
+        for (index, row) in current
+            .rows
+            .iter()
+            .enumerate()
+            .skip(offset)
+            .take(visible_nodes)
+        {
+            let style = if index == panel.selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else if row.jump.is_none() {
+                Style::default().fg(Color::DarkGray)
+            } else {
+                Style::default()
+            };
+            let last = index + 1 == current.rows.len();
+            for text in module_graph_relationship_lines(row, panel.direction, inner_width, last) {
+                lines.push(Line::from(Span::styled(text, style)));
+            }
+        }
+    }
+
+    frame.render_widget(Paragraph::new(lines).block(block), area);
+}
+
+fn module_graph_block<'a>(
+    title: impl Into<Line<'a>>,
+    border_style: Style,
+    graph_help: &str,
+) -> Block<'a> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .title(title)
+        .title_bottom(Line::from(Span::styled(
+            graph_help.to_string(),
+            Style::default().fg(Color::DarkGray),
+        )))
+}
+
+fn module_graph_relationship_lines(
+    row: &ModuleGraphRow,
+    direction: ModuleGraphDirection,
+    width: usize,
+    last: bool,
+) -> [String; 3] {
+    let prefix_width = usize::from(width >= 7) * 3;
+    let box_width = width.saturating_sub(prefix_width);
+    let [top, middle, bottom] = module_graph_box_lines(&row.node, &row.edge, box_width, false);
+    if prefix_width == 0 {
+        return [top, middle, bottom];
+    }
+    let connector = match (direction, last) {
+        (ModuleGraphDirection::Dependencies, false) => "├─▶",
+        (ModuleGraphDirection::Dependencies, true) => "└─▶",
+        (ModuleGraphDirection::Dependents, false) => "▲─┤",
+        (ModuleGraphDirection::Dependents, true) => "▲─┘",
+    };
+    let tail = if last { "   " } else { "│  " };
+    [
+        format!("│  {top}"),
+        format!("{connector}{middle}"),
+        format!("{tail}{bottom}"),
+    ]
+}
+
+fn module_graph_box_lines(
+    title: &str,
+    detail: &str,
+    width: usize,
+    emphasized: bool,
+) -> [String; 3] {
+    if width < 4 {
+        return [
+            fit_module_graph_text(title, width),
+            fit_module_graph_text(detail, width),
+            fit_module_graph_text("─", width),
+        ];
+    }
+
+    let (top_left, horizontal, top_right, vertical, bottom_left, bottom_right) = if emphasized {
+        ('╔', '═', '╗', '║', '╚', '╝')
+    } else {
+        ('┌', '─', '┐', '│', '└', '┘')
+    };
+    let inner = width - 2;
+    let top = if inner <= 3 {
+        format!(
+            "{top_left}{}{top_right}",
+            horizontal.to_string().repeat(inner)
+        )
+    } else {
+        let title = truncate_with_width(title, inner - 3);
+        let title_width = title.width();
+        let fill = inner.saturating_sub(title_width + 3);
+        format!(
+            "{top_left}{horizontal} {title} {}{top_right}",
+            horizontal.to_string().repeat(fill)
+        )
+    };
+    let middle = format!(
+        "{vertical}{}{vertical}",
+        fit_module_graph_text(detail, inner)
     );
-    frame.render_widget(list, area);
+    let bottom = format!(
+        "{bottom_left}{}{bottom_right}",
+        horizontal.to_string().repeat(inner)
+    );
+    [top, middle, bottom]
+}
+
+fn fit_module_graph_text(text: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let text = truncate_with_width(text, width);
+    let padding = width.saturating_sub(text.width());
+    format!("{text}{}", " ".repeat(padding))
 }
 
 fn outline_row(symbol: &Symbol, selected: bool) -> Line<'static> {
@@ -1365,7 +1572,7 @@ mod tests {
         │                          ││                                                  │
         │                          ││                                                  │
         └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd d
         "#);
     }
 
@@ -1680,8 +1887,8 @@ mod tests {
                 footer_at(&mut app, 60)
             ),
             @"
-        80:  o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
-        60:  o outline | s search | i imports | gb blame | gc diff | gp
+        80:  o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd d
+        60:  o outline | s search | i graph | gb blame | gc diff | gp PR
         "
         );
     }
@@ -1706,7 +1913,7 @@ mod tests {
         │                          ││                                                  │
         │                          ││                                                  │
         └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd d
         ");
     }
 
@@ -1748,7 +1955,7 @@ mod tests {
         │  main.rs                               ││aaaaaaa Alice Example 2h ago        1 fn main() {}                          │
         │                                        ││                                                                            │
         └────────────────────────────────────────┘└────────────────────────────────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc back
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc back
         --- no time (90) ---
         ┌────────────────────────────────────────────────────────────────────────────────────────┐
         │Repo Browse - demo  1 files  symbols: -                                                 │
@@ -1757,7 +1964,7 @@ mod tests {
         │  main.rs                     ││aaaaaaa Alice Example      1 fn main() {}               │
         │                              ││                                                        │
         └──────────────────────────────┘└────────────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd def | gf
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd def | gf ed
         --- identity (70) ---
         ┌────────────────────────────────────────────────────────────────────┐
         │Repo Browse - demo  1 files  symbols: -                             │
@@ -1766,7 +1973,7 @@ mod tests {
         │  main.rs              ││aaaaaaa         1 fn main() {}             │
         │                       ││                                           │
         └───────────────────────┘└───────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr di
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr disc
         --- hidden (50) ---
         ┌────────────────────────────────────────────────┐
         │Repo Browse - demo  1 files  symbols: -         │
@@ -1775,7 +1982,7 @@ mod tests {
         │  main.rs       ││    1 fn main() {}            │
         │                ││                              │
         └────────────────┘└──────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc
+         o outline | s search | i graph | gb blame | gc di
         ");
     }
 
@@ -1908,7 +2115,7 @@ mod tests {
         │                                        ││Uncommitted                         3 third                                 │
         │                                        ││                                                                            │
         └────────────────────────────────────────┘└────────────────────────────────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc back
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/Esc back
         ");
     }
 
@@ -2000,7 +2207,7 @@ mod tests {
         │  empty.rs                ││                                                  │
         │                          ││                                                  │
         └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd d
         ");
     }
 
@@ -2025,7 +2232,7 @@ mod tests {
         │                          ││   29 line 29                                     ║
         │                          ││   30 line 30                                     █
         └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd d
         ");
     }
 
@@ -2325,48 +2532,141 @@ mod tests {
     }
 
     #[test]
-    fn test_render_module_graph_loading_overlay() {
+    fn test_module_graph_loading_renders_as_a_right_side_pane() {
         let mut app = app_with_browse(&["src/app.ts"]);
         let state = app.browse_state.as_mut().unwrap();
         open_file(state, "src/app.ts", "import './helper';\n");
-        state.overlay = BrowseOverlay::ModuleGraphLoading {
+        state.module_graph_pane = ModuleGraphPaneState::Loading {
             request_id: 7,
             path: "src/app.ts".to_string(),
         };
-        app.state = AppState::RepoBrowseFile;
+        app.state = AppState::RepoBrowseGraph;
 
-        assert_snapshot!(render_at(&mut app, 60, 8), @"
-        ┌──────────────────────────────────────────────────────────┐
-        │Repo ┌Imports (loading…)────────────────────────────┐     │
-        └─────│ Resolving direct and reverse dependencies…   │─────┘
-        ┌Files│                                              │─────┐
-        │▼ src│                                              │     │
-        │    a└ Esc cancel ──────────────────────────────────┘     │
-        └───────────────────┘└─────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp
+        assert_snapshot!(render_at(&mut app, 100, 12), @"
+        ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+        │Repo Browse - demo  1 files  symbols: -                                                           │
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ┌Files────────────────────────────┐┌src/app.ts (1/1)───────────────┐┌Graph (loading…)──────────────┐
+        │▼ src/                           ││    1 import './helper';       ││╔═ current module ═══════════╗│
+        │    app.ts                       ││                               ││║src/app.ts                  ║│
+        │                                 ││                               ││╚════════════════════════════╝│
+        │                                 ││                               ││ Resolving imports and importe│
+        │                                 ││                               ││                              │
+        │                                 ││                               ││                              │
+        └─────────────────────────────────┘└───────────────────────────────┘└ Tab/h/l dir | j/k node | Ente┘
+         Tab/h/l direction | j/k node | Enter open | i close graph | Esc/q code
         ");
     }
 
     #[test]
-    fn test_render_module_graph_outgoing_overlay() {
+    fn test_module_graph_waiting_keeps_the_right_side_pane_visible() {
+        let mut app = app_with_browse(&["src/helper.ts"]);
+        let state = app.browse_state.as_mut().unwrap();
+        open_file(state, "src/helper.ts", "export {};\n");
+        state.module_graph_pane = ModuleGraphPaneState::Waiting {
+            path: "src/helper.ts".to_string(),
+        };
+        app.state = AppState::RepoBrowseFile;
+
+        assert_snapshot!(render_at(&mut app, 80, 10), @"
+        ┌──────────────────────────────────────────────────────────────────────────────┐
+        │Repo Browse - demo  1 files  symbols: -                                       │
+        └──────────────────────────────────────────────────────────────────────────────┘
+        ┌Files─────────────────────┐┌src/helper.ts (1/1)─────┐┌Graph (opening…)────────┐
+        │▼ src/                    ││    1 export {};        ││╔═ current module ═════╗│
+        │    helper.ts             ││                        ││║src/helper.ts         ║│
+        │                          ││                        ││╚══════════════════════╝│
+        │                          ││                        ││ Waiting for the current│
+        └──────────────────────────┘└────────────────────────┘└ i/→ focus ─────────────┘
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd d
+        ");
+    }
+
+    #[test]
+    fn test_tree_focus_does_not_advertise_a_graph_focus_shortcut() {
+        let mut app = app_with_browse(&["src/app.ts"]);
+        let state = app.browse_state.as_mut().unwrap();
+        open_file(state, "src/app.ts", "export {};\n");
+        state.module_graph_pane = ModuleGraphPaneState::Waiting {
+            path: "src/app.ts".to_string(),
+        };
+        app.state = AppState::RepoBrowseTree;
+
+        let rendered = render_at(&mut app, 100, 10);
+        assert!(!rendered.contains("i/→ focus"), "{rendered}");
+    }
+
+    #[test]
+    fn test_module_graph_pane_hint_uses_the_configured_binding() {
+        let mut app = app_with_browse(&["src/app.ts"]);
+        let state = app.browse_state.as_mut().unwrap();
+        open_file(state, "src/app.ts", "export {};\n");
+        state.module_graph_pane = ModuleGraphPaneState::Waiting {
+            path: "src/app.ts".to_string(),
+        };
+        app.config.keybindings.module_graph =
+            KeySequence::double(KeyBinding::char('m'), KeyBinding::char('i'));
+        app.state = AppState::RepoBrowseFile;
+
+        let rendered = render_at(&mut app, 120, 12);
+        assert!(rendered.contains("mi/→ focus"), "{rendered}");
+    }
+
+    #[test]
+    fn test_module_graph_focused_hints_use_configured_controls() {
+        let mut app = app_with_browse(&["src/app.ts"]);
+        let state = app.browse_state.as_mut().unwrap();
+        open_file(state, "src/app.ts", "export {};\n");
+        state.module_graph_pane = ModuleGraphPaneState::Waiting {
+            path: "src/app.ts".to_string(),
+        };
+        app.config.keybindings.move_left = KeySequence::single(KeyBinding::char('a'));
+        app.config.keybindings.move_right = KeySequence::single(KeyBinding::char('d'));
+        app.config.keybindings.move_down = KeySequence::single(KeyBinding::char('n'));
+        app.config.keybindings.move_up = KeySequence::single(KeyBinding::char('p'));
+        app.config.keybindings.open_panel = KeySequence::single(KeyBinding::char(' '));
+        app.config.keybindings.module_graph =
+            KeySequence::double(KeyBinding::char('m'), KeyBinding::char('i'));
+        app.config.keybindings.quit = KeySequence::single(KeyBinding::char('z'));
+        app.state = AppState::RepoBrowseGraph;
+
+        let rendered = render_at(&mut app, 160, 12);
+        assert!(
+            rendered.contains(
+                "Tab/a/d direction | n/p node | Space open | mi close graph | Esc/z code"
+            ),
+            "{rendered}"
+        );
+    }
+
+    #[test]
+    fn test_render_module_graph_outgoing_pane_as_uml_nodes() {
         let mut app = app_with_browse(&["src/app.ts", "src/helper.ts"]);
         let state = app.browse_state.as_mut().unwrap();
         open_file(state, "src/app.ts", "import './helper';\n");
-        state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+        state.module_graph_pane = ModuleGraphPaneState::Ready(ModuleGraphPanel {
+            path: "src/app.ts".to_string(),
+            display_path: "src/app.ts".to_string(),
             direction: ModuleGraphDirection::Dependencies,
             selected: 0,
             dependencies: ModuleGraphRows {
                 rows: vec![
                     ModuleGraphRow {
-                        label: "[import] ./helper → src/helper.ts  :1".to_string(),
+                        node: "src/helper.ts".to_string(),
+                        edge: "[import] ./helper  :1".to_string(),
+                        jump: Some(crate::app::browse::ModuleGraphJump {
+                            path: "src/helper.ts".to_string(),
+                            line: 0,
+                        }),
+                    },
+                    ModuleGraphRow {
+                        node: "package react".to_string(),
+                        edge: "[import] react  :2".to_string(),
                         jump: None,
                     },
                     ModuleGraphRow {
-                        label: "[import] react → package react  :2".to_string(),
-                        jump: None,
-                    },
-                    ModuleGraphRow {
-                        label: "[dynamic] ./missing → unresolved (not found)  :3".to_string(),
+                        node: "unresolved (not found)".to_string(),
+                        edge: "[dynamic] ./missing  :3".to_string(),
                         jump: None,
                     },
                 ],
@@ -2379,39 +2679,58 @@ mod tests {
                 guarantee: DependencyGuarantee::Exact,
             },
         });
-        app.state = AppState::RepoBrowseFile;
+        app.state = AppState::RepoBrowseGraph;
 
-        assert_snapshot!(render_at(&mut app, 100, 16), @"
+        assert_snapshot!(render_at(&mut app, 100, 18), @"
         ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
         │Repo Browse - demo  2 files  symbols: -                                                           │
-        └─────────┌Imports (3/300 edges shown, exact)────────────────────────────────────────────┐─────────┘
-        ┌Files────│ [import] ./helper → src/helper.ts  :1                                        │─────────┐
-        │▼ src/   │ [import] react → package react  :2                                           │         │
-        │    app.t│ [dynamic] ./missing → unresolved (not found)  :3                             │         │
-        │    helpe│                                                                              │         │
-        │         │                                                                              │         │
-        │         │                                                                              │         │
-        │         │                                                                              │         │
-        │         │                                                                              │         │
-        │         │                                                                              │         │
-        │         └ Tab/h/l switch | j/k move | Enter open | Esc close ──────────────────────────┘         │
-        │                                 ││                                                               │
-        └─────────────────────────────────┘└───────────────────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd def | gf edit | q/E
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ┌Files────────────────────────────┐┌src/app.ts (1/1)───────────────┐┌Imports → 3/300 exact─────────┐
+        │▼ src/                           ││    1 import './helper';       ││╔═ current module ═══════════╗│
+        │    app.ts                       ││                               ││║src/app.ts                  ║│
+        │    helper.ts                    ││                               ││╚════════════════════════════╝│
+        │                                 ││                               │││  ┌─ src/helper.ts ─────────┐│
+        │                                 ││                               ││├─▶│[import] ./helper  :1    ││
+        │                                 ││                               │││  └─────────────────────────┘│
+        │                                 ││                               │││  ┌─ package react ─────────┐│
+        │                                 ││                               ││├─▶│[import] react  :2       ││
+        │                                 ││                               │││  └─────────────────────────┘│
+        │                                 ││                               │││  ┌─ unresolved (not found) ┐│
+        │                                 ││                               ││└─▶│[dynamic] ./missing  :3  ││
+        │                                 ││                               ││   └─────────────────────────┘│
+        └─────────────────────────────────┘└───────────────────────────────┘└ Tab/h/l dir | j/k node | Ente┘
+         Tab/h/l direction | j/k node | Enter open | i close graph | Esc/q code
         ");
     }
 
     #[test]
-    fn test_render_module_graph_bounded_long_cjk_label() {
+    fn test_five_column_module_graph_box_stays_within_its_width() {
+        let lines = module_graph_box_lines("node", "edge", 5, false);
+
+        assert_eq!(lines[0], "┌───┐");
+        assert!(lines
+            .iter()
+            .all(|line| unicode_width::UnicodeWidthStr::width(line.as_str()) == 5));
+    }
+
+    #[test]
+    fn test_render_module_graph_bounded_long_cjk_node() {
         let mut app = app_with_browse(&["src/app.ts"]);
-        let label = crate::app::browse::bounded_module_graph_text(&"依存先".repeat(1_000));
-        assert!(unicode_width::UnicodeWidthStr::width(label.as_str()) <= 240);
+        let node = crate::app::browse::bounded_module_graph_text(&"依存先".repeat(1_000));
+        assert!(unicode_width::UnicodeWidthStr::width(node.as_str()) <= 240);
         let state = app.browse_state.as_mut().unwrap();
-        state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+        open_file(state, "src/app.ts", "import './依存先';\n");
+        state.module_graph_pane = ModuleGraphPaneState::Ready(ModuleGraphPanel {
+            path: "src/app.ts".to_string(),
+            display_path: "src/app.ts".to_string(),
             direction: ModuleGraphDirection::Dependencies,
             selected: 0,
             dependencies: ModuleGraphRows {
-                rows: vec![ModuleGraphRow { label, jump: None }],
+                rows: vec![ModuleGraphRow {
+                    node,
+                    edge: "[import] ./依存先  :1".to_string(),
+                    jump: None,
+                }],
                 total: 1,
                 guarantee: DependencyGuarantee::Exact,
             },
@@ -2421,26 +2740,32 @@ mod tests {
                 guarantee: DependencyGuarantee::Exact,
             },
         });
-        app.state = AppState::RepoBrowseFile;
+        app.state = AppState::RepoBrowseGraph;
 
-        assert_snapshot!(render_at(&mut app, 80, 8), @"
+        assert_snapshot!(render_at(&mut app, 80, 12), @"
         ┌──────────────────────────────────────────────────────────────────────────────┐
-        │Repo Br┌Imports (1 edge, exact)───────────────────────────────────────┐       │
-        └───────│ 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先 依 存 先  │───────┘
-        ┌Files──│                                                              │───────┐
-        │▼ src/ │                                                              │       │
-        │    app└ Tab/h/l switch | j/k move | Enter open | Esc close ──────────┘       │
-        └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+        │Repo Browse - demo  1 files  symbols: -                                       │
+        └──────────────────────────────────────────────────────────────────────────────┘
+        ┌Files─────────────────────┐┌src/app.ts (1/1)────────┐┌Imports → 1 exact───────┐
+        │▼ src/                    ││    1 import './依 存 先 ';││╔═ current module ═════╗│
+        │    app.ts                ││                        ││║src/app.ts            ║│
+        │                          ││                        ││╚══════════════════════╝│
+        │                          ││                        │││  ┌─ 依 存 先 依 存 先 依 … ─┐│
+        │                          ││                        ││└─▶│[import] ./依 存 先  …││
+        │                          ││                        ││   └───────────────────┘│
+        └──────────────────────────┘└────────────────────────┘└ Tab/h/l dir | j/k node ┘
+         Tab/h/l direction | j/k node | Enter open | i close graph | Esc/q code
         ");
     }
 
     #[test]
-    fn test_render_module_graph_incoming_approximate_overlay() {
+    fn test_render_module_graph_incoming_approximate_pane() {
         let mut app = app_with_browse(&["src/app.ts", "src/helper.ts"]);
         let state = app.browse_state.as_mut().unwrap();
         open_file(state, "src/helper.ts", "export const helper = 1;\n");
-        state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+        state.module_graph_pane = ModuleGraphPaneState::Ready(ModuleGraphPanel {
+            path: "src/helper.ts".to_string(),
+            display_path: "src/helper.ts".to_string(),
             direction: ModuleGraphDirection::Dependents,
             selected: 0,
             dependencies: ModuleGraphRows {
@@ -2450,39 +2775,42 @@ mod tests {
             },
             dependents: ModuleGraphRows {
                 rows: vec![ModuleGraphRow {
-                    label: "[use] src/app.rs:4  crate::helper".to_string(),
+                    node: "src/app.rs".to_string(),
+                    edge: "[use] crate::helper  :4".to_string(),
                     jump: None,
                 }],
                 total: 1,
                 guarantee: DependencyGuarantee::Approximate,
             },
         });
-        app.state = AppState::RepoBrowseFile;
+        app.state = AppState::RepoBrowseGraph;
 
-        assert_snapshot!(render_at(&mut app, 80, 14), @"
-        ┌──────────────────────────────────────────────────────────────────────────────┐
-        │Repo Browse - demo  2 files  symbols: -                                       │
-        └───────┌Imported by (1 edge, approximate)─────────────────────────────┐───────┘
-        ┌Files──│ [use] src/app.rs:4  crate::helper                            │───────┐
-        │▼ src/ │                                                              │       │
-        │    app│                                                              │       │
-        │    hel│                                                              │       │
-        │       │                                                              │       │
-        │       │                                                              │       │
-        │       │                                                              │       │
-        │       └ Tab/h/l switch | j/k move | Enter open | Esc close ──────────┘       │
-        │                          ││                                                  │
-        └──────────────────────────┘└──────────────────────────────────────────────────┘
-         o outline | s search | i imports | gb blame | gc diff | gp PR | gr discuss | gd
+        assert_snapshot!(render_at(&mut app, 100, 14), @"
+        ┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
+        │Repo Browse - demo  2 files  symbols: -                                                           │
+        └──────────────────────────────────────────────────────────────────────────────────────────────────┘
+        ┌Files────────────────────────────┐┌src/helper.ts (1/1)────────────┐┌Importers 1 approximate───────┐
+        │▼ src/                           ││    1 export const helper = 1; ││╔═ current module ═══════════╗│
+        │    app.ts                       ││                               ││║src/helper.ts               ║│
+        │    helper.ts                    ││                               ││╚════════════════════════════╝│
+        │                                 ││                               │││  ┌─ src/app.rs ────────────┐│
+        │                                 ││                               ││▲─┘│[use] crate::helper  :4  ││
+        │                                 ││                               ││   └─────────────────────────┘│
+        │                                 ││                               ││                              │
+        │                                 ││                               ││                              │
+        └─────────────────────────────────┘└───────────────────────────────┘└ Tab/h/l dir | j/k node | Ente┘
+         Tab/h/l direction | j/k node | Enter open | i close graph | Esc/q code
         ");
     }
 
     #[test]
-    fn test_empty_module_graph_overlay_clips_in_a_tiny_terminal() {
+    fn test_empty_module_graph_pane_clips_in_a_tiny_terminal() {
         let mut app = app_with_browse(&["src/empty.ts"]);
         let state = app.browse_state.as_mut().unwrap();
         open_file(state, "src/empty.ts", "export {};\n");
-        state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
+        state.module_graph_pane = ModuleGraphPaneState::Ready(ModuleGraphPanel {
+            path: "src/empty.ts".to_string(),
+            display_path: "src/empty.ts".to_string(),
             direction: ModuleGraphDirection::Dependencies,
             selected: 0,
             dependencies: ModuleGraphRows {
@@ -2496,14 +2824,14 @@ mod tests {
                 guarantee: DependencyGuarantee::Exact,
             },
         });
-        app.state = AppState::RepoBrowseFile;
+        app.state = AppState::RepoBrowseGraph;
 
         assert_snapshot!(render_at(&mut app, 20, 5), @"
-        ┌Imports (0 edges, ┐
-        │ No imports.      │
-        │                  │
-        │                  │
-        └ Tab/h/l switch | ┘
+        ┌──────────────────┐
+        │Repo Browse - demo│
+        └──────────────────┘
+        ┌Files┐┌src/e┐┌ Tab┐
+         Tab/h/l direction |
         ");
     }
 
@@ -2981,43 +3309,6 @@ mod tests {
                 matches!(border, "│" | "┌" | "└"),
                 "row {y}: the overlay's left border is {border:?}"
             );
-        }
-    }
-
-    #[test]
-    fn test_module_graph_left_border_survives_a_wide_glyph_straddling_it() {
-        let paths: Vec<String> = (0..8).map(|i| format!("{i:0>4}日本語")).collect();
-        let refs: Vec<&str> = paths.iter().map(String::as_str).collect();
-        let mut app = app_with_browse(&refs);
-        let area = overlay_rect(Rect::new(0, 0, 80, 14), 80, 70);
-        let bare = render_buffer(&mut app, 80, 14);
-        let straddling_rows: Vec<u16> = (area.top()..area.bottom())
-            .filter(|&y| bare[(7, y)].symbol() == "日")
-            .collect();
-        assert!(straddling_rows.len() >= 5);
-
-        if let Some(state) = app.browse_state.as_mut() {
-            state.overlay = BrowseOverlay::ModuleGraph(ModuleGraphPanel {
-                direction: ModuleGraphDirection::Dependencies,
-                selected: 0,
-                dependencies: ModuleGraphRows {
-                    rows: Vec::new(),
-                    total: 0,
-                    guarantee: DependencyGuarantee::Exact,
-                },
-                dependents: ModuleGraphRows {
-                    rows: Vec::new(),
-                    total: 0,
-                    guarantee: DependencyGuarantee::Exact,
-                },
-            });
-        }
-        let overlaid = render_buffer(&mut app, 80, 14);
-        for y in area.top()..area.bottom() {
-            assert!(overlaid[(area.x - 1, y)].symbol().width() <= 1);
-        }
-        for y in straddling_rows {
-            assert!(matches!(overlaid[(area.x, y)].symbol(), "│" | "┌" | "└"));
         }
     }
 

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -1017,7 +1017,7 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
             fmt_key(&kb.symbol_search.display(), key_width)
         )),
         Line::from(format!(
-            "{}  Show imports and importers",
+            "{}  Open / focus UML module graph pane",
             fmt_key(&kb.module_graph.display(), key_width)
         )),
         Line::from(format!(
@@ -1047,6 +1047,40 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Jump back",
             fmt_key(&kb.jump_back.display(), key_width)
+        )),
+        Line::from(vec![Span::styled(
+            "  Graph Focus:",
+            Style::default().fg(Color::DarkGray),
+        )]),
+        Line::from(format!(
+            "{}  Switch imports / imported by",
+            fmt_key(
+                &format!(
+                    "Tab / {} / {}",
+                    kb.move_left.display(),
+                    kb.move_right.display()
+                ),
+                key_width
+            )
+        )),
+        Line::from(format!(
+            "{}  Select a module node",
+            fmt_key(
+                &format!("{} / {}", kb.move_down.display(), kb.move_up.display()),
+                key_width
+            )
+        )),
+        Line::from(format!(
+            "{}  Open a listed local module",
+            fmt_key(&kb.open_panel.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Close graph pane",
+            fmt_key(&kb.module_graph.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Return focus to code",
+            fmt_key(&format!("Esc / {}", kb.quit.display_primary()), key_width)
         )),
         Line::from(""),
         Line::from(vec![Span::styled(
@@ -1515,6 +1549,32 @@ mod tests {
         assert!(joined.contains("Readline-style editing keys"));
         for key in ["Ctrl-A", "Ctrl-E", "Ctrl-W", "Ctrl-K", "Ctrl-U"] {
             assert!(joined.contains(key), "help missing binding: {key}");
+        }
+    }
+
+    #[test]
+    fn test_graph_focus_help_uses_configured_bindings() {
+        use crate::keybinding::{KeyBinding, KeySequence};
+
+        let kb = KeybindingsConfig {
+            move_left: KeySequence::single(KeyBinding::char('a')),
+            move_right: KeySequence::single(KeyBinding::char('d')),
+            move_down: KeySequence::single(KeyBinding::char('n')),
+            move_up: KeySequence::single(KeyBinding::char('p')),
+            open_panel: KeySequence::single(KeyBinding::char(' ')),
+            module_graph: KeySequence::double(KeyBinding::char('m'), KeyBinding::char('i')),
+            quit: KeySequence::single(KeyBinding::char('z')),
+            ..KeybindingsConfig::default()
+        };
+
+        let joined = build_help_lines(&kb)
+            .iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        for hint in ["Tab / a / d", "n / p", "Space", "mi", "Esc / z"] {
+            assert!(joined.contains(hint), "help missing {hint:?}: {joined}");
         }
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -111,7 +111,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         AppState::IssueCommentList => issue_comment_list::render(frame, app),
         AppState::GitOpsSplitTree | AppState::GitOpsSplitDiff => git_ops::render(frame, app),
         AppState::Cockpit => cockpit::render(frame, app),
-        AppState::RepoBrowseTree | AppState::RepoBrowseFile => browse::render(frame, app),
+        AppState::RepoBrowseTree | AppState::RepoBrowseFile | AppState::RepoBrowseGraph => {
+            browse::render(frame, app)
+        }
     }
 
     // GitOps シミュレーションモーダル


### PR DESCRIPTION
## Summary
- replace the Repository Browser imports overlay with a persistent tree/code/graph three-pane layout
- reuse the one-pass Hearth module index with cancellable, stale-safe asynchronous graph queries
- add UML-style dependency/dependent rendering, navigation, configurable hints, narrow/CJK handling, tests, and documentation

## Test plan
- `cargo test -- --test-threads=1`
- `cargo clippy --all-targets --workspace -- -D warnings`
- `cargo check`
- `cargo fmt --all -- --check`
- `cargo bench --bench ui_rendering -- browse_render`