### PR TITLE
feat: wrap browse content lines and add markdown rich toggle to the browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ octorus is not only a review tool — `or --browse` (or `b` from the file list, 
 
 - Browse every file, not just the ones a PR touched — tracked and untracked files included, ignored files excluded, uncommitted files visible immediately
 - Same tree-sitter syntax highlighting as the diff view (24 languages, your configured theme, Vue/Svelte/Markdown injections)
+- Long lines wrap at the pane edge onto gutter-aligned continuation rows, breaking on character boundaries so CJK prose wraps cleanly
+- Markdown rich display (`M`) — the same rich rendering as the diff view, applied to the open markdown file
 - Background loading — listing the repository, reading a file, and highlighting never block the UI
 - Blame gutter (`gb`) with jump to the blamed commit's diff (`gc`) or the PR that introduced it (`gp`)
 - Review discussion anchoring (`gr`) — marks the lines a PR review discussed and opens the thread at the cursor line; threads are placed by blame origin, so lines edited or moved since the review may not be matched
@@ -774,6 +776,7 @@ This view can be opened with `b` from the file list, **Repo Browse** in the Cock
 | `gr` | Mark reviewed lines and open the review discussion for the cursor line (blame gutter must be on) |
 | `gd` | Go to definition |
 | `gf` | Open file in your editor at the cursor line |
+| `M` | Toggle Markdown rich display |
 | `Ctrl-o` | Jump back |
 | `l` / `→` | Focus the graph pane when it is visible |
 | `h` / `←` / `q` / `Esc` | Back to the tree |

--- a/docs/repo-browse-architecture.md
+++ b/docs/repo-browse-architecture.md
@@ -329,6 +329,15 @@ string interning and takes no `ParserPool`. This is why a file can be displayed
 without waiting for highlighting; the replacement produced by
 `build_diff_cache()` arrives afterwards.
 
+`start_browse_highlight()` passes `App::is_markdown_rich()` through to
+`build_diff_cache()`, so the browser shares the diff view's markdown rich
+display. `M` (`toggle_markdown_rich`) in the file pane flips the flag via
+`toggle_browse_markdown_rich()` and re-runs `start_browse_highlight()` — but
+only for an open markdown file (the flag changes no other language's output),
+and never while `open_is_pending()`: a pending `open` is a placeholder, and
+highlighting it would race the landing file's cache with an empty one. The
+landing load starts its own highlight and reads the new flag then.
+
 Two verdicts come from a single `std::fs::metadata` call. Anything that is not a
 regular file (directories included) makes `file_metadata()` return
 `not a regular file` and the load becomes `FileLoad::Failed`; files over
@@ -434,6 +443,11 @@ of:
 4. `SCREEN_SPECIFIC_KEYS` (only when the single key really is valid on one screen only)
 5. `serialize_entry` in the `Serialize` impl
 
+`toggle_markdown_rich` (`M`) is a pre-existing global binding that the file
+pane merely dispatches; nothing new is registered, and because the same key is
+valid in the diff view and issue detail too, it must not be added to
+`SCREEN_SPECIFIC_KEYS`.
+
 The blame gutter registers into the file pane's existing sequence layer as
 `toggle_blame = ["g", "b"]`. It shares the prefix with `gg` / `gd` / `gf` but
 differs in the second key. Because `validate()` puts only the first key of a
@@ -498,6 +512,16 @@ frame becomes the active panes.
   work scales with the viewport width. **Line N of the file is line N+1 of the
   cache**
 - One context-marker space is stripped from the leading span of every line
+- A file line wider than the pane wraps onto continuation rows
+  (`push_wrapped_line()`), each carrying a blank prefix as wide as the whole
+  gutter — blame and discussion columns included — so the line-number column
+  stays straight. Rows break on character boundaries: CJK prose has no spaces,
+  and ratatui's word wrapper would push such a paragraph onto its own rows
+  below a lonely line number, which is why the pane does not use
+  `Paragraph::wrap`. Sub-spans borrow slices of the interned text, and
+  `content_lines()` stops emitting at the viewport height (`max_rows`), so
+  rendering stays O(viewport) even when every visible line wraps. The
+  cursor-line background extends across a wrapped line's continuation rows
 
 Overlays are drawn centred, after going through `clear_overlay_area()`. The
 function `Clear`s the target area and, if the column just left of it holds a
@@ -616,8 +640,7 @@ source — but that is not the default procedure.
 | The index is built once, when `BrowseState` is created | Re-entering the same root does not rebuild, so the index stays stale after external changes. No double start while building. Closing and reopening rebuilds everything from zero rather than incrementally | There is no refresh key today. Rebuild on `R`, or piggyback on the existing file watcher |
 | The file listing is also produced once, at `BrowseState` creation | Re-entering the same root does not re-enumerate, so new files do not appear in the tree. Closing and reopening re-enumerates everything | Same as above |
 | Search results are cut off at 200 | Only `MAX_SYMBOL_SEARCH_RESULTS` entries are returned and the rest are lost. The returned order equals sorting all matches, so ranking is not lost | `matches` is the post-truncation `hits.len()`, so it saturates at `200 matches` and truncation cannot be told apart. Paging is unimplemented |
-| No horizontal scrolling | Long lines are cut off | Add horizontal scroll to ratatui's `Paragraph` |
-| No intra-line wrapping | Same as above | Wrapping makes cursor-line arithmetic visual-line-based (the same problem as `pr_description`) |
+| Cursor/scroll arithmetic is logical-line-based under wrapping | Long lines wrap instead of being cut off, but `clamp_scroll` still counts logical lines, so when several wrapped lines share the viewport the cursor line can sit below the last visible row (the diff view accepts the same imperfection) | Make margin scrolling visual-row-based, the way `pr_description` counts wrapped rows with `Paragraph::line_count` |
 | `gd` jumps to the first identifier that resolves | Columns are ignored; identifiers are scanned from the start of the line, minus duplicates and common keywords. For `foo.bar()`, if `foo` has a definition it jumps there, otherwise it tries `bar` | Show the existing `SymbolPopupState` when there are several candidates |
 | symbol references unimplemented | The `@reference.*` captures present in the tags queries are still dropped; the module graph models file imports, not arbitrary symbol references | Keep import navigation file-level, or add a separate reference index with explicit per-language coverage |
 | Module graph is built once | Imports and resolver configuration become stale after external edits; no watcher-driven upsert or re-resolution exists | Re-analyze changed files and use Hearth incremental graph APIs; clear resolver caches when config dependencies change |

--- a/src/app/browse.rs
+++ b/src/app/browse.rs
@@ -1613,6 +1613,30 @@ impl App {
         });
     }
 
+    /// Toggle markdown rich display and rebuild the open markdown file's
+    /// highlight so the change shows without reopening the file.
+    pub(crate) fn toggle_browse_markdown_rich(&mut self) {
+        self.toggle_markdown_rich();
+        let Some(state) = self.browse_state.as_ref() else {
+            return;
+        };
+        // A pending `open` is a placeholder; highlighting it would race the
+        // landing file's cache with an empty one. The landing load starts its
+        // own highlight and reads the new flag then.
+        if state.open_is_pending() {
+            return;
+        }
+        // The flag only changes markdown output, so rebuilding any other
+        // language would be wasted work.
+        let is_markdown = state
+            .open
+            .as_ref()
+            .is_some_and(|open| crate::language::is_markdown_ext_from_filename(&open.path));
+        if is_markdown {
+            self.start_browse_highlight();
+        }
+    }
+
     /// Jump to the definition of the identifier under the cursor.
     ///
     /// Returns `false` when there is no index yet, no identifier under the

--- a/src/app/input_browse.rs
+++ b/src/app/input_browse.rs
@@ -148,6 +148,10 @@ impl App {
             self.open_browse_module_graph();
             return Ok(());
         }
+        if self.matches_single_key(&key, &kb.toggle_markdown_rich) {
+            self.toggle_browse_markdown_rich();
+            return Ok(());
+        }
 
         let graph_visible = self
             .browse_state
@@ -1191,6 +1195,23 @@ mod tests {
         panic!("blame load never settled");
     }
 
+    /// Drive the browse channels until the pending highlight upgrade lands.
+    async fn settle_highlight(app: &mut App) {
+        for _ in 0..2_000 {
+            app.poll_browse_updates();
+            if matches!(
+                app.browse_state
+                    .as_ref()
+                    .map(|state| &state.highlight_receiver),
+                None | Some(None)
+            ) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+        }
+        panic!("highlight never settled");
+    }
+
     async fn settle_commit_diff(app: &mut App) {
         for _ in 0..2_000 {
             app.poll_browse_updates();
@@ -1367,6 +1388,117 @@ mod tests {
         let state = app.browse_state.as_ref().unwrap();
         assert!(matches!(state.blame, BlameState::Off));
         assert!(state.blame_receiver.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_scenario_markdown_toggle_rebuilds_highlight_for_the_open_markdown_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app =
+            browsing_app_on_disk(dir.path(), &[("README.md", "# Title\n\nSome prose.\n")]);
+        app.handle_repo_browse_tree_input(press(KeyCode::Enter))
+            .unwrap();
+        settle_browse(&mut app).await;
+        settle_highlight(&mut app).await;
+
+        let cache_rich = |app: &App| {
+            app.browse_state
+                .as_ref()
+                .and_then(|state| state.open.as_ref())
+                .expect("open file")
+                .cache
+                .markdown_rich
+        };
+        assert!(!app.is_markdown_rich());
+        assert!(!cache_rich(&app));
+
+        let mut terminal = test_terminal();
+        app.handle_repo_browse_file_input(press(KeyCode::Char('M')), &mut terminal)
+            .unwrap();
+        assert!(app.is_markdown_rich());
+        assert!(
+            app.browse_state
+                .as_ref()
+                .unwrap()
+                .highlight_receiver
+                .is_some(),
+            "toggling markdown rich must restart the open markdown file's highlight"
+        );
+
+        settle_highlight(&mut app).await;
+        assert!(
+            cache_rich(&app),
+            "the rebuilt cache must carry the rich transforms"
+        );
+
+        app.handle_repo_browse_file_input(press(KeyCode::Char('M')), &mut terminal)
+            .unwrap();
+        assert!(!app.is_markdown_rich());
+        settle_highlight(&mut app).await;
+        assert!(
+            !cache_rich(&app),
+            "toggling back must restore the base cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_scenario_markdown_toggle_skips_rehighlight_for_non_markdown_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = browsing_app_on_disk(dir.path(), &[("main.rs", "fn main() {}\n")]);
+        app.handle_repo_browse_tree_input(press(KeyCode::Enter))
+            .unwrap();
+        settle_browse(&mut app).await;
+        settle_highlight(&mut app).await;
+
+        let mut terminal = test_terminal();
+        app.handle_repo_browse_file_input(press(KeyCode::Char('M')), &mut terminal)
+            .unwrap();
+        assert!(app.is_markdown_rich(), "the flag itself still toggles");
+        assert!(
+            app.browse_state
+                .as_ref()
+                .unwrap()
+                .highlight_receiver
+                .is_none(),
+            "a non-markdown file's highlight is unaffected by the flag, so \
+             rebuilding it would be wasted work"
+        );
+    }
+
+    /// While a load is pending, `open` is a placeholder with no content.
+    /// Highlighting it would race the landing file's cache with an empty one,
+    /// so the toggle only flips the flag and lets the landing load pick it up.
+    #[tokio::test]
+    async fn test_scenario_markdown_toggle_during_a_pending_load_lands_rich() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut app = browsing_app_on_disk(dir.path(), &[("README.md", "# Title\n")]);
+        app.handle_repo_browse_tree_input(press(KeyCode::Enter))
+            .unwrap();
+        assert!(app.browse_state.as_ref().unwrap().open_is_pending());
+
+        let mut terminal = test_terminal();
+        app.handle_repo_browse_file_input(press(KeyCode::Char('M')), &mut terminal)
+            .unwrap();
+        assert!(app.is_markdown_rich());
+        assert!(
+            app.browse_state
+                .as_ref()
+                .unwrap()
+                .highlight_receiver
+                .is_none(),
+            "a pending placeholder must not be highlighted"
+        );
+
+        settle_browse(&mut app).await;
+        settle_highlight(&mut app).await;
+        assert!(
+            app.browse_state
+                .as_ref()
+                .and_then(|state| state.open.as_ref())
+                .expect("open file")
+                .cache
+                .markdown_rich,
+            "the landing load's highlight must read the toggled flag"
+        );
     }
 
     #[test]

--- a/src/ui/browse.rs
+++ b/src/ui/browse.rs
@@ -36,6 +36,7 @@ use crate::ui::common::truncate_with_width;
 const LINE_NUMBER_WIDTH: usize = 5;
 const MIN_CODE_WIDTH_WITH_BLAME: usize = 24;
 const DISCUSSION_GUTTER_WIDTH: usize = 2;
+const CURSOR_LINE_BG: Color = Color::Rgb(48, 48, 64);
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let zen = app.zen_mode;
@@ -347,6 +348,7 @@ fn render_content(frame: &mut Frame, app: &mut App, area: Rect, focused: bool) {
         blame,
         discussion,
         content_width,
+        inner_height,
     );
 
     let building = matches!(state.index, crate::app::browse::IndexState::Building);
@@ -559,6 +561,10 @@ fn gutter_width(total: usize) -> usize {
 /// every string, and copying them would allocate once per span on every keystroke.
 /// A copy renders the identical frame, so `test_content_lines_borrow_their_text`
 /// asserts the `Cow` variant rather than the output.
+///
+/// A file line wider than the pane continues on extra visual rows instead of
+/// being cut off; `max_rows` caps the emitted rows at the viewport height so
+/// the work stays O(viewport) even when every visible line wraps.
 fn content_lines<'a>(
     window: &ContentWindow<'a>,
     cursor_line: usize,
@@ -566,46 +572,53 @@ fn content_lines<'a>(
     blame: Option<&'a BlameGutter>,
     discussion: Option<&DiscussionIndex>,
     content_width: usize,
+    max_rows: usize,
 ) -> Vec<Line<'a>> {
     let width = gutter_width(window.total);
     let discussion_width = discussion.map_or(0, |_| DISCUSSION_GUTTER_WIDTH);
     let blame_width =
         blame_gutter_width(content_width.saturating_sub(discussion_width), window.total);
-    window
-        .lines
-        .iter()
-        .enumerate()
-        .map(|(offset, cached)| {
-            let line_index = window.first_line + offset;
-            let is_cursor = line_index == cursor_line;
 
-            let mut spans = Vec::with_capacity(cached.spans.len() + 2);
-            if let (Some(gutter), Some(blame_width)) = (blame, blame_width) {
-                spans.push(Span::styled(
-                    gutter.text(line_index, blame_width),
-                    Style::default().fg(Color::DarkGray),
-                ));
-            }
-            if let Some(index) = discussion {
-                spans.push(Span::styled(
-                    if index.thread_indices_at(line_index).is_empty() {
-                        "  "
-                    } else {
-                        "● "
-                    },
-                    Style::default().fg(Color::Cyan),
-                ));
-            }
-            spans.push(Span::styled(
-                format!("{:>width$} ", line_index + 1),
-                Style::default().fg(if is_cursor {
-                    Color::Yellow
-                } else {
-                    Color::DarkGray
-                }),
+    let mut rows: Vec<Line<'a>> = Vec::new();
+    for (offset, cached) in window.lines.iter().enumerate() {
+        if rows.len() >= max_rows {
+            break;
+        }
+        let line_index = window.first_line + offset;
+        let is_cursor = line_index == cursor_line;
+
+        let mut prefix = Vec::with_capacity(3);
+        if let (Some(gutter), Some(blame_width)) = (blame, blame_width) {
+            prefix.push(Span::styled(
+                gutter.text(line_index, blame_width),
+                Style::default().fg(Color::DarkGray),
             ));
+        }
+        if let Some(index) = discussion {
+            prefix.push(Span::styled(
+                if index.thread_indices_at(line_index).is_empty() {
+                    "  "
+                } else {
+                    "● "
+                },
+                Style::default().fg(Color::Cyan),
+            ));
+        }
+        prefix.push(Span::styled(
+            format!("{:>width$} ", line_index + 1),
+            Style::default().fg(if is_cursor {
+                Color::Yellow
+            } else {
+                Color::DarkGray
+            }),
+        ));
+        let prefix_width: usize = prefix.iter().map(|span| span.content.width()).sum();
 
-            for (index, span) in cached.spans.iter().enumerate() {
+        let content: Vec<(&'a str, Style)> = cached
+            .spans
+            .iter()
+            .enumerate()
+            .map(|(index, span)| {
                 let text = window.cache.resolve(span.content);
                 // Strip the pseudo-patch's leading context marker.
                 let text = if index == 0 {
@@ -615,13 +628,103 @@ fn content_lines<'a>(
                 };
                 let mut style = span.style;
                 if is_cursor && bg_color {
-                    style = style.bg(Color::Rgb(48, 48, 64));
+                    style = style.bg(CURSOR_LINE_BG);
                 }
-                spans.push(Span::styled(text, style));
+                (text, style)
+            })
+            .collect();
+
+        push_wrapped_line(
+            &mut rows,
+            prefix,
+            prefix_width,
+            &content,
+            content_width,
+            max_rows,
+            is_cursor && bg_color,
+        );
+    }
+    rows
+}
+
+/// Append one file line as visual rows no wider than `content_width` cells.
+///
+/// Rows break on character boundaries: CJK prose has no spaces, so ratatui's
+/// word wrapper would push a whole paragraph onto its own row below a lonely
+/// line number. Continuation rows carry a blank prefix as wide as the gutter,
+/// keeping the line-number column straight. Sub-spans borrow slices of the
+/// same interned text as the unwrapped path, and emission stops at `max_rows`.
+fn push_wrapped_line<'a>(
+    rows: &mut Vec<Line<'a>>,
+    prefix: Vec<Span<'a>>,
+    prefix_width: usize,
+    content: &[(&'a str, Style)],
+    content_width: usize,
+    max_rows: usize,
+    cursor_bg: bool,
+) {
+    let text_width = content_width.saturating_sub(prefix_width);
+    // Degenerate pane: no room for text next to the gutter. Emit the single
+    // row the unwrapped path produced and let the renderer clip it.
+    if text_width == 0 {
+        let mut spans = prefix;
+        spans.extend(
+            content
+                .iter()
+                .map(|&(text, style)| Span::styled(text, style)),
+        );
+        rows.push(Line::from(spans));
+        return;
+    }
+
+    let pad = || {
+        Span::styled(
+            " ".repeat(prefix_width),
+            if cursor_bg {
+                Style::default().bg(CURSOR_LINE_BG)
+            } else {
+                Style::default()
+            },
+        )
+    };
+
+    let mut current = prefix;
+    let mut used = 0usize;
+    for &(text, style) in content {
+        // Fast path: the whole span fits on this row as one borrowed piece.
+        let span_width = text.width();
+        if used + span_width <= text_width {
+            if !text.is_empty() {
+                current.push(Span::styled(text, style));
             }
-            Line::from(spans)
-        })
-        .collect()
+            used += span_width;
+            continue;
+        }
+
+        let mut start = 0usize;
+        for (byte, ch) in text.char_indices() {
+            let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+            // A glyph wider than the whole text column still gets placed
+            // (`used > 0` fails), so every iteration makes progress.
+            if used + ch_width > text_width && used > 0 {
+                if byte > start {
+                    current.push(Span::styled(&text[start..byte], style));
+                }
+                rows.push(Line::from(std::mem::take(&mut current)));
+                if rows.len() >= max_rows {
+                    return;
+                }
+                current.push(pad());
+                start = byte;
+                used = 0;
+            }
+            used += ch_width;
+        }
+        if start < text.len() {
+            current.push(Span::styled(&text[start..], style));
+        }
+    }
+    rows.push(Line::from(current));
 }
 
 fn blame_gutter_width(content_width: usize, total: usize) -> Option<BlameGutterWidth> {
@@ -2004,16 +2107,23 @@ mod tests {
         );
         let index = discussion_index(2, 1);
 
-        let rendered: Vec<String> =
-            content_lines(&window, 0, false, Some(&blame), Some(&index), 20)
+        let rendered: Vec<String> = content_lines(
+            &window,
+            0,
+            false,
+            Some(&blame),
+            Some(&index),
+            20,
+            usize::MAX,
+        )
+        .iter()
+        .map(|line| {
+            line.spans
                 .iter()
-                .map(|line| {
-                    line.spans
-                        .iter()
-                        .map(|span| span.content.as_ref())
-                        .collect()
-                })
-                .collect();
+                .map(|span| span.content.as_ref())
+                .collect()
+        })
+        .collect();
 
         assert!(!rendered.join("\n").contains("aaaaaaa"));
         assert!(rendered[0].starts_with("      1"), "{rendered:?}");
@@ -2285,7 +2395,7 @@ mod tests {
         assert_eq!(window.total, 30);
         assert_eq!(window.lines.len(), 30);
 
-        let lines = content_lines(&window, 0, false, None, None, usize::MAX);
+        let lines = content_lines(&window, 0, false, None, None, usize::MAX, usize::MAX);
         let content_of = |line: &Line| -> String {
             line.spans[1..]
                 .iter()
@@ -2320,7 +2430,7 @@ mod tests {
         let cache = cache_of("fn main() {\n    println!(\"hi\");\n}\n");
         let window = content_window(&cache, 0, 3);
 
-        let lines = content_lines(&window, 0, true, None, None, usize::MAX);
+        let lines = content_lines(&window, 0, true, None, None, usize::MAX, usize::MAX);
 
         assert_eq!(lines.len(), 3);
         for line in &lines {
@@ -2363,7 +2473,7 @@ mod tests {
             ),
             3,
         );
-        let lines = content_lines(&window, 0, true, Some(&blame), None, 120);
+        let lines = content_lines(&window, 0, true, Some(&blame), None, 120, usize::MAX);
         for line in &lines {
             assert!(
                 matches!(line.spans[0].content, Cow::Borrowed(_)),
@@ -2380,6 +2490,53 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// Wrapping must not make a frame O(file): when every visible line wraps
+    /// many times, row emission stops at the viewport height instead of
+    /// materialising every continuation row of every window line.
+    #[test]
+    fn test_wrapped_rows_stop_at_the_viewport_row_cap() {
+        let long = "x".repeat(1_000);
+        let cache = cache_of(&format!("{long}\n{long}\n{long}\n"));
+        let window = content_window(&cache, 0, 3);
+
+        let rows = content_lines(&window, 0, false, None, None, 40, 5);
+
+        // content width 40 minus the 6-cell gutter leaves 34 text cells, so
+        // each 1,000-cell line alone would produce ~30 rows.
+        assert_eq!(rows.len(), 5);
+    }
+
+    /// The cursor-line background must extend across wrapped continuation rows
+    /// — pad and text alike — otherwise the highlight visually ends at the
+    /// first row of a wrapped line.
+    #[test]
+    fn test_cursor_line_background_covers_wrapped_continuation_rows() {
+        let cache = cache_of(&format!("{}\n", "y".repeat(80)));
+        let window = content_window(&cache, 0, 4);
+
+        let rows = content_lines(&window, 0, true, None, None, 46, usize::MAX);
+
+        // 46 cells minus the 6-cell gutter wraps 80 glyphs into exactly two rows.
+        assert_eq!(rows.len(), 2);
+        let text_of = |row: &Line| -> String {
+            row.spans[1..]
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect()
+        };
+        assert_eq!(text_of(&rows[0]), "y".repeat(40));
+        assert_eq!(text_of(&rows[1]), "y".repeat(40));
+
+        let pad = &rows[1].spans[0];
+        assert!(
+            pad.content.chars().all(|c| c == ' '),
+            "the continuation prefix must be blank, not a repeated gutter"
+        );
+        assert_eq!(pad.content.as_ref().len(), 6);
+        assert_eq!(pad.style.bg, Some(CURSOR_LINE_BG));
+        assert_eq!(rows[1].spans[1].style.bg, Some(CURSOR_LINE_BG));
     }
 
     /// The gutter is the one part of a browse row the renderer writes itself, so
@@ -2409,10 +2566,18 @@ mod tests {
             let cache = cache_of(&numbered_source(total));
             let window = content_window(&cache, total - 3, 3);
             assert_eq!(window.total, total);
-            content_lines(&window, total - 1, false, None, None, usize::MAX)
-                .iter()
-                .map(|line| line.spans[0].content.chars().count())
-                .collect()
+            content_lines(
+                &window,
+                total - 1,
+                false,
+                None,
+                None,
+                usize::MAX,
+                usize::MAX,
+            )
+            .iter()
+            .map(|line| line.spans[0].content.chars().count())
+            .collect()
         };
 
         // 99,999 lines: five-column gutter, and it must not widen early.
@@ -3156,13 +3321,13 @@ mod tests {
         assert_eq!(ascii_right_border_x, cjk_right_border_x);
     }
 
-    /// A CJK line wider than the pane has to be cut somewhere. The cut must land
-    /// on a character boundary: half a double-width glyph would either bleed over
+    /// A CJK line wider than the pane wraps, and every visual row must break on
+    /// a character boundary: half a double-width glyph would either bleed over
     /// the pane border or leave the border painted inside the glyph's cell.
     /// Both alignments matter — with an odd-width prefix the glyph that no longer
     /// fits straddles the border, which is the case that goes wrong.
     #[test]
-    fn test_cjk_line_wider_than_the_pane_is_cut_on_a_character_boundary() {
+    fn test_cjk_line_wider_than_the_pane_wraps_on_a_character_boundary() {
         let wide_only = "あ".repeat(40);
         let odd_offset = format!("x{}", "あ".repeat(40));
 
@@ -3202,7 +3367,52 @@ mod tests {
                     "the cell after the glyph at x={x} is not its continuation"
                 );
             }
+
+            // The overflow is not discarded: the glyphs that no longer fit
+            // continue on the next visual row.
+            let continuation_glyphs = (0..border_x)
+                .filter(|&x| buf[(x, content_y + 1)].symbol() == "あ")
+                .count();
+            assert!(
+                continuation_glyphs > 0,
+                "the overflowing tail must wrap onto the next row: {source}"
+            );
         }
+    }
+
+    /// The diff view wraps long lines onto continuation rows instead of cutting
+    /// them off at the pane edge; the browse content pane matches so markdown
+    /// prose and long code lines stay readable.
+    #[test]
+    fn test_long_line_wraps_onto_continuation_rows() {
+        let mut app = app_with_browse(&["notes.md"]);
+        if let Some(state) = app.browse_state.as_mut() {
+            open_file(
+                state,
+                "notes.md",
+                &format!("{}tail-sentinel\nshort line\n", "word ".repeat(18)),
+            );
+        }
+        app.state = AppState::RepoBrowseFile;
+        let out = render_at(&mut app, 80, 12);
+        assert!(
+            out.contains("tail-sentinel"),
+            "the overflowing tail must land on a wrapped continuation row:\n{out}"
+        );
+        assert_snapshot!(out, @"
+        ┌──────────────────────────────────────────────────────────────────────────────┐
+        │Repo Browse - demo  1 files  symbols: -                                       │
+        └──────────────────────────────────────────────────────────────────────────────┘
+        ┌Files─────────────────────┐┌notes.md (1/2)────────────────────────────────────┐
+        │  notes.md                ││    1 word word word word word word word word word│
+        │                          ││       word word word word word word word word wor│
+        │                          ││      d tail-sentinel                             │
+        │                          ││    2 short line                                  │
+        │                          ││                                                  │
+        │                          ││                                                  │
+        └──────────────────────────┘└──────────────────────────────────────────────────┘
+         o outline | s search | i graph | gb blame | gc diff | gp PR | gr discuss | gd d
+        ");
     }
 
     /// A CJK glyph in the tree can start in the column immediately left of the

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -1045,6 +1045,10 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
             fmt_key(&kb.go_to_file.display(), key_width)
         )),
         Line::from(format!(
+            "{}  Toggle markdown rich display",
+            fmt_key(&kb.toggle_markdown_rich.display(), key_width)
+        )),
+        Line::from(format!(
             "{}  Jump back",
             fmt_key(&kb.jump_back.display(), key_width)
         )),


### PR DESCRIPTION
## Summary

Two gaps in the repository browser's file content pane, both reported against browse mode:

- **Long lines were cut off at the pane edge** — the diff view wraps, the browser did not (the "No intra-line wrapping" known limitation). Markdown prose, especially CJK text, was unreadable.
- **No way to use markdown rich display** — the browse highlight path already passed `is_markdown_rich()` through to `build_diff_cache`, but no browser key flipped the flag.

## Changes

### Intra-line wrapping with a gutter-aligned hanging indent

`content_lines` now wraps file lines onto continuation rows itself instead of using `Paragraph::wrap`: ratatui's word wrapper treats a spaceless CJK paragraph as one long word, pushing it onto its own rows below an orphaned line number. Wrapping breaks on character boundaries (CJK-safe), continuation rows carry a blank prefix as wide as the whole gutter (blame and discussion columns included), and the cursor-line background extends across continuation rows.

```
    1 word word word word word
      continuation rows indent
      under the content column
    2 short line
```

Performance: sub-spans borrow slices of the interned text (no allocation), and row emission stops at the viewport height (`max_rows`), so rendering stays O(viewport). `browse_render` measured +3-4% vs main on an idle machine (200: 49.0→51.2µs, 30000: 50.6→54.1µs), flat across file sizes.

### `M` toggles markdown rich display in the browser file pane

The file pane dispatches the existing `toggle_markdown_rich` binding and rebuilds the open markdown file's highlight so the change shows without reopening. While a file load is pending, only the flag flips — highlighting the pending placeholder would race the landing file's cache with an empty one; the landing load starts its own highlight and reads the new flag then. Non-markdown files skip the rebuild (the flag changes no other language's output).

## Tests

- Snapshot: long line wrapping with hanging indent; CJK overflow wraps on character boundaries with the tail on the next row
- Unit: row emission capped at the viewport height; cursor background covers continuation rows; borrowed-`Cow` contract preserved
- Scenario: `M` rebuilds the highlight for an open markdown file (both directions), skips non-markdown files, and defers during a pending load with the rich cache landing afterwards

Gates: `cargo clippy --all-targets -- -D warnings`, `cargo test` (1693/84/18/1), `cargo fmt --check` all green.

## Docs

README (browser feature list + File Focus key table), in-app help, and `docs/repo-browse-architecture.md` (§3 data flow, §5 keybinding caveats, §6 rendering, §8 known limitations — the wrapping limitation is replaced by an honest note that cursor/scroll arithmetic stays logical-line-based, the same accepted imperfection as the diff view).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RkYB5XS9wWWo2BqYGSPYiF