### PR TITLE
feat: add mouse support across all screens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,7 +1534,7 @@ dependencies = [
 
 [[package]]
 name = "octorus"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/tree-sitter-moonbit", "crates/tree-sitter-vue3"]
 
 [package]
 name = "octorus"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.95"
 authors = ["ushironoko"]

--- a/README.md
+++ b/README.md
@@ -420,6 +420,13 @@ All octorus settings are configurable. Settings can be global or project-local.
 | `left_panel_width` | `u16` | `35` | Left panel width percentage in split view (clamped to `10`–`90`). Right panel fills the rest |
 | `zen_mode` | `bool` | `false` | Zen mode — hides UI chrome for distraction-free diff reading |
 
+#### `[mouse]`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | `bool` | `true` | Enable mouse support (click, wheel, drag). While capture is on, the terminal's native text selection is unavailable — press `F2` (`toggle_mouse`) to temporarily release the mouse for copying, or set this to `false` to opt out entirely |
+| `wheel_step` | `u16` | `3` | Lines moved per wheel notch (clamped to `1`–`10`) |
+
 #### `[ai]`
 
 | Key | Type | Default | Description |
@@ -579,6 +586,27 @@ theme = "MyCustomTheme"
 Custom themes with the same name as a built-in theme will override it.
 
 ## Keybindings
+
+### Mouse
+
+Mouse support works on every screen and follows the same paths as the keyboard,
+so lazy loading, prefetching, and state transitions behave identically.
+
+| Gesture | Action |
+|---------|--------|
+| Click a list row / diff line | Select it (also focuses the clicked pane in split views) |
+| Click the selected row / line again | Open it (`Enter` equivalent) |
+| Wheel | Move the cursor/selection under the pointer by `wheel_step` lines (works on unfocused panes too) |
+| Drag on diff lines | Multi-line selection (`V` equivalent) |
+| Drag the split border | Resize the left panel (session only) |
+| Click outside an informational overlay | Close it (`Esc` equivalent) |
+| Click outside a confirmation dialog | Ignored — destructive confirmations are answered with `y`/`n` only |
+| `F2` | Toggle mouse capture on/off |
+
+> **Copying text:** while mouse capture is on, the terminal's native
+> drag-to-select is unavailable. Press `F2` to release the mouse, copy, then
+> press `F2` again (many terminals also support `Shift`+drag as a bypass).
+> Set `[mouse] enabled = false` to disable mouse support entirely.
 
 ### PR List View
 
@@ -1046,6 +1074,7 @@ go_to_definition = ["g", "d"]
 | `open_blame_pr` | `gp` | Open the PR for the blamed line's commit (browser file pane only) |
 | `open_line_discussion` | `gr` | Anchor review threads to lines and open the cursor line's discussion (browser file pane only) |
 | `toggle_zen_mode` | `Z` | Toggle zen mode (fullscreen diff) |
+| `toggle_mouse` | `F2` | Toggle mouse capture (release the mouse to copy text with the terminal) |
 | **Git Ops** |||
 | `git_ops_stage` | `Space` | Stage/unstage file or directory |
 | `git_ops_stage_all` | `s` | Stage all files |

--- a/docs/repo-browse-architecture.md
+++ b/docs/repo-browse-architecture.md
@@ -416,6 +416,15 @@ the original Git listing. Nodes without a jump stay visible and report why they
 cannot be opened. Opening a node returns focus to code and refreshes the still
 visible pane for that new current file.
 
+**Mouse routing**: mouse events do not pass through these key layers. Instead,
+renderers register hit regions into `App::hit_map` (`src/ui/hit.rs`) each frame
+and `handle_mouse` (`src/app/input_mouse.rs`) resolves the topmost region —
+overlay z-order is expressed by registration order (backdrop → surface → rows),
+so a click can never reach a layer the keyboard could not. Mouse actions call
+the same `pub(crate)` methods the key branches call (`browse_tree_move_down`,
+`browse_file_click_line`, `browse_graph_move`, the four `browse_*_dismiss`
+overlay closers, …), so behaviour cannot drift between the two input paths.
+
 ## 5. Keybinding registration caveats
 
 `KeybindingsConfig::validate()` detects exact duplicates between single keys and
@@ -466,6 +475,16 @@ before the sequence layer.
 
 `src/ui/browse.rs`. In zen mode the header and footer are dropped and the whole
 frame becomes the active panes.
+
+Renderers also populate the frame's mouse hit map while they draw: the tree
+pane registers one `ListRow` per visible row using the same centered offset it
+renders with, the content pane registers one `ContentLine` per rendered row
+with the logical file line resolved at wrap time (`WrappedRows` keeps rendered
+rows and logical lines in lockstep), the graph pane registers one three-row
+region per visible node plus a title-row direction toggle, and each overlay
+registers backdrop → surface → rows on top. Because registration happens at
+draw time with the renderer's own offsets, the input side never re-derives
+layout math.
 
 - Tree pane: "loading spinner", "error", or "tree" according to `LoadState`
 - Content pane: nothing selected / the binary or oversized-file notice / the contents

--- a/src/app/ai_rally.rs
+++ b/src/app/ai_rally.rs
@@ -206,29 +206,9 @@ impl App {
                 }
             }
         } else if self.matches_single_key(&key, &kb.move_down) {
-            if let Some(ref mut rally_state) = self.ai_rally_state {
-                let total_logs = rally_state.logs.len();
-                if total_logs == 0 {
-                    return Ok(());
-                }
-                let current = rally_state.selected_log_index.unwrap_or(0);
-                let new_index = (current + 1).min(total_logs.saturating_sub(1));
-                rally_state.selected_log_index = Some(new_index);
-                self.adjust_log_scroll_to_selection();
-            }
+            self.rally_log_move_down();
         } else if self.matches_single_key(&key, &kb.move_up) {
-            if let Some(ref mut rally_state) = self.ai_rally_state {
-                let total_logs = rally_state.logs.len();
-                if total_logs == 0 {
-                    return Ok(());
-                }
-                let current = rally_state
-                    .selected_log_index
-                    .unwrap_or(total_logs.saturating_sub(1));
-                let new_index = current.saturating_sub(1);
-                rally_state.selected_log_index = Some(new_index);
-                self.adjust_log_scroll_to_selection();
-            }
+            self.rally_log_move_up();
         } else if self.matches_single_key(&key, &kb.page_down)
             || Self::is_shift_char_shortcut(&key, 'j')
         {
@@ -260,11 +240,7 @@ impl App {
                 self.adjust_log_scroll_to_selection();
             }
         } else if self.matches_single_key(&key, &kb.open_panel) {
-            if let Some(ref mut rally_state) = self.ai_rally_state {
-                if rally_state.selected_log_index.is_some() && !rally_state.logs.is_empty() {
-                    rally_state.showing_log_detail = true;
-                }
-            }
+            self.open_selected_rally_log();
         } else if self.matches_single_key(&key, &kb.jump_to_last) {
             if let Some(ref mut rally_state) = self.ai_rally_state {
                 let total_logs = rally_state.logs.len();
@@ -317,6 +293,56 @@ impl App {
         }
         Ok(())
     }
+
+    pub(crate) fn rally_log_move_down(&mut self) {
+        if let Some(ref mut rally_state) = self.ai_rally_state {
+            let total_logs = rally_state.logs.len();
+            if total_logs == 0 {
+                return;
+            }
+            let current = rally_state.selected_log_index.unwrap_or(0);
+            let new_index = (current + 1).min(total_logs.saturating_sub(1));
+            rally_state.selected_log_index = Some(new_index);
+            self.adjust_log_scroll_to_selection();
+        }
+    }
+
+    pub(crate) fn rally_log_move_up(&mut self) {
+        if let Some(ref mut rally_state) = self.ai_rally_state {
+            let total_logs = rally_state.logs.len();
+            if total_logs == 0 {
+                return;
+            }
+            let current = rally_state
+                .selected_log_index
+                .unwrap_or(total_logs.saturating_sub(1));
+            let new_index = current.saturating_sub(1);
+            rally_state.selected_log_index = Some(new_index);
+            self.adjust_log_scroll_to_selection();
+        }
+    }
+
+    pub(crate) fn open_selected_rally_log(&mut self) {
+        if let Some(ref mut rally_state) = self.ai_rally_state {
+            if rally_state.selected_log_index.is_some() && !rally_state.logs.is_empty() {
+                rally_state.showing_log_detail = true;
+            }
+        }
+    }
+
+    pub(crate) fn rally_log_click_select(&mut self, row: usize) -> bool {
+        let Some(ref mut rally_state) = self.ai_rally_state else {
+            return false;
+        };
+
+        if rally_state.selected_log_index == Some(row) {
+            true
+        } else {
+            rally_state.selected_log_index = Some(row);
+            false
+        }
+    }
+
     pub(crate) fn adjust_log_scroll_to_selection(&mut self) {
         if let Some(ref mut rally_state) = self.ai_rally_state {
             let Some(selected) = rally_state.selected_log_index else {
@@ -398,7 +424,7 @@ impl App {
             crate::editor::open_clarification_editor(self.config.editor.as_deref(), question)?;
 
         // Re-setup terminal after editor closes
-        *terminal = ui::setup_terminal()?;
+        *terminal = ui::setup_terminal(self.mouse_capture_active)?;
 
         // Process result
         if let Some(ref mut rally_state) = self.ai_rally_state {

--- a/src/app/cockpit.rs
+++ b/src/app/cockpit.rs
@@ -29,16 +29,15 @@ impl App {
         let Some(ref cockpit) = self.cockpit_state else {
             return Ok(());
         };
-        let selected = cockpit.selected_item;
         let repo_available = cockpit.repo_available;
 
         if is_move_down {
-            self.cockpit_state.as_mut().unwrap().selected_item = selected.next();
+            self.cockpit_move_down();
             return Ok(());
         }
 
         if is_move_up {
-            self.cockpit_state.as_mut().unwrap().selected_item = selected.prev();
+            self.cockpit_move_up();
             return Ok(());
         }
 
@@ -48,21 +47,56 @@ impl App {
         }
 
         if is_open {
-            if selected.requires_repo() && !repo_available {
-                return Ok(());
-            }
-
-            match selected {
-                CockpitMenuItem::PrList => self.open_pr_list_from_cockpit(),
-                CockpitMenuItem::IssueList => self.open_issue_list(),
-                CockpitMenuItem::LocalDiff => self.enter_local_mode_from_cockpit(),
-                CockpitMenuItem::GitOps => self.open_git_ops(),
-                CockpitMenuItem::RepoBrowse => self.open_repo_browse(),
-            }
+            self.activate_cockpit_selection();
             return Ok(());
         }
 
         Ok(())
+    }
+
+    pub(crate) fn cockpit_move_down(&mut self) {
+        if let Some(ref mut cockpit) = self.cockpit_state {
+            cockpit.selected_item = cockpit.selected_item.next();
+        }
+    }
+
+    pub(crate) fn cockpit_move_up(&mut self) {
+        if let Some(ref mut cockpit) = self.cockpit_state {
+            cockpit.selected_item = cockpit.selected_item.prev();
+        }
+    }
+
+    pub(crate) fn activate_cockpit_selection(&mut self) {
+        let Some(ref cockpit) = self.cockpit_state else {
+            return;
+        };
+        let selected = cockpit.selected_item;
+        let repo_available = cockpit.repo_available;
+
+        if selected.requires_repo() && !repo_available {
+            return;
+        }
+
+        match selected {
+            CockpitMenuItem::PrList => self.open_pr_list_from_cockpit(),
+            CockpitMenuItem::IssueList => self.open_issue_list(),
+            CockpitMenuItem::LocalDiff => self.enter_local_mode_from_cockpit(),
+            CockpitMenuItem::GitOps => self.open_git_ops(),
+            CockpitMenuItem::RepoBrowse => self.open_repo_browse(),
+        }
+    }
+
+    pub(crate) fn cockpit_click_select(&mut self, row: usize) -> bool {
+        let Some(ref mut cockpit) = self.cockpit_state else {
+            return false;
+        };
+
+        if cockpit.selected_item.index() == row {
+            true
+        } else {
+            cockpit.selected_item = CockpitMenuItem::from_index(row);
+            false
+        }
     }
 
     /// Single entry point for all cockpit return paths to prevent partial resets.

--- a/src/app/comments.rs
+++ b/src/app/comments.rs
@@ -82,7 +82,7 @@ impl App {
         tracing::debug!(?editor_result, "submit_review: editor returned");
 
         // エディタの成否に関わらずターミナルを再セットアップ
-        *terminal = ui::setup_terminal()?;
+        *terminal = ui::setup_terminal(self.mouse_capture_active)?;
 
         let body = match editor_result {
             Ok(body) => body,
@@ -710,23 +710,12 @@ impl App {
         } else if self.matches_single_key(&key, &kb.move_down) {
             match self.cmt.comment_tab {
                 CommentTab::Review => self.review_nav_down(1),
-                CommentTab::Discussion => {
-                    if let Some(ref comments) = self.cmt.discussion_comments {
-                        if !comments.is_empty() {
-                            self.cmt.selected_discussion_comment =
-                                (self.cmt.selected_discussion_comment + 1)
-                                    .min(comments.len().saturating_sub(1));
-                        }
-                    }
-                }
+                CommentTab::Discussion => self.discussion_move_down(),
             }
         } else if self.matches_single_key(&key, &kb.move_up) {
             match self.cmt.comment_tab {
                 CommentTab::Review => self.review_nav_up(1),
-                CommentTab::Discussion => {
-                    self.cmt.selected_discussion_comment =
-                        self.cmt.selected_discussion_comment.saturating_sub(1);
-                }
+                CommentTab::Discussion => self.discussion_move_up(),
             }
         } else if self.matches_single_key(&key, &kb.page_down)
             || Self::is_shift_char_shortcut(&key, 'j')
@@ -758,21 +747,67 @@ impl App {
         } else if self.matches_single_key(&key, &kb.open_panel) {
             match self.cmt.comment_tab {
                 CommentTab::Review => self.review_tab_open_panel(),
-                CommentTab::Discussion => {
-                    if self
-                        .cmt
-                        .discussion_comments
-                        .as_ref()
-                        .map(|c| !c.is_empty())
-                        .unwrap_or(false)
-                    {
-                        self.cmt.discussion_comment_detail_mode = true;
-                        self.cmt.discussion_comment_detail_scroll = 0;
-                    }
-                }
+                CommentTab::Discussion => self.open_selected_discussion_comment(),
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn discussion_move_down(&mut self) {
+        if let Some(ref comments) = self.cmt.discussion_comments {
+            if !comments.is_empty() {
+                self.cmt.selected_discussion_comment = (self.cmt.selected_discussion_comment + 1)
+                    .min(comments.len().saturating_sub(1));
+            }
+        }
+    }
+
+    pub(crate) fn discussion_move_up(&mut self) {
+        self.cmt.selected_discussion_comment =
+            self.cmt.selected_discussion_comment.saturating_sub(1);
+    }
+
+    pub(crate) fn open_selected_discussion_comment(&mut self) {
+        if self
+            .cmt
+            .discussion_comments
+            .as_ref()
+            .map(|comments| !comments.is_empty())
+            .unwrap_or(false)
+        {
+            self.cmt.discussion_comment_detail_mode = true;
+            self.cmt.discussion_comment_detail_scroll = 0;
+        }
+    }
+
+    pub(crate) fn comment_list_click_select(&mut self, row: usize) -> bool {
+        match self.cmt.comment_tab {
+            CommentTab::Review if self.cmt.expanded_thread.is_some() => {
+                if self.cmt.expanded_selected == row {
+                    true
+                } else {
+                    self.cmt.expanded_selected = row;
+                    self.sync_expanded_comment_id();
+                    false
+                }
+            }
+            CommentTab::Review => {
+                if self.cmt.selected_thread == row {
+                    true
+                } else {
+                    self.cmt.selected_thread = row;
+                    false
+                }
+            }
+            CommentTab::Discussion => {
+                if self.cmt.selected_discussion_comment == row {
+                    true
+                } else {
+                    self.cmt.selected_discussion_comment = row;
+                    false
+                }
+            }
+        }
     }
 
     pub(crate) async fn handle_local_comment_list_input(
@@ -852,7 +887,7 @@ impl App {
     /// Enter on the review list: jump within an expanded thread, expand a
     /// thread that has replies, or jump straight to a single-comment file.
     /// Shared by GitHub-mode and local-mode comment list handlers.
-    fn review_tab_open_panel(&mut self) {
+    pub(crate) fn review_tab_open_panel(&mut self) {
         if let Some(thread_idx) = self
             .cmt
             .expanded_thread
@@ -907,7 +942,7 @@ impl App {
         }
     }
 
-    fn review_nav_down(&mut self, step: usize) {
+    pub(crate) fn review_nav_down(&mut self, step: usize) {
         if let Some(thread_idx) = self
             .cmt
             .expanded_thread
@@ -923,7 +958,7 @@ impl App {
         }
     }
 
-    fn review_nav_up(&mut self, step: usize) {
+    pub(crate) fn review_nav_up(&mut self, step: usize) {
         if self
             .cmt
             .expanded_thread

--- a/src/app/git_ops/mod.rs
+++ b/src/app/git_ops/mod.rs
@@ -896,7 +896,7 @@ impl App {
             .current_dir(working_dir)
             .status();
 
-        *terminal = crate::ui::setup_terminal()?;
+        *terminal = crate::ui::setup_terminal(self.mouse_capture_active)?;
 
         match status {
             Ok(s) if s.success() => {
@@ -1150,6 +1150,97 @@ impl App {
         ops.tree.toggle_expand();
     }
 
+    pub(crate) fn git_ops_tree_move_down(&mut self) {
+        if let Some(ref mut ops) = self.git_ops_state {
+            ops.tree.move_down();
+        }
+        self.update_git_ops_diff();
+    }
+
+    pub(crate) fn git_ops_tree_move_up(&mut self) {
+        if let Some(ref mut ops) = self.git_ops_state {
+            ops.tree.move_up();
+        }
+        self.update_git_ops_diff();
+    }
+
+    pub(crate) fn open_selected_git_ops_tree_entry(&mut self) {
+        let is_dir = self
+            .git_ops_state
+            .as_ref()
+            .and_then(|ops| ops.tree.visible_rows.get(ops.tree.selected_row))
+            .map(|row| matches!(row, TreeRow::Dir { .. }))
+            .unwrap_or(false);
+
+        if is_dir {
+            self.toggle_dir_expand();
+        } else {
+            if let Some(ref mut ops) = self.git_ops_state {
+                ops.left_return_focus = LeftPaneFocus::Tree;
+            }
+            self.state = AppState::GitOpsSplitDiff;
+        }
+    }
+
+    pub(crate) fn git_ops_tree_click_select(&mut self, row: usize) -> bool {
+        let Some(ref mut ops) = self.git_ops_state else {
+            return false;
+        };
+        if ops.tree.selected_row == row {
+            return true;
+        }
+        ops.tree.selected_row = row;
+        self.update_git_ops_diff();
+        false
+    }
+
+    pub(crate) fn git_ops_commits_move_down(&mut self) {
+        if let Some(ref mut ops) = self.git_ops_state {
+            let cl = &mut ops.commit_log;
+            if !cl.commits.is_empty() {
+                cl.selected = (cl.selected + 1).min(cl.commits.len() - 1);
+            }
+        }
+        self.start_fetch_git_ops_commit_diff();
+        let should_load_more = self
+            .git_ops_state
+            .as_ref()
+            .map(|ops| {
+                let cl = &ops.commit_log;
+                cl.selected + 5 >= cl.commits.len() && cl.has_more && !cl.loading
+            })
+            .unwrap_or(false);
+        if should_load_more {
+            self.load_more_git_ops_commits();
+        }
+    }
+
+    pub(crate) fn git_ops_commits_move_up(&mut self) {
+        if let Some(ref mut ops) = self.git_ops_state {
+            ops.commit_log.selected = ops.commit_log.selected.saturating_sub(1);
+        }
+        self.start_fetch_git_ops_commit_diff();
+    }
+
+    pub(crate) fn open_selected_git_ops_commit(&mut self) {
+        if let Some(ref mut ops) = self.git_ops_state {
+            ops.left_return_focus = LeftPaneFocus::Commits;
+        }
+        self.state = AppState::GitOpsSplitDiff;
+    }
+
+    pub(crate) fn git_ops_commits_click_select(&mut self, row: usize) -> bool {
+        let Some(ref mut ops) = self.git_ops_state else {
+            return false;
+        };
+        if ops.commit_log.selected == row {
+            return true;
+        }
+        ops.commit_log.selected = row;
+        self.start_fetch_git_ops_commit_diff();
+        false
+    }
+
     /// Handle input for GitOpsSplitTree state
     pub(crate) fn handle_git_ops_tree_input(
         &mut self,
@@ -1178,18 +1269,12 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if let Some(ref mut ops) = self.git_ops_state {
-                ops.tree.move_down();
-            }
-            self.update_git_ops_diff();
+            self.git_ops_tree_move_down();
             return;
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            if let Some(ref mut ops) = self.git_ops_state {
-                ops.tree.move_up();
-            }
-            self.update_git_ops_diff();
+            self.git_ops_tree_move_up();
             return;
         }
 
@@ -1243,21 +1328,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.open_panel) {
-            let is_dir = self
-                .git_ops_state
-                .as_ref()
-                .and_then(|ops| ops.tree.visible_rows.get(ops.tree.selected_row))
-                .map(|row| matches!(row, TreeRow::Dir { .. }))
-                .unwrap_or(false);
-
-            if is_dir {
-                self.toggle_dir_expand();
-            } else {
-                if let Some(ref mut ops) = self.git_ops_state {
-                    ops.left_return_focus = LeftPaneFocus::Tree;
-                }
-                self.state = AppState::GitOpsSplitDiff;
-            }
+            self.open_selected_git_ops_tree_entry();
             return;
         }
 
@@ -1322,32 +1393,12 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if let Some(ref mut ops) = self.git_ops_state {
-                let cl = &mut ops.commit_log;
-                if !cl.commits.is_empty() {
-                    cl.selected = (cl.selected + 1).min(cl.commits.len() - 1);
-                }
-            }
-            self.start_fetch_git_ops_commit_diff();
-            let should_load_more = self
-                .git_ops_state
-                .as_ref()
-                .map(|ops| {
-                    let cl = &ops.commit_log;
-                    cl.selected + 5 >= cl.commits.len() && cl.has_more && !cl.loading
-                })
-                .unwrap_or(false);
-            if should_load_more {
-                self.load_more_git_ops_commits();
-            }
+            self.git_ops_commits_move_down();
             return;
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            if let Some(ref mut ops) = self.git_ops_state {
-                ops.commit_log.selected = ops.commit_log.selected.saturating_sub(1);
-            }
-            self.start_fetch_git_ops_commit_diff();
+            self.git_ops_commits_move_up();
             return;
         }
 
@@ -1417,10 +1468,7 @@ impl App {
         if self.matches_single_key(&key, &kb.open_panel)
             || self.matches_single_key(&key, &kb.move_right)
         {
-            if let Some(ref mut ops) = self.git_ops_state {
-                ops.left_return_focus = LeftPaneFocus::Commits;
-            }
-            self.state = AppState::GitOpsSplitDiff;
+            self.open_selected_git_ops_commit();
             return;
         }
 
@@ -1586,19 +1634,10 @@ impl App {
                 // j/k scroll for Previewing
                 let scroll_down = self.matches_single_key(key, &kb.move_down);
                 let scroll_up = self.matches_single_key(key, &kb.move_up);
-                if let Some(PendingGitOpsConfirm::Previewing {
-                    ref mut scroll_offset,
-                    ..
-                }) = self
-                    .git_ops_state
-                    .as_mut()
-                    .and_then(|o| o.pending_confirm.as_mut())
-                {
-                    if scroll_down {
-                        *scroll_offset = scroll_offset.saturating_add(1);
-                    } else if scroll_up {
-                        *scroll_offset = scroll_offset.saturating_sub(1);
-                    }
+                if scroll_down {
+                    self.git_ops_preview_wheel(true);
+                } else if scroll_up {
+                    self.git_ops_preview_wheel(false);
                 }
             }
             PendingGitOpsConfirm::Simulating { .. } => {
@@ -1616,6 +1655,23 @@ impl App {
         None
     }
 
+    pub(crate) fn git_ops_preview_wheel(&mut self, down: bool) {
+        if let Some(PendingGitOpsConfirm::Previewing {
+            ref mut scroll_offset,
+            ..
+        }) = self
+            .git_ops_state
+            .as_mut()
+            .and_then(|ops| ops.pending_confirm.as_mut())
+        {
+            if down {
+                *scroll_offset = scroll_offset.saturating_add(1);
+            } else {
+                *scroll_offset = scroll_offset.saturating_sub(1);
+            }
+        }
+    }
+
     /// Return the active diff_scroll based on left_return_focus
     fn active_git_ops_diff_scroll(&mut self) -> Option<&mut crate::diff_store::DiffScrollState> {
         self.git_ops_state
@@ -1624,6 +1680,33 @@ impl App {
                 LeftPaneFocus::Commits => &mut ops.commit_log.diff_scroll,
                 LeftPaneFocus::Tree => &mut ops.diff_scroll,
             })
+    }
+
+    pub(crate) fn git_ops_diff_wheel_move(&mut self, down: bool) {
+        if let Some(scroll) = self.active_git_ops_diff_scroll() {
+            if down {
+                scroll.move_down();
+            } else {
+                scroll.move_up();
+            }
+        }
+    }
+
+    pub(crate) fn git_ops_diff_click_line(&mut self, line: usize) -> bool {
+        let Some(scroll) = self.active_git_ops_diff_scroll() else {
+            return false;
+        };
+
+        if scroll.selected_line == line {
+            return true;
+        }
+
+        if line > scroll.selected_line {
+            scroll.page_down(line - scroll.selected_line);
+        } else {
+            scroll.page_up(scroll.selected_line - line);
+        }
+        false
     }
 
     /// Handle input for GitOpsSplitDiff state
@@ -1676,16 +1759,12 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if let Some(scroll) = self.active_git_ops_diff_scroll() {
-                scroll.move_down();
-            }
+            self.git_ops_diff_wheel_move(true);
             return;
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            if let Some(scroll) = self.active_git_ops_diff_scroll() {
-                scroll.move_up();
-            }
+            self.git_ops_diff_wheel_move(false);
             return;
         }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -9,19 +9,103 @@ use crate::filter::ListFilter;
 use crate::github::{self, ChangedFile};
 use crate::keybinding::{event_to_keybinding, SequenceMatch};
 
+use super::input_mouse::coalesce;
+
 use super::types::*;
 use super::{App, AppState, DataState};
 
 impl App {
+    /// toggle_mouse キー(既定 F2)を処理する。処理したら true。
+    /// mouse.enabled=false のときはキーを消費せず他の処理へ流す。
+    pub(crate) fn handle_toggle_mouse_key(&mut self, key: &crossterm::event::KeyEvent) -> bool {
+        if !self.matches_single_key(key, &self.config.keybindings.toggle_mouse) {
+            return false;
+        }
+        let Some(target) = self.mouse_capture_target() else {
+            return false;
+        };
+        let applied = if target {
+            crate::ui::enable_mouse_capture_runtime().is_ok()
+        } else {
+            crate::ui::cleanup_mouse_capture();
+            true
+        };
+        if applied {
+            self.set_mouse_capture_active(target);
+        }
+        true
+    }
+
     pub(crate) async fn handle_input(
         &mut self,
         terminal: &mut Terminal<CrosstermBackend<Stdout>>,
     ) -> Result<()> {
-        if event::poll(std::time::Duration::from_millis(100))? {
-            if let Event::Key(key) = event::read()? {
+        let deadline = Instant::now() + std::time::Duration::from_millis(100);
+        loop {
+            let event = if let Some(ev) = self.pending_events.pop_front() {
+                ev
+            } else {
+                let timeout = deadline.saturating_duration_since(Instant::now());
+                if !event::poll(timeout)? {
+                    return Ok(());
+                }
+                event::read()?
+            };
+
+            match event {
+                Event::Key(key) => return self.handle_key_event(key, terminal).await,
+                Event::Mouse(mouse) => {
+                    let mut batch = vec![Event::Mouse(mouse)];
+                    while let Some(ev) = self.pending_events.pop_front() {
+                        batch.push(ev);
+                    }
+                    while event::poll(std::time::Duration::ZERO)? {
+                        batch.push(event::read()?);
+                    }
+                    let (coalesced, leftover) = coalesce(batch);
+                    self.pending_events = leftover;
+                    if coalesced.is_empty() {
+                        if self.pending_events.is_empty() {
+                            // Moved だけのバッチではフレームを進めない(?1003h の移動洪水対策)
+                            continue;
+                        }
+                        return Ok(());
+                    }
+                    let mut fingerprint = self.mouse_context_fingerprint();
+                    for ev in coalesced {
+                        self.handle_mouse(ev, terminal).await?;
+                        let current = self.mouse_context_fingerprint();
+                        if current != fingerprint {
+                            // 画面/モーダルが変わったら残りは旧レイアウト前提のため破棄
+                            break;
+                        }
+                        fingerprint = current;
+                    }
+                    return Ok(());
+                }
+                // Resize 等は次イテレーションの無条件再描画が拾う
+                _ => return Ok(()),
+            }
+        }
+    }
+
+    pub(crate) async fn handle_key_event(
+        &mut self,
+        key: event::KeyEvent,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<()> {
+        {
+            {
                 // Only handle Press events to avoid double-execution when
                 // Kitty keyboard protocol reports Release/Repeat events.
                 if key.kind != KeyEventKind::Press {
+                    return Ok(());
+                }
+
+                // Mouse-capture toggle works in every state, including loading,
+                // error, and overlays — that is when the user wants terminal-native
+                // text selection back.
+                if self.handle_toggle_mouse_key(&key) {
                     return Ok(());
                 }
 
@@ -239,25 +323,12 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if has_filter {
-                self.handle_filter_navigation("file", true);
-            } else if tree_active {
-                self.file_tree_move_down();
-            } else if !self.files().is_empty() {
-                self.selected_file =
-                    (self.selected_file + 1).min(self.files().len().saturating_sub(1));
-            }
+            self.file_list_move_down();
             return Ok(());
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            if has_filter {
-                self.handle_filter_navigation("file", false);
-            } else if tree_active {
-                self.file_tree_move_up();
-            } else {
-                self.selected_file = self.selected_file.saturating_sub(1);
-            }
+            self.file_list_move_up();
             return Ok(());
         }
 
@@ -356,17 +427,7 @@ impl App {
         if self.matches_single_key(&key, &kb.open_panel)
             || self.matches_single_key(&key, &kb.move_right)
         {
-            if self.is_filter_selection_empty("file") {
-                return Ok(());
-            }
-            // Tree mode: toggle expand on dir rows, enter diff on file rows
-            if tree_active && self.file_tree_enter() {
-                return Ok(());
-            }
-            if !self.files().is_empty() {
-                self.enter_diff_from_file_list();
-                self.sync_diff_to_selected_file();
-            }
+            self.open_selected_file_entry();
             return Ok(());
         }
 
@@ -721,15 +782,12 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if check_count > 0 {
-                self.chk.selected_check =
-                    (self.chk.selected_check + 1).min(check_count.saturating_sub(1));
-            }
+            self.checks_move_down();
             return Ok(());
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            self.chk.selected_check = self.chk.selected_check.saturating_sub(1);
+            self.checks_move_up();
             return Ok(());
         }
 
@@ -758,13 +816,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.open_panel) {
-            if let Some(ref checks) = self.chk.checks {
-                if let Some(check) = checks.get(self.chk.selected_check) {
-                    if let Some(ref url) = check.link {
-                        Self::open_url_in_browser(url);
-                    }
-                }
-            }
+            self.open_selected_check();
             return Ok(());
         }
 
@@ -788,6 +840,36 @@ impl App {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn checks_move_down(&mut self) {
+        let check_count = self.chk.checks.as_ref().map(|c| c.len()).unwrap_or(0);
+        if check_count > 0 {
+            self.chk.selected_check =
+                (self.chk.selected_check + 1).min(check_count.saturating_sub(1));
+        }
+    }
+
+    pub(crate) fn checks_move_up(&mut self) {
+        self.chk.selected_check = self.chk.selected_check.saturating_sub(1);
+    }
+
+    pub(crate) fn open_selected_check(&mut self) {
+        if let Some(ref checks) = self.chk.checks {
+            if let Some(check) = checks.get(self.chk.selected_check) {
+                if let Some(ref url) = check.link {
+                    Self::open_url_in_browser(url);
+                }
+            }
+        }
+    }
+
+    pub(crate) fn checks_click_select(&mut self, index: usize) -> bool {
+        if self.chk.selected_check == index {
+            return true;
+        }
+        self.chk.selected_check = index;
+        false
     }
 
     pub(crate) fn open_url_in_browser(url: &str) {
@@ -856,6 +938,73 @@ impl App {
                 self.selected_file = idx;
             }
         }
+    }
+
+    pub(crate) fn file_list_move_down(&mut self) {
+        if self.file_list_filter.is_some() {
+            self.handle_filter_navigation("file", true);
+        } else if self.is_file_tree_active() {
+            self.file_tree_move_down();
+        } else if !self.files().is_empty() {
+            self.selected_file = (self.selected_file + 1).min(self.files().len().saturating_sub(1));
+        }
+    }
+
+    pub(crate) fn file_list_move_up(&mut self) {
+        if self.file_list_filter.is_some() {
+            self.handle_filter_navigation("file", false);
+        } else if self.is_file_tree_active() {
+            self.file_tree_move_up();
+        } else {
+            self.selected_file = self.selected_file.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn open_selected_file_entry(&mut self) {
+        if self.is_filter_selection_empty("file") {
+            return;
+        }
+        // Tree mode: toggle expand on dir rows, enter diff on file rows
+        if self.is_file_tree_active() && self.file_tree_enter() {
+            return;
+        }
+        if !self.files().is_empty() {
+            self.enter_diff_from_file_list();
+            self.sync_diff_to_selected_file();
+        }
+    }
+
+    pub(crate) fn file_list_click_select(&mut self, row: usize, index: usize) -> bool {
+        if let Some(filter) = self.file_list_filter.as_mut() {
+            if filter.selected == Some(row) {
+                return true;
+            }
+            filter.selected = Some(row);
+            self.selected_file = index;
+            return false;
+        }
+
+        if self.is_file_tree_active() {
+            let Some(tree) = self.file_tree_state.as_mut() else {
+                return false;
+            };
+            if tree.selected_row == row {
+                return true;
+            }
+            let selected_file =
+                matches!(tree.visible_rows.get(row), Some(TreeRow::File { .. })).then_some(index);
+            tree.selected_row = row;
+            if let Some(index) = selected_file {
+                self.selected_file = index;
+            }
+            return false;
+        }
+
+        if self.selected_file == index {
+            return true;
+        }
+        self.selected_file = index;
+        false
     }
 
     pub(crate) fn file_tree_move_down(&mut self) {

--- a/src/app/input_browse.rs
+++ b/src/app/input_browse.rs
@@ -18,7 +18,7 @@ use crate::keybinding::{event_to_keybinding, SequenceMatch};
 use super::browse::ModuleGraphState;
 use super::browse::{
     BrowseCommitDiffState, BrowseOverlay, IndexState, ModuleGraphDirection, ModuleGraphPaneState,
-    PrLookupState,
+    ModuleGraphPanel, PrLookupState,
 };
 use super::browse_discussion::{DiscussionView, LineDiscussionState};
 use super::{App, AppState, PrOpenSource};
@@ -49,17 +49,7 @@ impl App {
         if self.matches_single_key(&key, &kb.open_panel)
             || self.matches_single_key(&key, &kb.move_right)
         {
-            let is_dir = self
-                .browse_state
-                .as_ref()
-                .is_some_and(|state| state.tree.selected_dir_path().is_some());
-            if is_dir {
-                if let Some(state) = self.browse_state.as_mut() {
-                    state.tree.toggle_expand();
-                }
-            } else {
-                self.browse_open_selected();
-            }
+            self.open_selected_browse_entry();
             return Ok(());
         }
 
@@ -82,23 +72,58 @@ impl App {
         let page_up = self.matches_single_key(&key, &kb.page_up);
         let jump_last = self.matches_single_key(&key, &kb.jump_to_last);
 
-        let Some(state) = self.browse_state.as_mut() else {
-            return Ok(());
-        };
-
         if move_down {
-            state.tree.move_down();
+            self.browse_tree_move_down();
         } else if move_up {
-            state.tree.move_up();
-        } else if page_down {
-            state.tree.page_down(PAGE_STEP);
-        } else if page_up {
-            state.tree.page_up(PAGE_STEP);
-        } else if jump_last {
-            state.tree.jump_to_last();
+            self.browse_tree_move_up();
+        } else if let Some(state) = self.browse_state.as_mut() {
+            if page_down {
+                state.tree.page_down(PAGE_STEP);
+            } else if page_up {
+                state.tree.page_up(PAGE_STEP);
+            } else if jump_last {
+                state.tree.jump_to_last();
+            }
         }
 
         Ok(())
+    }
+
+    pub(crate) fn browse_tree_move_down(&mut self) {
+        if let Some(state) = self.browse_state.as_mut() {
+            state.tree.move_down();
+        }
+    }
+
+    pub(crate) fn browse_tree_move_up(&mut self) {
+        if let Some(state) = self.browse_state.as_mut() {
+            state.tree.move_up();
+        }
+    }
+
+    pub(crate) fn open_selected_browse_entry(&mut self) {
+        let is_dir = self
+            .browse_state
+            .as_ref()
+            .is_some_and(|state| state.tree.selected_dir_path().is_some());
+        if is_dir {
+            if let Some(state) = self.browse_state.as_mut() {
+                state.tree.toggle_expand();
+            }
+        } else {
+            self.browse_open_selected();
+        }
+    }
+
+    pub(crate) fn browse_tree_click_select(&mut self, row: usize) -> bool {
+        let Some(state) = self.browse_state.as_mut() else {
+            return false;
+        };
+        let already_selected = state.tree.selected_row == row;
+        if !already_selected {
+            state.tree.selected_row = row;
+        }
+        already_selected
     }
 
     pub(crate) fn handle_repo_browse_file_input(
@@ -176,28 +201,43 @@ impl App {
         let move_up = self.matches_single_key(&key, &kb.move_up);
         let jump_last = self.matches_single_key(&key, &kb.jump_to_last);
 
-        let Some(state) = self.browse_state.as_mut() else {
-            return Ok(());
-        };
-
         if move_down {
-            state.move_cursor(1);
+            self.browse_file_wheel_move(true);
         } else if move_up {
-            state.move_cursor(-1);
-        } else if page_down {
-            state.move_cursor(PAGE_STEP as isize);
-        } else if page_up {
-            state.move_cursor(-(PAGE_STEP as isize));
-        } else if jump_last {
-            let last = state
-                .open
-                .as_ref()
-                .map(|open| open.line_count().saturating_sub(1))
-                .unwrap_or(0);
-            state.focus_line(last);
+            self.browse_file_wheel_move(false);
+        } else if let Some(state) = self.browse_state.as_mut() {
+            if page_down {
+                state.move_cursor(PAGE_STEP as isize);
+            } else if page_up {
+                state.move_cursor(-(PAGE_STEP as isize));
+            } else if jump_last {
+                let last = state
+                    .open
+                    .as_ref()
+                    .map(|open| open.line_count().saturating_sub(1))
+                    .unwrap_or(0);
+                state.focus_line(last);
+            }
         }
 
         Ok(())
+    }
+
+    pub(crate) fn browse_file_wheel_move(&mut self, down: bool) {
+        if let Some(state) = self.browse_state.as_mut() {
+            state.move_cursor(if down { 1 } else { -1 });
+        }
+    }
+
+    pub(crate) fn browse_file_click_line(&mut self, line: usize) -> bool {
+        let Some(state) = self.browse_state.as_mut() else {
+            return false;
+        };
+        if state.cursor_line == line {
+            return true;
+        }
+        state.focus_line(line);
+        false
     }
 
     fn handle_pr_lookup_selection_input(&mut self, key: &event::KeyEvent) -> bool {
@@ -214,100 +254,208 @@ impl App {
         let down = self.matches_single_key(key, &kb.move_down);
         let up = self.matches_single_key(key, &kb.move_up);
         let confirm = self.matches_single_key(key, &kb.open_panel);
-        let mut selected_pull = None;
 
-        if let Some(state) = self.browse_state.as_mut() {
-            let PrLookupState::Selecting {
-                sha,
-                pulls,
-                selected,
-            } = &mut state.pr_lookup
-            else {
-                return false;
-            };
-            if close {
-                state.pr_lookup = PrLookupState::Idle;
-            } else if down {
-                *selected = (*selected + 1).min(pulls.len().saturating_sub(1));
-            } else if up {
-                *selected = selected.saturating_sub(1);
-            } else if confirm {
-                selected_pull = pulls.get(*selected).map(|pull| (pull.number, sha.clone()));
-            }
-        }
-
-        if let Some((number, sha)) = selected_pull {
-            self.open_pr_from_browse(number, PrOpenSource::ConfirmedCommit { sha });
+        if close {
+            self.browse_pr_choice_dismiss();
+        } else if down {
+            self.browse_pr_choice_move(true);
+        } else if up {
+            self.browse_pr_choice_move(false);
+        } else if confirm {
+            self.browse_pr_choice_open_selected();
         }
         true
     }
 
+    pub(crate) fn browse_pr_choice_move(&mut self, down: bool) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        let PrLookupState::Selecting {
+            pulls, selected, ..
+        } = &mut state.pr_lookup
+        else {
+            return;
+        };
+        if down {
+            *selected = (*selected + 1).min(pulls.len().saturating_sub(1));
+        } else {
+            *selected = selected.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn browse_pr_choice_click_select(&mut self, row: usize) -> bool {
+        let Some(state) = self.browse_state.as_mut() else {
+            return false;
+        };
+        let PrLookupState::Selecting { selected, .. } = &mut state.pr_lookup else {
+            return false;
+        };
+        let already_selected = *selected == row;
+        if !already_selected {
+            *selected = row;
+        }
+        already_selected
+    }
+
+    pub(crate) fn browse_pr_choice_open_selected(&mut self) {
+        let selected_pull = self.browse_state.as_ref().and_then(|state| {
+            let PrLookupState::Selecting {
+                sha,
+                pulls,
+                selected,
+            } = &state.pr_lookup
+            else {
+                return None;
+            };
+            pulls.get(*selected).map(|pull| (pull.number, sha.clone()))
+        });
+        if let Some((number, sha)) = selected_pull {
+            self.open_pr_from_browse(number, PrOpenSource::ConfirmedCommit { sha });
+        }
+    }
+
+    pub(crate) fn browse_pr_choice_dismiss(&mut self) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        if matches!(state.pr_lookup, PrLookupState::Selecting { .. }) {
+            state.pr_lookup = PrLookupState::Idle;
+        }
+    }
+
     fn handle_line_discussion_input(&mut self, key: &event::KeyEvent) -> bool {
+        let active = self.browse_state.as_ref().is_some_and(|state| {
+            matches!(
+                state.line_discussion,
+                LineDiscussionState::Ready {
+                    view: DiscussionView::ThreadList { .. } | DiscussionView::Expanded { .. },
+                    ..
+                }
+            )
+        });
+        if !active {
+            return false;
+        }
+
         let kb = self.config.keybindings.clone();
         let close = key.code == KeyCode::Esc || self.matches_single_key(key, &kb.quit);
         let down = self.matches_single_key(key, &kb.move_down);
         let up = self.matches_single_key(key, &kb.move_up);
         let confirm = self.matches_single_key(key, &kb.open_panel);
 
+        if close {
+            self.browse_line_discussion_dismiss();
+        } else if down {
+            self.browse_line_discussion_move(true);
+        } else if up {
+            self.browse_line_discussion_move(false);
+        } else if confirm {
+            self.browse_line_discussion_open_selected();
+        }
+        true
+    }
+
+    pub(crate) fn browse_line_discussion_move(&mut self, down: bool) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        let LineDiscussionState::Ready { index, view, .. } = &mut state.line_discussion else {
+            return;
+        };
+        let (selected, count) = match view {
+            DiscussionView::ThreadList { line, selected, .. } => {
+                (selected, index.thread_indices_at(*line).len())
+            }
+            DiscussionView::Expanded {
+                line,
+                thread_position,
+                selected,
+                ..
+            } => {
+                let count = index
+                    .thread_indices_at(*line)
+                    .get(*thread_position)
+                    .and_then(|thread| index.threads.get(*thread))
+                    .map(|thread| thread.replies.len() + 1)
+                    .unwrap_or(0);
+                (selected, count)
+            }
+            DiscussionView::Closed => return,
+        };
+        if down {
+            *selected = (*selected + 1).min(count.saturating_sub(1));
+        } else {
+            *selected = selected.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn browse_line_discussion_click_select(&mut self, row: usize) -> bool {
         let Some(state) = self.browse_state.as_mut() else {
             return false;
         };
-        match &mut state.line_discussion {
-            LineDiscussionState::Ready { index, view, .. } => match view {
-                DiscussionView::Closed => return false,
-                DiscussionView::ThreadList {
-                    line,
-                    selected,
-                    scroll: _,
-                } => {
-                    let count = index.thread_indices_at(*line).len();
-                    if close {
-                        *view = DiscussionView::Closed;
-                    } else if down {
-                        *selected = (*selected + 1).min(count.saturating_sub(1));
-                    } else if up {
-                        *selected = selected.saturating_sub(1);
-                    } else if confirm && count > 0 {
-                        *view = DiscussionView::Expanded {
-                            line: *line,
-                            thread_position: *selected,
-                            selected: 0,
-                            scroll: 0,
-                        };
-                    }
-                }
-                DiscussionView::Expanded {
-                    line,
-                    thread_position,
-                    selected,
-                    scroll: _,
-                } => {
-                    let count = index
-                        .thread_indices_at(*line)
-                        .get(*thread_position)
-                        .and_then(|thread| index.threads.get(*thread))
-                        .map(|thread| thread.replies.len() + 1)
-                        .unwrap_or(0);
-                    if close {
-                        *view = DiscussionView::ThreadList {
-                            line: *line,
-                            selected: *thread_position,
-                            scroll: 0,
-                        };
-                    } else if down {
-                        *selected = (*selected + 1).min(count.saturating_sub(1));
-                    } else if up {
-                        *selected = selected.saturating_sub(1);
-                    }
-                }
-            },
-            LineDiscussionState::Idle
-            | LineDiscussionState::ResolvingPullRequests { .. }
-            | LineDiscussionState::LoadingComments { .. }
-            | LineDiscussionState::Failed { .. } => return false,
+        let LineDiscussionState::Ready { view, .. } = &mut state.line_discussion else {
+            return false;
+        };
+        let selected = match view {
+            DiscussionView::ThreadList { selected, .. }
+            | DiscussionView::Expanded { selected, .. } => selected,
+            DiscussionView::Closed => return false,
+        };
+        let already_selected = *selected == row;
+        if !already_selected {
+            *selected = row;
         }
+        already_selected
+    }
 
-        true
+    pub(crate) fn browse_line_discussion_open_selected(&mut self) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        let LineDiscussionState::Ready { index, view, .. } = &mut state.line_discussion else {
+            return;
+        };
+        let DiscussionView::ThreadList {
+            line,
+            selected,
+            scroll: _,
+        } = view
+        else {
+            return;
+        };
+        if !index.thread_indices_at(*line).is_empty() {
+            *view = DiscussionView::Expanded {
+                line: *line,
+                thread_position: *selected,
+                selected: 0,
+                scroll: 0,
+            };
+        }
+    }
+
+    pub(crate) fn browse_line_discussion_dismiss(&mut self) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        let LineDiscussionState::Ready { view, .. } = &mut state.line_discussion else {
+            return;
+        };
+        match view {
+            DiscussionView::Closed => {}
+            DiscussionView::ThreadList { .. } => *view = DiscussionView::Closed,
+            DiscussionView::Expanded {
+                line,
+                thread_position,
+                ..
+            } => {
+                *view = DiscussionView::ThreadList {
+                    line: *line,
+                    selected: *thread_position,
+                    scroll: 0,
+                };
+            }
+        }
     }
 
     /// Resolve tree-pane sequences (`Space /` filter, `gg` jump to first).
@@ -602,7 +750,7 @@ impl App {
         crate::ui::restore_terminal(terminal)?;
         let result =
             crate::editor::open_file_at_line(editor.as_deref(), &path.to_string_lossy(), line);
-        *terminal = crate::ui::setup_terminal()?;
+        *terminal = crate::ui::setup_terminal(self.mouse_capture_active)?;
         terminal.clear()?;
 
         if let Err(e) = result {
@@ -683,42 +831,108 @@ impl App {
         let up = self.matches_single_key(&key, &kb.move_up);
         let confirm = self.matches_single_key(&key, &kb.open_panel);
 
+        if close {
+            self.browse_outline_dismiss();
+        } else if down {
+            self.browse_outline_move(true);
+        } else if up {
+            self.browse_outline_move(false);
+        } else if confirm {
+            self.browse_outline_open_selected();
+        }
+    }
+
+    pub(crate) fn browse_outline_move(&mut self, down: bool) {
         let Some(state) = self.browse_state.as_mut() else {
             return;
         };
         let count = state.outline_symbols().len();
-
-        if close {
-            state.overlay = BrowseOverlay::None;
-            return;
-        }
-
         let BrowseOverlay::Outline { selected } = state.overlay else {
             return;
         };
+        state.overlay = BrowseOverlay::Outline {
+            selected: if down {
+                (selected + 1).min(count.saturating_sub(1))
+            } else {
+                selected.saturating_sub(1)
+            },
+        };
+    }
 
-        if down {
-            state.overlay = BrowseOverlay::Outline {
-                selected: (selected + 1).min(count.saturating_sub(1)),
+    pub(crate) fn browse_outline_click_select(&mut self, row: usize) -> bool {
+        let Some(state) = self.browse_state.as_mut() else {
+            return false;
+        };
+        let BrowseOverlay::Outline { selected } = &mut state.overlay else {
+            return false;
+        };
+        let already_selected = *selected == row;
+        if !already_selected {
+            *selected = row;
+        }
+        already_selected
+    }
+
+    pub(crate) fn browse_outline_open_selected(&mut self) {
+        let target = self.browse_state.as_ref().and_then(|state| {
+            let BrowseOverlay::Outline { selected } = state.overlay else {
+                return None;
             };
-        } else if up {
-            state.overlay = BrowseOverlay::Outline {
-                selected: selected.saturating_sub(1),
-            };
-        } else if confirm {
-            let target = state.outline_symbols().get(selected).map(|s| s.line);
-            state.overlay = BrowseOverlay::None;
-            if let Some(line) = target {
-                self.browse_push_jump();
-                if let Some(state) = self.browse_state.as_mut() {
-                    state.focus_line(line.saturating_sub(1));
-                }
-                self.state = AppState::RepoBrowseFile;
+            state
+                .outline_symbols()
+                .get(selected)
+                .map(|symbol| symbol.line)
+        });
+        self.browse_outline_dismiss();
+        if let Some(line) = target {
+            self.browse_push_jump();
+            if let Some(state) = self.browse_state.as_mut() {
+                state.focus_line(line.saturating_sub(1));
             }
+            self.state = AppState::RepoBrowseFile;
+        }
+    }
+
+    pub(crate) fn browse_outline_dismiss(&mut self) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        if matches!(state.overlay, BrowseOverlay::Outline { .. }) {
+            state.overlay = BrowseOverlay::None;
         }
     }
 
     fn handle_browse_symbol_search_input(&mut self, key: event::KeyEvent) {
+        // Typing wins over navigation: only arrows and Ctrl-n/p move the
+        // selection, so `j` and `k` stay usable inside the query.
+        match key.code {
+            KeyCode::Esc => {
+                self.browse_symbol_search_dismiss();
+                return;
+            }
+            KeyCode::Enter => {
+                self.browse_symbol_search_open_selected();
+                return;
+            }
+            KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.browse_symbol_search_move(true);
+                return;
+            }
+            KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.browse_symbol_search_move(false);
+                return;
+            }
+            KeyCode::Down => {
+                self.browse_symbol_search_move(true);
+                return;
+            }
+            KeyCode::Up => {
+                self.browse_symbol_search_move(false);
+                return;
+            }
+            _ => {}
+        }
+
         let Some(state) = self.browse_state.as_mut() else {
             return;
         };
@@ -729,29 +943,7 @@ impl App {
         else {
             return;
         };
-
-        // Typing wins over navigation: only arrows and Ctrl-n/p move the
-        // selection, so `j` and `k` stay usable inside the query.
         match key.code {
-            KeyCode::Esc => {
-                state.overlay = BrowseOverlay::None;
-                return;
-            }
-            KeyCode::Enter => {
-                let query = query.clone();
-                let selected = *selected;
-                let target = state
-                    .symbol_search_results(&query)
-                    .into_iter()
-                    .nth(selected)
-                    .map(|(path, line, _)| (path, line));
-                state.overlay = BrowseOverlay::None;
-                if let Some((path, line)) = target {
-                    self.browse_push_jump();
-                    self.browse_open_path(&path, line.saturating_sub(1));
-                }
-                return;
-            }
             KeyCode::Backspace => {
                 query.pop();
                 *selected = 0;
@@ -760,14 +952,6 @@ impl App {
                 query.clear();
                 *selected = 0;
             }
-            KeyCode::Char('n') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                *selected += 1;
-            }
-            KeyCode::Char('p') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                *selected = selected.saturating_sub(1);
-            }
-            KeyCode::Down => *selected += 1,
-            KeyCode::Up => *selected = selected.saturating_sub(1),
             KeyCode::Char(c) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                 query.push(c);
                 *selected = 0;
@@ -776,6 +960,62 @@ impl App {
         }
 
         state.clamp_symbol_search_selection();
+    }
+
+    pub(crate) fn browse_symbol_search_move(&mut self, down: bool) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        let BrowseOverlay::SymbolSearch { selected, .. } = &mut state.overlay else {
+            return;
+        };
+        if down {
+            *selected += 1;
+        } else {
+            *selected = selected.saturating_sub(1);
+        }
+        state.clamp_symbol_search_selection();
+    }
+
+    pub(crate) fn browse_symbol_search_click_select(&mut self, row: usize) -> bool {
+        let Some(state) = self.browse_state.as_mut() else {
+            return false;
+        };
+        let BrowseOverlay::SymbolSearch { selected, .. } = &mut state.overlay else {
+            return false;
+        };
+        let already_selected = *selected == row;
+        if !already_selected {
+            *selected = row;
+        }
+        already_selected
+    }
+
+    pub(crate) fn browse_symbol_search_open_selected(&mut self) {
+        let target = self.browse_state.as_ref().and_then(|state| {
+            let BrowseOverlay::SymbolSearch { query, selected } = &state.overlay else {
+                return None;
+            };
+            state
+                .symbol_search_results(query)
+                .into_iter()
+                .nth(*selected)
+                .map(|(path, line, _)| (path, line))
+        });
+        self.browse_symbol_search_dismiss();
+        if let Some((path, line)) = target {
+            self.browse_push_jump();
+            self.browse_open_path(&path, line.saturating_sub(1));
+        }
+    }
+
+    pub(crate) fn browse_symbol_search_dismiss(&mut self) {
+        let Some(state) = self.browse_state.as_mut() else {
+            return;
+        };
+        if matches!(state.overlay, BrowseOverlay::SymbolSearch { .. }) {
+            state.overlay = BrowseOverlay::None;
+        }
     }
 
     pub(crate) fn handle_repo_browse_graph_input(&mut self, key: event::KeyEvent) {
@@ -816,44 +1056,92 @@ impl App {
         let show_dependents =
             key.code == KeyCode::Right || self.matches_single_key(&key, &kb.move_right);
         let toggle = key.code == KeyCode::Tab;
-        let mut jump = None;
 
-        let Some(state) = self.browse_state.as_mut() else {
-            return;
-        };
-        let ModuleGraphPaneState::Ready(panel) = &mut state.module_graph_pane else {
-            if matches!(state.module_graph_pane, ModuleGraphPaneState::Closed) {
-                self.state = AppState::RepoBrowseFile;
-            }
-            return;
-        };
-        if toggle {
-            panel.set_direction(match panel.direction {
-                ModuleGraphDirection::Dependencies => ModuleGraphDirection::Dependents,
-                ModuleGraphDirection::Dependents => ModuleGraphDirection::Dependencies,
-            });
-        } else if show_dependencies {
-            panel.set_direction(ModuleGraphDirection::Dependencies);
-        } else if show_dependents {
-            panel.set_direction(ModuleGraphDirection::Dependents);
-        } else if down {
-            panel.selected = (panel.selected + 1).min(panel.current_rows().len().saturating_sub(1));
-        } else if up {
-            panel.selected = panel.selected.saturating_sub(1);
-        } else if confirm {
-            if let Some(row) = panel.current_rows().get(panel.selected) {
-                jump = row.jump.clone();
-                if jump.is_none() {
-                    state.status =
-                        Some("This dependency target is not a listed repository file".into());
+        {
+            let Some(state) = self.browse_state.as_ref() else {
+                return;
+            };
+            if !matches!(state.module_graph_pane, ModuleGraphPaneState::Ready(_)) {
+                if matches!(state.module_graph_pane, ModuleGraphPaneState::Closed) {
+                    self.state = AppState::RepoBrowseFile;
                 }
+                return;
             }
         }
 
+        if toggle {
+            self.browse_graph_toggle_direction();
+        } else if show_dependencies {
+            let _ = self
+                .with_graph_panel(|panel| panel.set_direction(ModuleGraphDirection::Dependencies));
+        } else if show_dependents {
+            let _ = self
+                .with_graph_panel(|panel| panel.set_direction(ModuleGraphDirection::Dependents));
+        } else if down || up {
+            self.browse_graph_move(down);
+        } else if confirm {
+            self.browse_graph_open_selected();
+        }
+    }
+
+    fn with_graph_panel<T>(&mut self, f: impl FnOnce(&mut ModuleGraphPanel) -> T) -> Option<T> {
+        let state = self.browse_state.as_mut()?;
+        let ModuleGraphPaneState::Ready(panel) = &mut state.module_graph_pane else {
+            return None;
+        };
+        Some(f(panel))
+    }
+
+    pub(crate) fn browse_graph_move(&mut self, down: bool) {
+        let _ = self.with_graph_panel(|panel| {
+            if down {
+                panel.selected =
+                    (panel.selected + 1).min(panel.current_rows().len().saturating_sub(1));
+            } else {
+                panel.selected = panel.selected.saturating_sub(1);
+            }
+        });
+    }
+
+    pub(crate) fn browse_graph_click_select(&mut self, row: usize) -> bool {
+        self.with_graph_panel(|panel| {
+            if panel.selected == row {
+                return true;
+            }
+            panel.selected = row.min(panel.current_rows().len().saturating_sub(1));
+            false
+        })
+        .unwrap_or(false)
+    }
+
+    pub(crate) fn browse_graph_open_selected(&mut self) {
+        let mut jump = None;
+        let mut unlisted = false;
+        let _ = self.with_graph_panel(|panel| {
+            if let Some(row) = panel.current_rows().get(panel.selected) {
+                jump = row.jump.clone();
+                unlisted = jump.is_none();
+            }
+        });
+        if unlisted {
+            if let Some(state) = self.browse_state.as_mut() {
+                state.status =
+                    Some("This dependency target is not a listed repository file".into());
+            }
+        }
         if let Some(jump) = jump {
             self.browse_push_jump();
             self.browse_open_path(&jump.path, jump.line);
         }
+    }
+
+    pub(crate) fn browse_graph_toggle_direction(&mut self) {
+        let _ = self.with_graph_panel(|panel| {
+            panel.set_direction(match panel.direction {
+                ModuleGraphDirection::Dependencies => ModuleGraphDirection::Dependents,
+                ModuleGraphDirection::Dependents => ModuleGraphDirection::Dependencies,
+            });
+        });
     }
 
     fn handle_browse_graph_module_sequence(&mut self, key: &event::KeyEvent) -> bool {
@@ -3492,6 +3780,74 @@ mod tests {
         settle_module_graph(&mut app).await;
         assert_eq!(open_path(&app), "src/app.ts");
         assert_eq!(app.browse_state.as_ref().unwrap().cursor_line, 1);
+    }
+
+    #[tokio::test]
+    async fn test_browse_graph_mouse_helpers_follow_key_semantics() {
+        let dir = tempfile::tempdir().unwrap();
+        let app_source = "import { helper } from './helper';\nimport { util } from './util';\n";
+        let mut app = browsing_app_on_disk(
+            dir.path(),
+            &[
+                ("src/app.ts", app_source),
+                ("src/helper.ts", "export function helper() { return 1; }\n"),
+                ("src/util.ts", "export function util() { return 2; }\n"),
+            ],
+        );
+        attach_open_file(&mut app, "src/app.ts", app_source, Vec::new());
+        attach_code_index(
+            &mut app,
+            dir.path(),
+            &["src/app.ts", "src/helper.ts", "src/util.ts"],
+        );
+        app.state = AppState::RepoBrowseFile;
+
+        app.open_browse_module_graph();
+        settle_module_graph(&mut app).await;
+        app.state = AppState::RepoBrowseGraph;
+
+        // ホイール相当: 1 行下 → クランプ確認
+        app.browse_graph_move(true);
+        let selected = |app: &App| {
+            let ModuleGraphPaneState::Ready(panel) =
+                &app.browse_state.as_ref().unwrap().module_graph_pane
+            else {
+                panic!("panel not ready");
+            };
+            panel.selected
+        };
+        assert_eq!(selected(&app), 1);
+        app.browse_graph_move(true);
+        assert_eq!(selected(&app), 1, "末尾でクランプ(依存 2 件)");
+        app.browse_graph_move(false);
+        assert_eq!(selected(&app), 0);
+
+        // クリック: 未選択行は選択のみ、選択済み行は true
+        assert!(!app.browse_graph_click_select(1));
+        assert_eq!(selected(&app), 1);
+        assert!(app.browse_graph_click_select(1));
+
+        // タイトルクリックで方向トグル
+        let direction = |app: &App| {
+            let ModuleGraphPaneState::Ready(panel) =
+                &app.browse_state.as_ref().unwrap().module_graph_pane
+            else {
+                panic!("panel not ready");
+            };
+            panel.direction
+        };
+        let before = direction(&app);
+        app.browse_graph_toggle_direction();
+        assert_ne!(direction(&app), before);
+    }
+
+    #[test]
+    fn test_browse_graph_mouse_helpers_are_noop_without_panel() {
+        let mut app = App::new_cockpit("owner/repo", crate::config::Config::default(), true);
+        app.browse_graph_move(true);
+        assert!(!app.browse_graph_click_select(0));
+        app.browse_graph_toggle_direction();
+        app.browse_graph_open_selected();
     }
 
     #[test]

--- a/src/app/input_diff.rs
+++ b/src/app/input_diff.rs
@@ -280,6 +280,7 @@ impl App {
             // Header(3) + Footer(3) + border(2) = 8
             term_h.saturating_sub(8)
         };
+        self.diff_scroll.set_visible_lines(visible_lines);
         let panel_inner_width = self.comment_panel_inner_width(term_w);
 
         let kb = self.config.keybindings.clone();
@@ -328,17 +329,12 @@ impl App {
 
         if self.cmt.comment_panel_open {
             if self.matches_single_key(&key, &kb.move_down) {
-                let max_scroll = self.max_comment_panel_scroll(term_h, term_w);
-                self.cmt.comment_panel_scroll = self
-                    .cmt
-                    .comment_panel_scroll
-                    .saturating_add(1)
-                    .min(max_scroll);
+                self.comment_panel_wheel(true);
                 return Ok(());
             }
 
             if self.matches_single_key(&key, &kb.move_up) {
-                self.cmt.comment_panel_scroll = self.cmt.comment_panel_scroll.saturating_sub(1);
+                self.comment_panel_wheel(false);
                 return Ok(());
             }
 
@@ -538,17 +534,12 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if self.diff_scroll.line_count > 0 {
-                self.diff_scroll.selected_line = (self.diff_scroll.selected_line + 1)
-                    .min(self.diff_scroll.line_count.saturating_sub(1));
-                self.adjust_scroll(visible_lines);
-            }
+            self.diff_wheel_move(true);
             return Ok(());
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            self.diff_scroll.selected_line = self.diff_scroll.selected_line.saturating_sub(1);
-            self.adjust_scroll(visible_lines);
+            self.diff_wheel_move(false);
             return Ok(());
         }
 
@@ -624,6 +615,50 @@ impl App {
 
         Ok(())
     }
+
+    pub(crate) fn diff_wheel_move(&mut self, down: bool) {
+        if down {
+            if self.diff_scroll.line_count > 0 {
+                self.diff_scroll.move_down();
+            }
+        } else {
+            self.diff_scroll.move_up();
+        }
+    }
+
+    pub(crate) fn diff_click_line(&mut self, line: usize) -> bool {
+        if self.diff_scroll.selected_line == line {
+            return true;
+        }
+
+        self.diff_scroll.selected_line = line;
+        self.diff_scroll.page_up(0);
+        false
+    }
+
+    pub(crate) fn diff_open_at_cursor(&mut self) {
+        self.cmt.comment_panel_open = true;
+        self.cmt.comment_panel_scroll = 0;
+        self.cmt.selected_inline_comment = 0;
+    }
+
+    pub(crate) fn comment_panel_wheel(&mut self, down: bool) {
+        if down {
+            let max_scroll = crossterm::terminal::size()
+                .map(|(term_w, term_h)| {
+                    self.max_comment_panel_scroll(term_h as usize, term_w as usize)
+                })
+                .unwrap_or(u16::MAX);
+            self.cmt.comment_panel_scroll = self
+                .cmt
+                .comment_panel_scroll
+                .saturating_add(1)
+                .min(max_scroll);
+        } else {
+            self.cmt.comment_panel_scroll = self.cmt.comment_panel_scroll.saturating_sub(1);
+        }
+    }
+
     pub(crate) fn try_open_comment_panel(
         &mut self,
         key: &event::KeyEvent,
@@ -632,9 +667,7 @@ impl App {
         if !self.matches_single_key(key, &kb.open_panel) {
             return false;
         }
-        self.cmt.comment_panel_open = true;
-        self.cmt.comment_panel_scroll = 0;
-        self.cmt.selected_inline_comment = 0;
+        self.diff_open_at_cursor();
         true
     }
 

--- a/src/app/input_diff.rs
+++ b/src/app/input_diff.rs
@@ -328,6 +328,19 @@ impl App {
         }
 
         if self.cmt.comment_panel_open {
+            // 複数行選択の開始はパネルより優先する。パネルは開いたままだと
+            // 以降の全キーを吸うため(末尾の包括 return)、ここで閉じて
+            // 選択モードへ入る。マウスの再クリックでパネルが開きやすく
+            // なったことで、この取りこぼしが顕在化した。
+            if (key.code == KeyCode::Enter && key.modifiers.contains(KeyModifiers::SHIFT))
+                || self.matches_single_key(&key, &kb.multiline_select)
+            {
+                self.cmt.comment_panel_open = false;
+                self.cmt.comment_panel_scroll = 0;
+                self.enter_multiline_selection();
+                return Ok(());
+            }
+
             if self.matches_single_key(&key, &kb.move_down) {
                 self.comment_panel_wheel(true);
                 return Ok(());

--- a/src/app/input_mouse.rs
+++ b/src/app/input_mouse.rs
@@ -1,0 +1,1325 @@
+//! マウスイベントの畳み込みと分派
+//!
+//! イベント読み取りは `input.rs` の単一サイトで行われ、ドレインしたバッチを
+//! ここの純関数 `coalesce` が意味単位へ畳み込む。分派 (`handle_mouse`) は
+//! キー処理と同じく `AppState` の網羅 match で行う。
+
+use anyhow::Result;
+use crossterm::event::{Event, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::{backend::CrosstermBackend, Terminal};
+use std::collections::VecDeque;
+use std::io::Stdout;
+use std::mem::Discriminant;
+
+use super::{App, AppState, DataState, LeftPaneFocus};
+use crate::ui::hit::{HitTarget, ListKind, PaneKind};
+
+/// ドレインしたイベント列を意味単位へ畳み込んだマウスイベント
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CoalescedMouseEvent {
+    Down {
+        x: u16,
+        y: u16,
+    },
+    Up {
+        x: u16,
+        y: u16,
+    },
+    Drag {
+        x: u16,
+        y: u16,
+    },
+    /// delta は正で下方向、負で上方向。同方向の連続ノッチのみ合算する。
+    Scroll {
+        x: u16,
+        y: u16,
+        delta: i32,
+    },
+}
+
+/// マウスバッチ処理中の画面/モーダル変化を検出するための指紋。
+/// 変化したら残りのバッチは旧レイアウト前提のため破棄する。
+pub(crate) type MouseContextFingerprint = (Discriminant<AppState>, [bool; 8]);
+
+/// マウスドラッグの状態機械(ブール併用ではなく enum で管理)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) enum DragState {
+    #[default]
+    Idle,
+    /// スプリット境界をドラッグ中。body_x/body_width は分割対象領域の水平範囲。
+    ResizingSplit { body_x: u16, body_width: u16 },
+    /// 差分行を Down した直後の中間状態。まだ通常クリック。
+    /// 最初の Drag で SelectingDiffLines へ昇格する(Drag なしの Up は普通のクリック)。
+    PressedDiffLine { anchor: usize },
+    /// 複数行選択をドラッグで拡張中(V 相当)
+    SelectingDiffLines,
+}
+
+/// イベント列を畳み込む。
+///
+/// - 同方向の連続スクロールは合算(飽和)、方向転換で分割
+/// - 連続する Drag は最後の座標のみ残す
+/// - Moved・横スクロール・右/中ボタン・修飾キー付きは破棄
+/// - 最初の Key 以降は畳み込まず、そのまま返す(呼び出し側が保留キューへ積む)
+pub(crate) fn coalesce(events: Vec<Event>) -> (Vec<CoalescedMouseEvent>, VecDeque<Event>) {
+    let mut out: Vec<CoalescedMouseEvent> = Vec::new();
+    let mut leftover: VecDeque<Event> = VecDeque::new();
+    let mut iter = events.into_iter();
+    while let Some(event) = iter.next() {
+        match event {
+            Event::Key(_) => {
+                leftover.push_back(event);
+                leftover.extend(iter);
+                break;
+            }
+            Event::Mouse(mouse) => coalesce_mouse(&mut out, mouse),
+            // Resize/Paste はここでは扱わない(再描画は毎イテレーション行われる)
+            _ => {}
+        }
+    }
+    (out, leftover)
+}
+
+fn coalesce_mouse(out: &mut Vec<CoalescedMouseEvent>, mouse: MouseEvent) {
+    if !mouse.modifiers.is_empty() {
+        return;
+    }
+    let (x, y) = (mouse.column, mouse.row);
+    match mouse.kind {
+        MouseEventKind::Down(MouseButton::Left) => out.push(CoalescedMouseEvent::Down { x, y }),
+        MouseEventKind::Up(MouseButton::Left) => out.push(CoalescedMouseEvent::Up { x, y }),
+        MouseEventKind::Drag(MouseButton::Left) => {
+            if let Some(CoalescedMouseEvent::Drag { x: px, y: py }) = out.last_mut() {
+                *px = x;
+                *py = y;
+            } else {
+                out.push(CoalescedMouseEvent::Drag { x, y });
+            }
+        }
+        MouseEventKind::ScrollDown => push_scroll(out, x, y, 1),
+        MouseEventKind::ScrollUp => push_scroll(out, x, y, -1),
+        // 横スクロールは対象外
+        MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {}
+        // ホバー機能はないため Moved は捨てる(?1003h の移動洪水はここで消える)
+        MouseEventKind::Moved => {}
+        // 右/中ボタンは対象外
+        MouseEventKind::Down(_) | MouseEventKind::Up(_) | MouseEventKind::Drag(_) => {}
+    }
+}
+
+fn push_scroll(out: &mut Vec<CoalescedMouseEvent>, x: u16, y: u16, dir: i32) {
+    if let Some(CoalescedMouseEvent::Scroll {
+        x: px,
+        y: py,
+        delta,
+    }) = out.last_mut()
+    {
+        if delta.signum() == dir.signum() {
+            *delta = delta.saturating_add(dir);
+            *px = x;
+            *py = y;
+            return;
+        }
+    }
+    out.push(CoalescedMouseEvent::Scroll { x, y, delta: dir });
+}
+
+impl App {
+    pub(crate) fn mouse_context_fingerprint(&self) -> MouseContextFingerprint {
+        (
+            std::mem::discriminant(&self.state),
+            [
+                self.shell_state.is_some(),
+                self.multiline_selection.is_some(),
+                self.symbol_popup.is_some(),
+                self.input_mode.is_some(),
+                self.git_ops_state
+                    .as_ref()
+                    .is_some_and(|g| g.pending_confirm.is_some()),
+                self.cmt.pending_approve_body.is_some(),
+                self.file_list_filter
+                    .as_ref()
+                    .is_some_and(|f| f.input_active),
+                matches!(self.data_state, DataState::Loading | DataState::Error(_)),
+            ],
+        )
+    }
+
+    /// キー処理と同じ割り込み順のガード。true のときマウス入力を受けない。
+    /// オーバーレイの z-order は HitMap の Backdrop 登録が表現するため、
+    /// ここで塞ぐのは「何も描画しない確認状態」だけ。
+    fn mouse_input_blocked(&self) -> bool {
+        (!self.state.is_data_state_independent()
+            && matches!(self.data_state, DataState::Loading | DataState::Error(_)))
+            // 承認確認はフッタープロンプトのみでモーダル描画がない
+            || self.cmt.pending_approve_body.is_some()
+            // Simple 確認(gitfilm なし)はモーダルを描画しない
+            || self.git_ops_state.as_ref().is_some_and(|g| {
+                matches!(
+                    g.pending_confirm,
+                    Some(super::PendingGitOpsConfirm::Simple { .. })
+                )
+            })
+    }
+
+    /// 外側クリックによるオーバーレイ却下(Esc 相当を 1 段だけ)。
+    /// 各 dismiss は自分のオーバーレイが非活性なら何もしない。
+    fn overlay_dismiss(&mut self) {
+        if self
+            .shell_state
+            .as_ref()
+            .is_some_and(|s| matches!(s.phase, super::ShellPhase::Done(_)))
+        {
+            self.shell_state = None;
+            return;
+        }
+        if self.symbol_popup.is_some() {
+            self.symbol_popup = None;
+            return;
+        }
+        self.browse_symbol_search_dismiss();
+        self.browse_outline_dismiss();
+        self.browse_pr_choice_dismiss();
+        self.browse_line_discussion_dismiss();
+    }
+
+    pub(crate) async fn handle_mouse(
+        &mut self,
+        ev: CoalescedMouseEvent,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<()> {
+        if self.mouse_input_blocked() {
+            return Ok(());
+        }
+
+        match ev {
+            CoalescedMouseEvent::Down { x, y } => {
+                let Some(target) = self.hit_map.hit(x, y) else {
+                    return Ok(());
+                };
+                self.mouse_down(target, terminal).await
+            }
+            CoalescedMouseEvent::Scroll { x, y, delta } => {
+                let Some(target) = self.hit_map.hit(x, y) else {
+                    return Ok(());
+                };
+                self.mouse_scroll(target, delta);
+                Ok(())
+            }
+            CoalescedMouseEvent::Drag { x, y } => {
+                self.mouse_drag(x, y);
+                Ok(())
+            }
+            CoalescedMouseEvent::Up { .. } => {
+                self.drag_state = DragState::Idle;
+                Ok(())
+            }
+        }
+    }
+
+    fn mouse_drag(&mut self, x: u16, y: u16) {
+        match self.drag_state {
+            DragState::ResizingSplit { body_x, body_width } => {
+                if body_width == 0 {
+                    return;
+                }
+                let rel = u32::from(x.saturating_sub(body_x));
+                let percent = (rel * 100 / u32::from(body_width)) as u16;
+                // セッション内のみの変更(ファイルへは書き戻さない)
+                self.config.layout.left_panel_width = percent.clamp(10, 90);
+            }
+            DragState::PressedDiffLine { anchor } => {
+                // 最初の Drag で複数行選択へ昇格(V 相当)
+                if let Some(line) = self.diff_line_at(x, y) {
+                    self.multiline_selection = Some(super::MultilineSelection {
+                        anchor_line: anchor,
+                        cursor_line: line,
+                    });
+                    self.mouse_extend_diff_selection(line);
+                    self.drag_state = DragState::SelectingDiffLines;
+                }
+            }
+            DragState::SelectingDiffLines => {
+                if let Some(line) = self.diff_line_at(x, y) {
+                    self.mouse_extend_diff_selection(line);
+                }
+            }
+            DragState::Idle => {}
+        }
+    }
+
+    fn diff_line_at(&self, x: u16, y: u16) -> Option<usize> {
+        match self.hit_map.hit(x, y) {
+            Some(HitTarget::ContentLine {
+                pane: PaneKind::Diff,
+                line,
+            }) => Some(line),
+            _ => None,
+        }
+    }
+
+    /// 選択拡張: カーソル行と選択終端を同時に動かす(キー移動と同じ)
+    fn mouse_extend_diff_selection(&mut self, line: usize) {
+        let line = line.min(self.diff_scroll.line_count.saturating_sub(1));
+        self.diff_scroll.selected_line = line;
+        self.diff_scroll.page_up(0);
+        if let Some(sel) = self.multiline_selection.as_mut() {
+            sel.cursor_line = line;
+        }
+    }
+
+    /// クリックしたペインへフォーカスを移す(h/l/Tab と同じ状態遷移を通す)
+    fn mouse_focus_pane(&mut self, pane: PaneKind) {
+        match (self.state, pane) {
+            // Split view: ファイル一覧 ⇄ 差分プレビュー
+            (AppState::SplitViewFileList, PaneKind::Diff) if !self.files().is_empty() => {
+                self.state = AppState::SplitViewDiff;
+            }
+            (AppState::SplitViewDiff, PaneKind::List(ListKind::FileList)) => {
+                self.state = AppState::SplitViewFileList;
+            }
+            // Git Ops: 左リスト ⇄ 右差分、左内の Tree/Commits フォーカス
+            (AppState::GitOpsSplitTree, PaneKind::GitOpsDiff) => {
+                if let Some(ops) = self.git_ops_state.as_mut() {
+                    ops.left_return_focus = ops.left_focus;
+                }
+                self.state = AppState::GitOpsSplitDiff;
+            }
+            (
+                AppState::GitOpsSplitTree | AppState::GitOpsSplitDiff,
+                PaneKind::List(ListKind::GitOpsTree),
+            ) => {
+                if let Some(ops) = self.git_ops_state.as_mut() {
+                    ops.left_focus = LeftPaneFocus::Tree;
+                }
+                self.state = AppState::GitOpsSplitTree;
+            }
+            (
+                AppState::GitOpsSplitTree | AppState::GitOpsSplitDiff,
+                PaneKind::List(ListKind::GitOpsCommits),
+            ) => {
+                if let Some(ops) = self.git_ops_state.as_mut() {
+                    ops.left_focus = LeftPaneFocus::Commits;
+                }
+                self.state = AppState::GitOpsSplitTree;
+            }
+            // Repository Browser: ツリー ⇄ ファイル内容
+            (AppState::RepoBrowseTree, PaneKind::BrowseFile)
+                if self
+                    .browse_state
+                    .as_ref()
+                    .is_some_and(|state| state.open.is_some()) =>
+            {
+                self.state = AppState::RepoBrowseFile;
+            }
+            (
+                AppState::RepoBrowseFile | AppState::RepoBrowseGraph,
+                PaneKind::List(ListKind::BrowseTree),
+            ) => {
+                self.state = AppState::RepoBrowseTree;
+            }
+            // グラフペインのクリックでグラフへフォーカス(Right 相当)
+            (
+                AppState::RepoBrowseTree | AppState::RepoBrowseFile,
+                PaneKind::ModuleGraph | PaneKind::List(ListKind::BrowseGraph),
+            ) => {
+                self.state = AppState::RepoBrowseGraph;
+            }
+            // ファイルペインのクリックでグラフからコードへ戻る(Esc 相当)
+            (AppState::RepoBrowseGraph, PaneKind::BrowseFile) => {
+                self.state = AppState::RepoBrowseFile;
+            }
+            // Issue detail: 本文 ⇄ リンク PR
+            (AppState::IssueDetail, PaneKind::IssueBody) => {
+                self.issue_detail_set_focus(super::IssueDetailFocus::Body);
+            }
+            (AppState::IssueDetail, PaneKind::List(ListKind::IssueLinkedPrs)) => {
+                self.issue_detail_set_focus(super::IssueDetailFocus::LinkedPrs);
+            }
+            _ => {}
+        }
+    }
+
+    /// Split view 中のファイル選択変更後に差分プレビューを同期する
+    /// (キー経路と同じ Dir 行ガード付き)
+    fn split_view_sync_after_file_selection(&mut self) {
+        if !matches!(
+            self.state,
+            AppState::SplitViewFileList | AppState::SplitViewDiff
+        ) {
+            return;
+        }
+        let tree_active = self.is_file_tree_active();
+        if !tree_active
+            || self
+                .file_tree_state
+                .as_ref()
+                .is_none_or(|t| t.selected_file_index().is_some())
+        {
+            self.sync_diff_to_selected_file();
+        }
+    }
+
+    /// フォーカス比較用のスナップショット(画面 + サブフォーカス)
+    fn focus_snapshot(&self) -> (Discriminant<AppState>, Option<LeftPaneFocus>, bool) {
+        (
+            std::mem::discriminant(&self.state),
+            self.git_ops_state.as_ref().map(|g| g.left_focus),
+            self.issue_state
+                .as_ref()
+                .is_some_and(|s| s.detail_focus == super::IssueDetailFocus::LinkedPrs),
+        )
+    }
+
+    async fn mouse_down(
+        &mut self,
+        target: HitTarget,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<()> {
+        // シンボルポップアップは開くのに async + terminal が要るため先に処理
+        if let HitTarget::ListRow {
+            list: ListKind::SymbolPopup,
+            row,
+            ..
+        } = target
+        {
+            return self.symbol_popup_click(row, terminal).await;
+        }
+
+        // 複数行選択モード中は差分関連ターゲット以外のクリックを受けない
+        // (キー処理が move/comment/suggestion/quit 以外を飲み込むのと同じ)
+        if self.multiline_selection.is_some()
+            && !matches!(
+                target,
+                HitTarget::ContentLine {
+                    pane: PaneKind::Diff,
+                    ..
+                } | HitTarget::Pane {
+                    pane: PaneKind::Diff
+                } | HitTarget::Backdrop { .. }
+                    | HitTarget::OverlaySurface
+            )
+        {
+            return Ok(());
+        }
+
+        // ペインに属するターゲットならまずフォーカスを移す(h/l/Tab 相当)。
+        // フォーカスが移った場合、そのクリックは選択までに留める
+        // (非フォーカスペインの選択済み行クリックで即アクティベートしない)。
+        let before = self.focus_snapshot();
+        match target {
+            HitTarget::ListRow { list, .. } => {
+                self.mouse_focus_pane(PaneKind::List(list));
+            }
+            HitTarget::Pane { pane } | HitTarget::ContentLine { pane, .. } => {
+                self.mouse_focus_pane(pane);
+            }
+            _ => {}
+        }
+        let focus_changed = self.focus_snapshot() != before;
+
+        match target {
+            HitTarget::ListRow { list, row, index } => {
+                let opened = self.mouse_list_row_down(list, row, index, !focus_changed);
+                if matches!(list, ListKind::FileList) && !opened {
+                    self.split_view_sync_after_file_selection();
+                }
+            }
+            // 行クリック=カーソル移動、選択済み行の再クリック=Enter 相当。
+            // 複数行選択中のクリックは選択拡張、通常クリックはドラッグ昇格待ち。
+            HitTarget::ContentLine {
+                pane: PaneKind::Diff,
+                line,
+            } => {
+                if self.multiline_selection.is_some() {
+                    self.mouse_extend_diff_selection(line);
+                    self.drag_state = DragState::SelectingDiffLines;
+                } else if self.diff_click_line(line) && !focus_changed {
+                    self.diff_open_at_cursor();
+                } else {
+                    self.drag_state = DragState::PressedDiffLine { anchor: line };
+                }
+            }
+            // カーソル移動のみ(これらのビューに Enter アクションはない)
+            HitTarget::ContentLine {
+                pane: PaneKind::GitOpsDiff,
+                line,
+            } => {
+                let _ = self.git_ops_diff_click_line(line);
+            }
+            HitTarget::ContentLine {
+                pane: PaneKind::BrowseFile,
+                line,
+            } => {
+                let _ = self.browse_file_click_line(line);
+            }
+            HitTarget::ContentLine { .. } => {}
+            // フォーカス切替は上で処理済み
+            HitTarget::Pane { .. } => {}
+            HitTarget::SplitDivider {
+                body_x, body_width, ..
+            } => {
+                self.drag_state = DragState::ResizingSplit { body_x, body_width };
+            }
+            HitTarget::Backdrop { dismiss } => {
+                if dismiss {
+                    self.overlay_dismiss();
+                }
+            }
+            // Surface はクリックを消費するだけ(内部の操作要素は上に登録済み)
+            HitTarget::OverlaySurface => {}
+            HitTarget::Tab {
+                group: crate::ui::hit::TabGroup::GraphDirection,
+                ..
+            } => {
+                self.browse_graph_toggle_direction();
+            }
+            HitTarget::Tab {
+                group: crate::ui::hit::TabGroup::HelpTabs,
+                index,
+            } => {
+                self.help_tab = if index == 0 {
+                    super::HelpTab::Keybindings
+                } else {
+                    super::HelpTab::Config
+                };
+            }
+            HitTarget::Tab {
+                group: crate::ui::hit::TabGroup::CommentTabs,
+                index,
+            } => {
+                self.cmt.comment_tab = if index == 0 {
+                    super::CommentTab::Review
+                } else {
+                    super::CommentTab::Discussion
+                };
+            }
+            // DialogButton は未対応(確認系はキーボード応答のみ)
+            HitTarget::Tab { .. } | HitTarget::DialogButton { .. } => {}
+        }
+        Ok(())
+    }
+
+    /// シンボルポップアップのクリック(選択済み行の再クリックでジャンプ)
+    async fn symbol_popup_click(
+        &mut self,
+        row: usize,
+        terminal: &mut Terminal<CrosstermBackend<Stdout>>,
+    ) -> Result<()> {
+        let Some(popup) = self.symbol_popup.as_mut() else {
+            return Ok(());
+        };
+        if popup.selected != row {
+            popup.selected = row.min(popup.symbols.len().saturating_sub(1));
+            return Ok(());
+        }
+        let symbol_name = popup.symbols[popup.selected].0.clone();
+        self.symbol_popup = None;
+        self.jump_to_symbol_definition_async(&symbol_name, terminal)
+            .await
+    }
+
+    fn symbol_popup_move(&mut self, down: bool) {
+        let Some(popup) = self.symbol_popup.as_mut() else {
+            return;
+        };
+        if down {
+            popup.selected = (popup.selected + 1).min(popup.symbols.len().saturating_sub(1));
+        } else {
+            popup.selected = popup.selected.saturating_sub(1);
+        }
+    }
+
+    /// クリック: 未選択行なら選択のみ、選択済み行なら開く(Enter 相当)。
+    /// 戻り値は「開いたかどうか」。allow_open=false のときは選択のみ。
+    fn mouse_list_row_down(
+        &mut self,
+        list: ListKind,
+        row: usize,
+        index: usize,
+        allow_open: bool,
+    ) -> bool {
+        let already_selected = match list {
+            ListKind::PrList => self.pr_list_click_select(row, index),
+            ListKind::FileList => self.file_list_click_select(row, index),
+            ListKind::ChecksList => self.checks_click_select(index),
+            ListKind::IssueList => self.issue_list_click_select(row, index),
+            ListKind::CockpitMenu => self.cockpit_click_select(row),
+            ListKind::AiRallyLog => self.rally_log_click_select(row),
+            ListKind::CommentList => self.comment_list_click_select(row),
+            ListKind::IssueCommentList => self.issue_comment_click_select(index),
+            ListKind::BrowseTree => self.browse_tree_click_select(row),
+            ListKind::GitOpsTree => self.git_ops_tree_click_select(row),
+            ListKind::GitOpsCommits => self.git_ops_commits_click_select(row),
+            ListKind::IssueLinkedPrs => self.linked_pr_click_select(row),
+            ListKind::BrowseOutline => self.browse_outline_click_select(row),
+            ListKind::BrowseSymbolSearch => self.browse_symbol_search_click_select(row),
+            ListKind::BrowsePrChoice => self.browse_pr_choice_click_select(row),
+            ListKind::BrowseLineDiscussion => self.browse_line_discussion_click_select(row),
+            ListKind::BrowseGraph => self.browse_graph_click_select(row),
+            // SymbolPopup は mouse_down で async 処理済み
+            ListKind::SymbolPopup => return false,
+        };
+        if !already_selected || !allow_open {
+            return false;
+        }
+        match list {
+            ListKind::PrList => self.open_selected_pr(),
+            ListKind::FileList => self.open_selected_file_entry(),
+            ListKind::ChecksList => self.open_selected_check(),
+            ListKind::IssueList => self.open_selected_issue(),
+            ListKind::CockpitMenu => self.activate_cockpit_selection(),
+            ListKind::AiRallyLog => self.open_selected_rally_log(),
+            ListKind::CommentList => self.comment_list_open_selected(),
+            ListKind::IssueCommentList => self.open_selected_issue_comment(),
+            ListKind::BrowseTree => self.open_selected_browse_entry(),
+            ListKind::GitOpsTree => self.open_selected_git_ops_tree_entry(),
+            ListKind::GitOpsCommits => self.open_selected_git_ops_commit(),
+            ListKind::IssueLinkedPrs => self.open_selected_linked_pr(),
+            ListKind::BrowseOutline => self.browse_outline_open_selected(),
+            ListKind::BrowseSymbolSearch => self.browse_symbol_search_open_selected(),
+            ListKind::BrowsePrChoice => self.browse_pr_choice_open_selected(),
+            ListKind::BrowseLineDiscussion => self.browse_line_discussion_open_selected(),
+            ListKind::BrowseGraph => self.browse_graph_open_selected(),
+            ListKind::SymbolPopup => {}
+        }
+        true
+    }
+
+    /// ホイール: カーソル下のペインのカーソル/選択を wheel_step × ノッチ数だけ動かす。
+    /// 既存の move 経路を呼ぶため lazy fetch や diff プリフェッチも同一に発火する。
+    fn mouse_scroll(&mut self, target: HitTarget, delta: i32) {
+        let pane = match target {
+            HitTarget::ListRow { list, .. } => PaneKind::List(list),
+            HitTarget::Pane { pane } => pane,
+            HitTarget::ContentLine { pane, .. } => pane,
+            _ => return,
+        };
+        let steps = i64::from(self.config.mouse.wheel_step)
+            .saturating_mul(i64::from(delta.unsigned_abs()))
+            .min(1000);
+        let down = delta > 0;
+        for _ in 0..steps {
+            match pane {
+                PaneKind::List(list) => {
+                    if down {
+                        self.mouse_list_move_down(list);
+                    } else {
+                        self.mouse_list_move_up(list);
+                    }
+                }
+                PaneKind::Diff => {
+                    self.diff_wheel_move(down);
+                    // 複数行選択中はキー移動と同じく選択終端も追従させる
+                    let cursor = self.diff_scroll.selected_line;
+                    if let Some(sel) = self.multiline_selection.as_mut() {
+                        sel.cursor_line = cursor;
+                    }
+                }
+                PaneKind::BrowseFile => self.browse_file_wheel_move(down),
+                PaneKind::GitOpsDiff => self.git_ops_diff_wheel_move(down),
+                PaneKind::PrDescription => self.pr_description_wheel(down),
+                PaneKind::Help => self.help_wheel(down),
+                PaneKind::IssueBody => self.issue_body_wheel(down),
+                // TextArea のビューポートはカーソル駆動(adjust_scroll が毎レンダ
+                // 再計算)のため独立スクロールは成立しない — v1 は no-op
+                PaneKind::TextArea => {}
+                PaneKind::ShellOutput => self.shell_scroll_by(if down { 1 } else { -1 }),
+                PaneKind::CommentPanel => self.comment_panel_wheel(down),
+                PaneKind::GitOpsPreview => self.git_ops_preview_wheel(down),
+                PaneKind::ModuleGraph => self.browse_graph_move(down),
+            }
+        }
+        if pane == PaneKind::List(ListKind::FileList) {
+            self.split_view_sync_after_file_selection();
+        }
+    }
+
+    fn mouse_list_move_down(&mut self, list: ListKind) {
+        match list {
+            ListKind::PrList => self.pr_list_move_down(),
+            ListKind::FileList => self.file_list_move_down(),
+            ListKind::ChecksList => self.checks_move_down(),
+            ListKind::IssueList => self.issue_list_move_down(),
+            ListKind::CockpitMenu => self.cockpit_move_down(),
+            ListKind::AiRallyLog => self.rally_log_move_down(),
+            ListKind::CommentList => self.comment_list_move_down(),
+            ListKind::IssueCommentList => self.issue_comments_move_down(),
+            ListKind::BrowseTree => self.browse_tree_move_down(),
+            ListKind::GitOpsTree => self.git_ops_tree_move_down(),
+            ListKind::GitOpsCommits => self.git_ops_commits_move_down(),
+            ListKind::IssueLinkedPrs => self.linked_prs_move_down(),
+            ListKind::SymbolPopup => self.symbol_popup_move(true),
+            ListKind::BrowseOutline => self.browse_outline_move(true),
+            ListKind::BrowseSymbolSearch => self.browse_symbol_search_move(true),
+            ListKind::BrowsePrChoice => self.browse_pr_choice_move(true),
+            ListKind::BrowseLineDiscussion => self.browse_line_discussion_move(true),
+            ListKind::BrowseGraph => self.browse_graph_move(true),
+        }
+    }
+
+    fn mouse_list_move_up(&mut self, list: ListKind) {
+        match list {
+            ListKind::PrList => self.pr_list_move_up(),
+            ListKind::FileList => self.file_list_move_up(),
+            ListKind::ChecksList => self.checks_move_up(),
+            ListKind::IssueList => self.issue_list_move_up(),
+            ListKind::CockpitMenu => self.cockpit_move_up(),
+            ListKind::AiRallyLog => self.rally_log_move_up(),
+            ListKind::CommentList => self.comment_list_move_up(),
+            ListKind::IssueCommentList => self.issue_comments_move_up(),
+            ListKind::BrowseTree => self.browse_tree_move_up(),
+            ListKind::GitOpsTree => self.git_ops_tree_move_up(),
+            ListKind::GitOpsCommits => self.git_ops_commits_move_up(),
+            ListKind::IssueLinkedPrs => self.linked_prs_move_up(),
+            ListKind::SymbolPopup => self.symbol_popup_move(false),
+            ListKind::BrowseOutline => self.browse_outline_move(false),
+            ListKind::BrowseSymbolSearch => self.browse_symbol_search_move(false),
+            ListKind::BrowsePrChoice => self.browse_pr_choice_move(false),
+            ListKind::BrowseLineDiscussion => self.browse_line_discussion_move(false),
+            ListKind::BrowseGraph => self.browse_graph_move(false),
+        }
+    }
+
+    fn comment_list_move_down(&mut self) {
+        match self.cmt.comment_tab {
+            super::CommentTab::Discussion => self.discussion_move_down(),
+            super::CommentTab::Review => self.review_nav_down(1),
+        }
+    }
+
+    fn comment_list_move_up(&mut self) {
+        match self.cmt.comment_tab {
+            super::CommentTab::Discussion => self.discussion_move_up(),
+            super::CommentTab::Review => self.review_nav_up(1),
+        }
+    }
+
+    fn comment_list_open_selected(&mut self) {
+        match self.cmt.comment_tab {
+            super::CommentTab::Discussion => self.open_selected_discussion_comment(),
+            super::CommentTab::Review => self.review_tab_open_panel(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::RepositoryAvailability;
+    use crate::config::Config;
+    use crate::github::{Branch, ChangedFile, PullRequest, User};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn loaded_file_list_app(file_count: usize) -> App {
+        let (mut app, _tx) = App::new_loading(
+            "owner/repo",
+            1,
+            Config::default(),
+            RepositoryAvailability::Available,
+        );
+        let files: Vec<ChangedFile> = (0..file_count)
+            .map(|i| ChangedFile {
+                filename: format!("file_{i}.rs"),
+                status: "modified".to_string(),
+                additions: 1,
+                deletions: 1,
+                patch: Some("@@ -1,1 +1,1 @@\n-old\n+new".to_string()),
+                viewed: false,
+            })
+            .collect();
+        let pr = Box::new(PullRequest {
+            number: 1,
+            node_id: None,
+            title: "Test PR".to_string(),
+            body: None,
+            state: "open".to_string(),
+            head: Branch {
+                ref_name: "feature".to_string(),
+                sha: "abc123".to_string(),
+            },
+            base: Branch {
+                ref_name: "main".to_string(),
+                sha: "def456".to_string(),
+            },
+            user: User {
+                login: "user".to_string(),
+            },
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+        });
+        app.data_state = DataState::Loaded { pr, files };
+        app.state = AppState::FileList;
+        app
+    }
+
+    #[test]
+    fn test_mouse_input_blocked_while_loading_on_data_dependent_screen() {
+        let (app, _tx) = App::new_loading(
+            "owner/repo",
+            1,
+            Config::default(),
+            RepositoryAvailability::Available,
+        );
+        assert!(matches!(app.data_state, DataState::Loading));
+        assert!(app.mouse_input_blocked());
+    }
+
+    #[test]
+    fn test_mouse_input_not_blocked_on_data_independent_screen() {
+        let app = App::new_cockpit("owner/repo", Config::default(), false);
+        assert!(!app.mouse_input_blocked());
+    }
+
+    #[test]
+    fn test_mouse_input_blocked_by_pending_approve_dialog() {
+        let mut app = loaded_file_list_app(3);
+        assert!(!app.mouse_input_blocked());
+        app.cmt.pending_approve_body = Some(String::new());
+        assert!(app.mouse_input_blocked());
+    }
+
+    #[test]
+    fn test_cockpit_click_select_semantics() {
+        let mut app = App::new_cockpit("owner/repo", Config::default(), false);
+        assert!(!app.cockpit_click_select(1), "未選択行のクリックは選択のみ");
+        assert!(
+            app.cockpit_click_select(1),
+            "選択済み行の再クリックは true(開く)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mouse_click_selects_then_opens_cockpit_entry() {
+        let mut app = App::new_cockpit("owner/repo", Config::default(), true);
+        assert_eq!(app.state, AppState::Cockpit);
+
+        // row 2 = LocalDiff(初期選択は row 0 なので 1 回目は選択のみ)
+        app.mouse_list_row_down(ListKind::CockpitMenu, 2, 2, true);
+        assert_eq!(app.state, AppState::Cockpit, "1回目のクリックは選択のみ");
+
+        app.mouse_list_row_down(ListKind::CockpitMenu, 2, 2, true);
+        assert_eq!(
+            app.state,
+            AppState::FileList,
+            "選択済み行の再クリックで開く(LocalDiff は FileList へ)"
+        );
+    }
+
+    #[test]
+    fn test_cockpit_activation_blocked_without_repo_even_via_mouse() {
+        let mut app = App::new_cockpit("owner/repo", Config::default(), false);
+        app.mouse_list_row_down(ListKind::CockpitMenu, 0, 0, true);
+        app.mouse_list_row_down(ListKind::CockpitMenu, 0, 0, true);
+        assert_eq!(
+            app.state,
+            AppState::Cockpit,
+            "repo なしでは requires_repo 項目は開かない(キーと同一挙動)"
+        );
+    }
+
+    #[test]
+    fn test_wheel_moves_file_selection_by_wheel_step() {
+        let mut app = loaded_file_list_app(10);
+        assert_eq!(app.selected_file, 0);
+
+        let pane = HitTarget::Pane {
+            pane: PaneKind::List(ListKind::FileList),
+        };
+        app.mouse_scroll(pane, 1);
+        assert_eq!(app.selected_file, 3, "wheel_step 既定 3 で 3 行進む");
+
+        app.mouse_scroll(pane, -1);
+        assert_eq!(app.selected_file, 0);
+    }
+
+    #[test]
+    fn test_wheel_on_list_row_target_scrolls_the_same_list() {
+        let mut app = loaded_file_list_app(10);
+        let row = HitTarget::ListRow {
+            list: ListKind::FileList,
+            row: 2,
+            index: 2,
+        };
+        app.mouse_scroll(row, 2);
+        assert_eq!(app.selected_file, 6, "2 ノッチ × wheel_step 3");
+    }
+
+    #[test]
+    fn test_wheel_clamps_at_list_end() {
+        let mut app = loaded_file_list_app(4);
+        let pane = HitTarget::Pane {
+            pane: PaneKind::List(ListKind::FileList),
+        };
+        app.mouse_scroll(pane, 5);
+        assert_eq!(app.selected_file, 3, "末尾でクランプ");
+        app.mouse_scroll(pane, -5);
+        assert_eq!(app.selected_file, 0, "先頭でクランプ");
+    }
+
+    #[test]
+    fn test_file_list_click_select_then_reclick_reports_already_selected() {
+        let mut app = loaded_file_list_app(5);
+        assert!(!app.file_list_click_select(2, 2));
+        assert_eq!(app.selected_file, 2);
+        assert!(app.file_list_click_select(2, 2));
+    }
+
+    #[test]
+    fn test_diff_wheel_moves_cursor_by_wheel_step() {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::DiffView;
+        app.diff_scroll.line_count = 100;
+        app.diff_scroll.selected_line = 10;
+
+        let pane = HitTarget::Pane {
+            pane: PaneKind::Diff,
+        };
+        app.mouse_scroll(pane, 1);
+        assert_eq!(
+            app.diff_scroll.selected_line, 13,
+            "wheel_step 3 で 3 行下へ"
+        );
+
+        app.mouse_scroll(pane, -2);
+        assert_eq!(app.diff_scroll.selected_line, 7, "2 ノッチ上で 6 行上へ");
+    }
+
+    #[test]
+    fn test_diff_click_line_selects_then_reports_already_selected() {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::DiffView;
+        app.diff_scroll.line_count = 100;
+        app.diff_scroll.selected_line = 0;
+
+        assert!(!app.diff_click_line(42), "未選択行のクリックはカーソル移動");
+        assert_eq!(app.diff_scroll.selected_line, 42);
+        assert!(app.diff_click_line(42), "同一行の再クリックは true(開く)");
+    }
+
+    #[test]
+    fn test_pr_description_wheel_scrolls_offset() {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::PrDescription;
+        assert_eq!(app.pr_description_scroll_offset, 0);
+
+        let pane = HitTarget::Pane {
+            pane: PaneKind::PrDescription,
+        };
+        app.mouse_scroll(pane, 1);
+        assert_eq!(app.pr_description_scroll_offset, 3);
+
+        app.mouse_scroll(pane, -1);
+        assert_eq!(app.pr_description_scroll_offset, 0);
+        app.mouse_scroll(pane, -1);
+        assert_eq!(app.pr_description_scroll_offset, 0, "先頭で飽和");
+    }
+
+    #[test]
+    fn test_content_line_scroll_targets_owning_pane() {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::DiffView;
+        app.diff_scroll.line_count = 100;
+        app.diff_scroll.selected_line = 10;
+
+        let line = HitTarget::ContentLine {
+            pane: PaneKind::Diff,
+            line: 12,
+        };
+        app.mouse_scroll(line, 1);
+        assert_eq!(
+            app.diff_scroll.selected_line, 13,
+            "ContentLine 上のホイールも同じペインをスクロール"
+        );
+    }
+
+    #[test]
+    fn test_click_diff_pane_focuses_split_view_diff() {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::SplitViewFileList;
+
+        app.mouse_focus_pane(PaneKind::Diff);
+        assert_eq!(app.state, AppState::SplitViewDiff);
+
+        app.mouse_focus_pane(PaneKind::List(ListKind::FileList));
+        assert_eq!(app.state, AppState::SplitViewFileList);
+    }
+
+    #[test]
+    fn test_click_diff_pane_without_files_keeps_file_list_focus() {
+        let mut app = loaded_file_list_app(0);
+        app.state = AppState::SplitViewFileList;
+        app.mouse_focus_pane(PaneKind::Diff);
+        assert_eq!(app.state, AppState::SplitViewFileList);
+    }
+
+    #[test]
+    fn test_divider_drag_resizes_split_session_only() {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::SplitViewFileList;
+        assert_eq!(app.config.layout.left_panel_width, 35);
+
+        app.drag_state = DragState::ResizingSplit {
+            body_x: 0,
+            body_width: 100,
+        };
+        app.mouse_drag(60, 5);
+        assert_eq!(app.config.layout.left_panel_width, 60);
+
+        app.mouse_drag(5, 5);
+        assert_eq!(app.config.layout.left_panel_width, 10, "下限 10 でクランプ");
+
+        app.mouse_drag(99, 5);
+        assert_eq!(app.config.layout.left_panel_width, 90, "上限 90 でクランプ");
+    }
+
+    #[test]
+    fn test_drag_without_active_drag_state_is_noop() {
+        let mut app = loaded_file_list_app(3);
+        let before = app.config.layout.left_panel_width;
+        app.mouse_drag(70, 5);
+        assert_eq!(app.config.layout.left_panel_width, before);
+    }
+
+    #[test]
+    fn test_backdrop_dismiss_closes_symbol_popup() {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::DiffView;
+        app.symbol_popup = Some(super::super::SymbolPopupState {
+            symbols: vec![("foo".to_string(), 0, 0), ("bar".to_string(), 0, 0)],
+            selected: 0,
+        });
+
+        app.overlay_dismiss();
+        assert!(
+            app.symbol_popup.is_none(),
+            "外側クリックでポップアップが閉じる"
+        );
+    }
+
+    #[test]
+    fn test_symbol_popup_move_and_wheel_dispatch() {
+        let mut app = loaded_file_list_app(3);
+        app.symbol_popup = Some(super::super::SymbolPopupState {
+            symbols: vec![
+                ("a".to_string(), 0, 0),
+                ("b".to_string(), 0, 0),
+                ("c".to_string(), 0, 0),
+            ],
+            selected: 0,
+        });
+
+        let row = HitTarget::ListRow {
+            list: ListKind::SymbolPopup,
+            row: 0,
+            index: 0,
+        };
+        app.mouse_scroll(row, 1);
+        assert_eq!(
+            app.symbol_popup.as_ref().unwrap().selected,
+            2,
+            "wheel_step 3 は末尾クランプで 2"
+        );
+    }
+
+    #[test]
+    fn test_mouse_blocked_during_simple_git_confirm() {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::GitOpsSplitTree;
+        assert!(!app.mouse_input_blocked());
+        // Simple 確認はモーダルを描画しないため dispatch 側で塞ぐ
+        let mut ops = super::super::GitOpsState::new(Vec::new());
+        ops.pending_confirm = Some(super::super::PendingGitOpsConfirm::Simple {
+            op: super::super::DestructiveOp::Discard {
+                path: "a.rs".to_string(),
+            },
+        });
+        app.git_ops_state = Some(ops);
+        assert!(app.mouse_input_blocked());
+    }
+
+    #[test]
+    fn test_focus_changing_click_does_not_activate_row() {
+        let mut app = loaded_file_list_app(5);
+        app.state = AppState::SplitViewDiff;
+        app.selected_file = 2;
+
+        // 非フォーカスのファイル一覧ペインで選択済み行をクリック:
+        // フォーカスが移るだけで開かない
+        let opened = {
+            let before = app.focus_snapshot();
+            app.mouse_focus_pane(PaneKind::List(ListKind::FileList));
+            let focus_changed = app.focus_snapshot() != before;
+            app.mouse_list_row_down(ListKind::FileList, 2, 2, !focus_changed)
+        };
+        assert!(!opened);
+        assert_eq!(app.state, AppState::SplitViewFileList, "フォーカスだけ移る");
+    }
+
+    fn diff_app_with_hit_rows(lines: usize) -> App {
+        let mut app = loaded_file_list_app(3);
+        app.state = AppState::DiffView;
+        app.diff_scroll.line_count = lines;
+        for line in 0..lines {
+            app.hit_map.push(
+                ratatui::layout::Rect {
+                    x: 0,
+                    y: line as u16,
+                    width: 40,
+                    height: 1,
+                },
+                HitTarget::ContentLine {
+                    pane: PaneKind::Diff,
+                    line,
+                },
+            );
+        }
+        app
+    }
+
+    #[test]
+    fn test_pressed_diff_line_promotes_to_selection_on_first_drag() {
+        let mut app = diff_app_with_hit_rows(20);
+        app.drag_state = DragState::PressedDiffLine { anchor: 5 };
+
+        app.mouse_drag(10, 8);
+        assert_eq!(app.drag_state, DragState::SelectingDiffLines);
+        let sel = app.multiline_selection.as_ref().unwrap();
+        assert_eq!(sel.anchor_line, 5);
+        assert_eq!(sel.cursor_line, 8);
+        assert_eq!(app.diff_scroll.selected_line, 8);
+
+        app.mouse_drag(10, 12);
+        assert_eq!(app.multiline_selection.as_ref().unwrap().cursor_line, 12);
+    }
+
+    #[test]
+    fn test_up_without_drag_keeps_plain_click_semantics() {
+        let mut app = diff_app_with_hit_rows(20);
+        app.drag_state = DragState::PressedDiffLine { anchor: 5 };
+
+        // Drag なしで Up: 選択モードに入らない
+        app.drag_state = DragState::Idle;
+        assert!(app.multiline_selection.is_none());
+    }
+
+    #[test]
+    fn test_selection_survives_mouse_up() {
+        let mut app = diff_app_with_hit_rows(20);
+        app.drag_state = DragState::PressedDiffLine { anchor: 3 };
+        app.mouse_drag(0, 7);
+        assert!(app.multiline_selection.is_some());
+
+        // Up 相当(handle_mouse の Up アームは drag_state のみ Idle へ戻す)
+        app.drag_state = DragState::Idle;
+        let sel = app.multiline_selection.as_ref().unwrap();
+        assert_eq!(
+            (sel.anchor_line, sel.cursor_line),
+            (3, 7),
+            "選択は確定後も維持"
+        );
+    }
+
+    #[test]
+    fn test_drag_outside_diff_rows_keeps_selection_unchanged() {
+        let mut app = diff_app_with_hit_rows(10);
+        app.drag_state = DragState::PressedDiffLine { anchor: 2 };
+        app.mouse_drag(100, 50);
+        assert!(
+            app.multiline_selection.is_none(),
+            "差分行の外では昇格しない"
+        );
+        assert_eq!(app.drag_state, DragState::PressedDiffLine { anchor: 2 });
+    }
+
+    #[test]
+    fn test_cockpit_render_populates_hit_map() {
+        use ratatui::{backend::TestBackend, Terminal};
+        let mut app = App::new_cockpit("owner/repo", Config::default(), false);
+        let mut terminal = Terminal::new(TestBackend::new(60, 20)).unwrap();
+        terminal
+            .draw(|frame| crate::ui::render(frame, &mut app))
+            .unwrap();
+
+        assert!(!app.hit_map.is_empty(), "描画後に HitMap が登録されている");
+        let hits: Vec<Option<HitTarget>> = (0..20).map(|y| app.hit_map.hit(30, y)).collect();
+        assert!(
+            hits.iter().any(|h| matches!(
+                h,
+                Some(HitTarget::ListRow {
+                    list: ListKind::CockpitMenu,
+                    ..
+                })
+            )),
+            "メニュー行の ListRow が登録されている: {hits:?}"
+        );
+    }
+
+    fn mouse(kind: MouseEventKind, x: u16, y: u16) -> Event {
+        Event::Mouse(MouseEvent {
+            kind,
+            column: x,
+            row: y,
+            modifiers: KeyModifiers::NONE,
+        })
+    }
+
+    fn key(c: char) -> Event {
+        Event::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn test_coalesce_merges_same_direction_scroll() {
+        let (out, leftover) = coalesce(vec![
+            mouse(MouseEventKind::ScrollDown, 5, 5),
+            mouse(MouseEventKind::ScrollDown, 5, 6),
+            mouse(MouseEventKind::ScrollDown, 5, 7),
+        ]);
+        assert_eq!(
+            out,
+            vec![CoalescedMouseEvent::Scroll {
+                x: 5,
+                y: 7,
+                delta: 3
+            }]
+        );
+        assert!(leftover.is_empty());
+    }
+
+    #[test]
+    fn test_coalesce_splits_on_direction_change() {
+        let (out, _) = coalesce(vec![
+            mouse(MouseEventKind::ScrollDown, 1, 1),
+            mouse(MouseEventKind::ScrollDown, 1, 1),
+            mouse(MouseEventKind::ScrollUp, 1, 1),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                CoalescedMouseEvent::Scroll {
+                    x: 1,
+                    y: 1,
+                    delta: 2
+                },
+                CoalescedMouseEvent::Scroll {
+                    x: 1,
+                    y: 1,
+                    delta: -1
+                },
+            ],
+            "上下スクロールを相殺してはならない(逐次処理と等価にする)"
+        );
+    }
+
+    #[test]
+    fn test_coalesce_drag_keeps_last_position() {
+        let (out, _) = coalesce(vec![
+            mouse(MouseEventKind::Drag(MouseButton::Left), 1, 1),
+            mouse(MouseEventKind::Drag(MouseButton::Left), 2, 2),
+            mouse(MouseEventKind::Drag(MouseButton::Left), 3, 3),
+        ]);
+        assert_eq!(out, vec![CoalescedMouseEvent::Drag { x: 3, y: 3 }]);
+    }
+
+    #[test]
+    fn test_coalesce_drag_runs_split_by_other_events() {
+        let (out, _) = coalesce(vec![
+            mouse(MouseEventKind::Drag(MouseButton::Left), 1, 1),
+            mouse(MouseEventKind::Down(MouseButton::Left), 2, 2),
+            mouse(MouseEventKind::Drag(MouseButton::Left), 3, 3),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                CoalescedMouseEvent::Drag { x: 1, y: 1 },
+                CoalescedMouseEvent::Down { x: 2, y: 2 },
+                CoalescedMouseEvent::Drag { x: 3, y: 3 },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_coalesce_drops_moved_events() {
+        let (out, leftover) = coalesce(vec![
+            mouse(MouseEventKind::Moved, 1, 1),
+            mouse(MouseEventKind::Moved, 2, 2),
+        ]);
+        assert!(out.is_empty());
+        assert!(leftover.is_empty());
+    }
+
+    #[test]
+    fn test_coalesce_preserves_down_up_pairs() {
+        let (out, _) = coalesce(vec![
+            mouse(MouseEventKind::Down(MouseButton::Left), 1, 1),
+            mouse(MouseEventKind::Down(MouseButton::Left), 1, 1),
+            mouse(MouseEventKind::Up(MouseButton::Left), 1, 1),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                CoalescedMouseEvent::Down { x: 1, y: 1 },
+                CoalescedMouseEvent::Down { x: 1, y: 1 },
+                CoalescedMouseEvent::Up { x: 1, y: 1 },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_coalesce_stops_at_key_and_requeues_rest() {
+        let (out, leftover) = coalesce(vec![
+            mouse(MouseEventKind::ScrollDown, 1, 1),
+            key('j'),
+            mouse(MouseEventKind::ScrollUp, 1, 1),
+        ]);
+        assert_eq!(
+            out,
+            vec![CoalescedMouseEvent::Scroll {
+                x: 1,
+                y: 1,
+                delta: 1
+            }]
+        );
+        assert_eq!(leftover.len(), 2, "Key とその後続は手つかずで返す");
+        assert!(matches!(leftover[0], Event::Key(_)));
+        assert!(matches!(leftover[1], Event::Mouse(_)));
+    }
+
+    #[test]
+    fn test_coalesce_drops_non_left_buttons_and_horizontal_scroll() {
+        let (out, _) = coalesce(vec![
+            mouse(MouseEventKind::Down(MouseButton::Right), 1, 1),
+            mouse(MouseEventKind::Down(MouseButton::Middle), 1, 1),
+            mouse(MouseEventKind::ScrollLeft, 1, 1),
+            mouse(MouseEventKind::ScrollRight, 1, 1),
+        ]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_coalesce_drops_modified_clicks() {
+        let (out, _) = coalesce(vec![Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 1,
+            row: 1,
+            modifiers: KeyModifiers::CONTROL,
+        })]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn test_coalesce_scroll_run_continues_across_dropped_events() {
+        let (out, _) = coalesce(vec![
+            mouse(MouseEventKind::ScrollDown, 1, 1),
+            mouse(MouseEventKind::Moved, 9, 9),
+            mouse(MouseEventKind::ScrollDown, 2, 2),
+        ]);
+        assert_eq!(
+            out,
+            vec![CoalescedMouseEvent::Scroll {
+                x: 2,
+                y: 2,
+                delta: 2
+            }]
+        );
+    }
+}

--- a/src/app/input_mouse.rs
+++ b/src/app/input_mouse.rs
@@ -49,8 +49,11 @@ pub(crate) enum DragState {
     /// スプリット境界をドラッグ中。body_x/body_width は分割対象領域の水平範囲。
     ResizingSplit { body_x: u16, body_width: u16 },
     /// 差分行を Down した直後の中間状態。まだ通常クリック。
-    /// 最初の Drag で SelectingDiffLines へ昇格する(Drag なしの Up は普通のクリック)。
-    PressedDiffLine { anchor: usize },
+    /// 最初の Drag で SelectingDiffLines へ昇格する。Drag なしの Up は普通の
+    /// クリックとして確定し、open_on_up が真(選択済み行を再クリック)なら
+    /// そこで初めてコメントパネルを開く(Down で開くとカーソル行からの
+    /// ドラッグ選択が武装できない)。
+    PressedDiffLine { anchor: usize, open_on_up: bool },
     /// 複数行選択をドラッグで拡張中(V 相当)
     SelectingDiffLines,
 }
@@ -211,6 +214,12 @@ impl App {
                 Ok(())
             }
             CoalescedMouseEvent::Up { .. } => {
+                if let DragState::PressedDiffLine {
+                    open_on_up: true, ..
+                } = self.drag_state
+                {
+                    self.diff_open_at_cursor();
+                }
                 self.drag_state = DragState::Idle;
                 Ok(())
             }
@@ -228,7 +237,7 @@ impl App {
                 // セッション内のみの変更(ファイルへは書き戻さない)
                 self.config.layout.left_panel_width = percent.clamp(10, 90);
             }
-            DragState::PressedDiffLine { anchor } => {
+            DragState::PressedDiffLine { anchor, .. } => {
                 // 最初の Drag で複数行選択へ昇格(V 相当)
                 if let Some(line) = self.diff_line_at(x, y) {
                     self.multiline_selection = Some(super::MultilineSelection {
@@ -434,10 +443,18 @@ impl App {
                 if self.multiline_selection.is_some() {
                     self.mouse_extend_diff_selection(line);
                     self.drag_state = DragState::SelectingDiffLines;
-                } else if self.diff_click_line(line) && !focus_changed {
-                    self.diff_open_at_cursor();
                 } else {
-                    self.drag_state = DragState::PressedDiffLine { anchor: line };
+                    let already_selected = self.diff_click_line(line);
+                    if !already_selected && self.cmt.comment_panel_open {
+                        // パネル表示中に別行へ移ったらパネル位置をリセット
+                        // (next_comment のキー経路と同じ扱い)
+                        self.cmt.comment_panel_scroll = 0;
+                        self.cmt.selected_inline_comment = 0;
+                    }
+                    self.drag_state = DragState::PressedDiffLine {
+                        anchor: line,
+                        open_on_up: already_selected && !focus_changed,
+                    };
                 }
             }
             // カーソル移動のみ(これらのビューに Enter アクションはない)
@@ -1076,10 +1093,99 @@ mod tests {
         app
     }
 
+    fn diff_line_target(line: usize) -> HitTarget {
+        HitTarget::ContentLine {
+            pane: PaneKind::Diff,
+            line,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reclick_on_selected_diff_line_opens_panel_on_up_not_down() {
+        let mut app = diff_app_with_hit_rows(20);
+        app.diff_scroll.selected_line = 5;
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::CrosstermBackend::new(std::io::stdout()))
+                .unwrap();
+
+        // 選択済み行への Down: この時点ではパネルを開かない
+        app.mouse_down(diff_line_target(5), &mut terminal)
+            .await
+            .unwrap();
+        assert!(
+            !app.cmt.comment_panel_open,
+            "Down の時点で開くとドラッグ選択が始められない"
+        );
+        assert_eq!(
+            app.drag_state,
+            DragState::PressedDiffLine {
+                anchor: 5,
+                open_on_up: true
+            }
+        );
+
+        // Drag なしの Up で初めて開く(再クリック=Enter 相当)
+        app.handle_mouse(CoalescedMouseEvent::Up { x: 0, y: 5 }, &mut terminal)
+            .await
+            .unwrap();
+        assert!(app.cmt.comment_panel_open, "Up でパネルが開く");
+        assert_eq!(app.drag_state, DragState::Idle);
+    }
+
+    #[tokio::test]
+    async fn test_drag_from_selected_line_selects_range_instead_of_opening_panel() {
+        let mut app = diff_app_with_hit_rows(20);
+        app.diff_scroll.selected_line = 5;
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::CrosstermBackend::new(std::io::stdout()))
+                .unwrap();
+
+        // カーソル行から Down → Drag: パネルではなく複数行選択になる
+        app.mouse_down(diff_line_target(5), &mut terminal)
+            .await
+            .unwrap();
+        app.mouse_drag(0, 9);
+        assert!(!app.cmt.comment_panel_open, "ドラッグしたら開かない");
+        let sel = app.multiline_selection.as_ref().unwrap();
+        assert_eq!((sel.anchor_line, sel.cursor_line), (5, 9));
+
+        // Up で確定してもパネルは開かず選択が残る
+        app.handle_mouse(CoalescedMouseEvent::Up { x: 0, y: 9 }, &mut terminal)
+            .await
+            .unwrap();
+        assert!(!app.cmt.comment_panel_open);
+        assert!(app.multiline_selection.is_some(), "選択は確定後も維持");
+    }
+
+    #[tokio::test]
+    async fn test_click_other_line_while_panel_open_resets_panel_position() {
+        let mut app = diff_app_with_hit_rows(20);
+        app.diff_scroll.selected_line = 5;
+        app.cmt.comment_panel_open = true;
+        app.cmt.comment_panel_scroll = 7;
+        app.cmt.selected_inline_comment = 1;
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::CrosstermBackend::new(std::io::stdout()))
+                .unwrap();
+
+        app.mouse_down(diff_line_target(9), &mut terminal)
+            .await
+            .unwrap();
+        assert_eq!(app.diff_scroll.selected_line, 9);
+        assert_eq!(
+            app.cmt.comment_panel_scroll, 0,
+            "行が変わればパネル位置リセット"
+        );
+        assert_eq!(app.cmt.selected_inline_comment, 0);
+    }
+
     #[test]
     fn test_pressed_diff_line_promotes_to_selection_on_first_drag() {
         let mut app = diff_app_with_hit_rows(20);
-        app.drag_state = DragState::PressedDiffLine { anchor: 5 };
+        app.drag_state = DragState::PressedDiffLine {
+            anchor: 5,
+            open_on_up: false,
+        };
 
         app.mouse_drag(10, 8);
         assert_eq!(app.drag_state, DragState::SelectingDiffLines);
@@ -1095,7 +1201,10 @@ mod tests {
     #[test]
     fn test_up_without_drag_keeps_plain_click_semantics() {
         let mut app = diff_app_with_hit_rows(20);
-        app.drag_state = DragState::PressedDiffLine { anchor: 5 };
+        app.drag_state = DragState::PressedDiffLine {
+            anchor: 5,
+            open_on_up: false,
+        };
 
         // Drag なしで Up: 選択モードに入らない
         app.drag_state = DragState::Idle;
@@ -1105,7 +1214,10 @@ mod tests {
     #[test]
     fn test_selection_survives_mouse_up() {
         let mut app = diff_app_with_hit_rows(20);
-        app.drag_state = DragState::PressedDiffLine { anchor: 3 };
+        app.drag_state = DragState::PressedDiffLine {
+            anchor: 3,
+            open_on_up: false,
+        };
         app.mouse_drag(0, 7);
         assert!(app.multiline_selection.is_some());
 
@@ -1122,13 +1234,22 @@ mod tests {
     #[test]
     fn test_drag_outside_diff_rows_keeps_selection_unchanged() {
         let mut app = diff_app_with_hit_rows(10);
-        app.drag_state = DragState::PressedDiffLine { anchor: 2 };
+        app.drag_state = DragState::PressedDiffLine {
+            anchor: 2,
+            open_on_up: false,
+        };
         app.mouse_drag(100, 50);
         assert!(
             app.multiline_selection.is_none(),
             "差分行の外では昇格しない"
         );
-        assert_eq!(app.drag_state, DragState::PressedDiffLine { anchor: 2 });
+        assert_eq!(
+            app.drag_state,
+            DragState::PressedDiffLine {
+                anchor: 2,
+                open_on_up: false
+            }
+        );
     }
 
     #[test]

--- a/src/app/issue_detail.rs
+++ b/src/app/issue_detail.rs
@@ -70,6 +70,76 @@ impl App {
         state.issue_detail_cache = Some(cache);
     }
 
+    pub(crate) fn issue_body_wheel(&mut self, down: bool) {
+        let Some(state) = self.issue_state.as_mut() else {
+            return;
+        };
+        state.issue_detail_scroll_offset = if down {
+            state.issue_detail_scroll_offset.saturating_add(1)
+        } else {
+            state.issue_detail_scroll_offset.saturating_sub(1)
+        };
+    }
+
+    pub(crate) fn linked_prs_move_down(&mut self) {
+        let pr_count = self
+            .issue_state
+            .as_ref()
+            .and_then(|s| s.linked_prs.as_loaded().map(|p| p.len()))
+            .unwrap_or(0);
+        if pr_count == 0 {
+            return;
+        }
+        if let Some(state) = self.issue_state.as_mut() {
+            state.selected_linked_pr = (state.selected_linked_pr + 1).min(pr_count - 1);
+        }
+    }
+
+    pub(crate) fn linked_prs_move_up(&mut self) {
+        if let Some(state) = self.issue_state.as_mut() {
+            state.selected_linked_pr = state.selected_linked_pr.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn open_selected_linked_pr(&mut self) {
+        let pr_info = self.issue_state.as_ref().and_then(|state| {
+            state
+                .linked_prs
+                .as_loaded()
+                .and_then(|prs| prs.get(state.selected_linked_pr))
+                .map(|pr| (pr.number, pr.repo.clone()))
+        });
+        if let Some((number, repo)) = pr_info {
+            self.enter_pr_from_issue(number, repo.as_deref());
+        }
+    }
+
+    pub(crate) fn linked_pr_click_select(&mut self, row: usize) -> bool {
+        let Some(state) = self.issue_state.as_mut() else {
+            return false;
+        };
+        if state.selected_linked_pr == row {
+            return true;
+        }
+        state.selected_linked_pr = row;
+        false
+    }
+
+    /// リンク PR が存在するときだけフォーカスを切替える(Tab と同じガード)
+    pub(crate) fn issue_detail_set_focus(&mut self, focus: IssueDetailFocus) {
+        let has_linked_prs = self
+            .issue_state
+            .as_ref()
+            .and_then(|s| s.linked_prs.as_loaded().map(|p| !p.is_empty()))
+            .unwrap_or(false);
+        if focus == IssueDetailFocus::LinkedPrs && !has_linked_prs {
+            return;
+        }
+        if let Some(state) = self.issue_state.as_mut() {
+            state.detail_focus = focus;
+        }
+    }
+
     pub(crate) fn handle_issue_detail_input(
         &mut self,
         key: event::KeyEvent,
@@ -95,15 +165,11 @@ impl App {
         match focus {
             IssueDetailFocus::Body => {
                 if self.matches_single_key(&key, &kb.move_down) {
-                    let state = self.issue_state.as_mut().unwrap();
-                    state.issue_detail_scroll_offset =
-                        state.issue_detail_scroll_offset.saturating_add(1);
+                    self.issue_body_wheel(true);
                     return Ok(());
                 }
                 if self.matches_single_key(&key, &kb.move_up) {
-                    let state = self.issue_state.as_mut().unwrap();
-                    state.issue_detail_scroll_offset =
-                        state.issue_detail_scroll_offset.saturating_sub(1);
+                    self.issue_body_wheel(false);
                     return Ok(());
                 }
                 if self.matches_single_key(&key, &kb.page_down)
@@ -124,31 +190,17 @@ impl App {
                 }
             }
             IssueDetailFocus::LinkedPrs => {
-                let pr_count = state.linked_prs.as_loaded().map(|p| p.len()).unwrap_or(0);
-
                 if self.matches_single_key(&key, &kb.move_down) {
-                    if pr_count > 0 {
-                        let state = self.issue_state.as_mut().unwrap();
-                        state.selected_linked_pr =
-                            (state.selected_linked_pr + 1).min(pr_count.saturating_sub(1));
-                    }
+                    self.linked_prs_move_down();
                     return Ok(());
                 }
                 if self.matches_single_key(&key, &kb.move_up) {
-                    let state = self.issue_state.as_mut().unwrap();
-                    state.selected_linked_pr = state.selected_linked_pr.saturating_sub(1);
+                    self.linked_prs_move_up();
                     return Ok(());
                 }
 
                 if self.matches_single_key(&key, &kb.open_panel) {
-                    let pr_info = state
-                        .linked_prs
-                        .as_loaded()
-                        .and_then(|prs| prs.get(state.selected_linked_pr))
-                        .map(|pr| (pr.number, pr.repo.clone()));
-                    if let Some((number, repo)) = pr_info {
-                        self.enter_pr_from_issue(number, repo.as_deref());
-                    }
+                    self.open_selected_linked_pr();
                     return Ok(());
                 }
             }
@@ -271,6 +323,47 @@ impl App {
         self.state = AppState::TextInput;
     }
 
+    pub(crate) fn issue_comments_move_down(&mut self) {
+        let Some(ref state) = self.issue_state else {
+            return;
+        };
+        let comment_count = state.issue_comments.as_ref().map(|c| c.len()).unwrap_or(0);
+
+        if comment_count > 0 {
+            let state = self.issue_state.as_mut().unwrap();
+            state.selected_issue_comment =
+                (state.selected_issue_comment + 1).min(comment_count.saturating_sub(1));
+        }
+    }
+
+    pub(crate) fn issue_comments_move_up(&mut self) {
+        let Some(ref mut state) = self.issue_state else {
+            return;
+        };
+        state.selected_issue_comment = state.selected_issue_comment.saturating_sub(1);
+    }
+
+    pub(crate) fn open_selected_issue_comment(&mut self) {
+        let Some(ref mut state) = self.issue_state else {
+            return;
+        };
+        let comment_count = state.issue_comments.as_ref().map(|c| c.len()).unwrap_or(0);
+
+        if comment_count > 0 {
+            state.issue_comment_detail_mode = true;
+            state.issue_comment_detail_scroll = 0;
+        }
+    }
+
+    pub(crate) fn issue_comment_click_select(&mut self, index: usize) -> bool {
+        let Some(ref mut state) = self.issue_state else {
+            return false;
+        };
+        let already_selected = state.selected_issue_comment == index;
+        state.selected_issue_comment = index;
+        already_selected
+    }
+
     pub(crate) fn handle_issue_comment_list_input(&mut self, key: event::KeyEvent) -> Result<()> {
         let kb = self.config.keybindings.clone();
 
@@ -290,17 +383,12 @@ impl App {
         let comment_count = state.issue_comments.as_ref().map(|c| c.len()).unwrap_or(0);
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if comment_count > 0 {
-                let state = self.issue_state.as_mut().unwrap();
-                state.selected_issue_comment =
-                    (state.selected_issue_comment + 1).min(comment_count.saturating_sub(1));
-            }
+            self.issue_comments_move_down();
             return Ok(());
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            let state = self.issue_state.as_mut().unwrap();
-            state.selected_issue_comment = state.selected_issue_comment.saturating_sub(1);
+            self.issue_comments_move_up();
             return Ok(());
         }
 
@@ -328,11 +416,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.open_panel) {
-            if comment_count > 0 {
-                let state = self.issue_state.as_mut().unwrap();
-                state.issue_comment_detail_mode = true;
-                state.issue_comment_detail_scroll = 0;
-            }
+            self.open_selected_issue_comment();
             return Ok(());
         }
 

--- a/src/app/issue_list.rs
+++ b/src/app/issue_list.rs
@@ -117,6 +117,88 @@ impl App {
         });
     }
 
+    pub(crate) fn issue_list_move_down(&mut self) {
+        let Some(ref state) = self.issue_state else {
+            return;
+        };
+        let issue_count = state.issues.as_loaded().map(|l| l.len()).unwrap_or(0);
+
+        if state.issue_list_filter.is_some() {
+            self.handle_filter_navigation("issue", true);
+        } else if issue_count > 0 {
+            let needs_load_more = {
+                let state = self.issue_state.as_mut().unwrap();
+                state.selected_issue =
+                    (state.selected_issue + 1).min(issue_count.saturating_sub(1));
+                state.issue_list_has_more
+                    && !state.issues.is_loading()
+                    && state.selected_issue + 5 >= issue_count
+            };
+            if needs_load_more {
+                self.load_more_issues();
+            }
+        }
+    }
+
+    pub(crate) fn issue_list_move_up(&mut self) {
+        let Some(ref state) = self.issue_state else {
+            return;
+        };
+
+        if state.issue_list_filter.is_some() {
+            self.handle_filter_navigation("issue", false);
+        } else {
+            let state = self.issue_state.as_mut().unwrap();
+            state.selected_issue = state.selected_issue.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn open_selected_issue(&mut self) {
+        if self.is_filter_selection_empty("issue") {
+            return;
+        }
+        let issue_number = {
+            let Some(ref state) = self.issue_state else {
+                return;
+            };
+            state
+                .issues
+                .as_loaded()
+                .and_then(|issues| issues.get(state.selected_issue))
+                .map(|issue| issue.number)
+        };
+        if let Some(number) = issue_number {
+            self.select_issue(number);
+        }
+    }
+
+    pub(crate) fn issue_list_click_select(&mut self, row: usize, index: usize) -> bool {
+        let Some(ref mut state) = self.issue_state else {
+            return false;
+        };
+
+        let (already_selected, needs_load_more) =
+            if let Some(ref mut filter) = state.issue_list_filter {
+                let already_selected = filter.selected == Some(row);
+                filter.selected = Some(row);
+                state.selected_issue = index;
+                (already_selected, false)
+            } else {
+                let already_selected = state.selected_issue == index;
+                state.selected_issue = index;
+                let issue_count = state.issues.as_loaded().map(|l| l.len()).unwrap_or(0);
+                let needs_load_more = state.issue_list_has_more
+                    && !state.issues.is_loading()
+                    && state.selected_issue + 5 >= issue_count;
+                (already_selected, needs_load_more)
+            };
+
+        if needs_load_more {
+            self.load_more_issues();
+        }
+        already_selected
+    }
+
     pub(crate) async fn handle_issue_list_input(&mut self, key: event::KeyEvent) -> Result<()> {
         let kb = self.config.keybindings.clone();
 
@@ -154,31 +236,12 @@ impl App {
         let has_filter = state.issue_list_filter.is_some();
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if has_filter {
-                self.handle_filter_navigation("issue", true);
-            } else if issue_count > 0 {
-                let needs_load_more = {
-                    let state = self.issue_state.as_mut().unwrap();
-                    state.selected_issue =
-                        (state.selected_issue + 1).min(issue_count.saturating_sub(1));
-                    state.issue_list_has_more
-                        && !state.issues.is_loading()
-                        && state.selected_issue + 5 >= issue_count
-                };
-                if needs_load_more {
-                    self.load_more_issues();
-                }
-            }
+            self.issue_list_move_down();
             return Ok(());
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            if has_filter {
-                self.handle_filter_navigation("issue", false);
-            } else {
-                let state = self.issue_state.as_mut().unwrap();
-                state.selected_issue = state.selected_issue.saturating_sub(1);
-            }
+            self.issue_list_move_up();
             return Ok(());
         }
 
@@ -259,20 +322,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.open_panel) {
-            if self.is_filter_selection_empty("issue") {
-                return Ok(());
-            }
-            let issue_number = {
-                let state = self.issue_state.as_ref().unwrap();
-                state
-                    .issues
-                    .as_loaded()
-                    .and_then(|issues| issues.get(state.selected_issue))
-                    .map(|i| i.number)
-            };
-            if let Some(number) = issue_number {
-                self.select_issue(number);
-            }
+            self.open_selected_issue();
             return Ok(());
         }
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -47,6 +47,7 @@ mod git_ops;
 mod input;
 mod input_browse;
 mod input_diff;
+mod input_mouse;
 mod input_text;
 mod issue_detail;
 mod issue_list;
@@ -203,11 +204,20 @@ pub struct App {
     pub home_state: Option<AppState>,
     /// Repository Browser state (None = browser inactive).
     pub browse_state: Option<browse::BrowseState>,
+    /// マウスキャプチャの現在状態(F2 トグルで切替、mouse.enabled=false なら常に false)
+    pub mouse_capture_active: bool,
+    /// ドレイン中に読んでしまった未処理イベントの保留キュー(次イテレーションで消費)
+    pub(crate) pending_events: std::collections::VecDeque<crossterm::event::Event>,
+    /// 直近フレームのヒット領域(描画時に登録、入力時に参照)
+    pub hit_map: crate::ui::hit::HitMap,
+    /// マウスドラッグの状態機械
+    pub(crate) drag_state: input_mouse::DragState,
 }
 
 impl App {
     fn base_app(repo: String, config: Config) -> Self {
         let submit_key = config.keybindings.submit.clone();
+        let mouse_capture_active = config.mouse.enabled;
         Self {
             repo,
             repository_availability: RepositoryAvailability::Unavailable,
@@ -283,7 +293,23 @@ impl App {
             cockpit_state: None,
             home_state: None,
             browse_state: None,
+            mouse_capture_active,
+            pending_events: std::collections::VecDeque::new(),
+            hit_map: crate::ui::hit::HitMap::default(),
+            drag_state: input_mouse::DragState::default(),
         }
+    }
+
+    /// F2 トグルで移行すべきキャプチャ状態。mouse.enabled=false なら None(トグル無効)。
+    pub(crate) fn mouse_capture_target(&self) -> Option<bool> {
+        self.config
+            .mouse
+            .enabled
+            .then_some(!self.mouse_capture_active)
+    }
+
+    pub(crate) fn set_mouse_capture_active(&mut self, active: bool) {
+        self.mouse_capture_active = active;
     }
 
     pub fn new_loading(
@@ -379,7 +405,7 @@ impl App {
     }
 
     pub async fn run(&mut self) -> Result<()> {
-        let mut terminal = ui::setup_terminal()?;
+        let mut terminal = ui::setup_terminal(self.mouse_capture_active)?;
 
         // データが既にロード済み（キャッシュヒット）の場合、プリフェッチを開始
         if matches!(self.data_state, DataState::Loaded { .. }) {
@@ -425,7 +451,7 @@ impl App {
                     let editor = self.config.editor.clone();
                     ui::restore_terminal(&mut terminal)?;
                     let _ = crate::editor::open_file_at_line(editor.as_deref(), &path_str, line);
-                    terminal = ui::setup_terminal()?;
+                    terminal = ui::setup_terminal(self.mouse_capture_active)?;
                 }
             }
             terminal.draw(|frame| ui::render(frame, self))?;

--- a/src/app/pr_list.rs
+++ b/src/app/pr_list.rs
@@ -37,26 +37,12 @@ impl App {
         let has_filter = self.prs.pr_list_filter.is_some();
 
         if self.matches_single_key(&key, &kb.move_down) {
-            if has_filter {
-                self.handle_filter_navigation("pr", true);
-            } else if pr_count > 0 {
-                self.prs.selected_pr = (self.prs.selected_pr + 1).min(pr_count.saturating_sub(1));
-                if self.prs.pr_list_has_more
-                    && !self.prs.pr_list.is_loading()
-                    && self.prs.selected_pr + 5 >= pr_count
-                {
-                    self.load_more_prs();
-                }
-            }
+            self.pr_list_move_down();
             return Ok(());
         }
 
         if self.matches_single_key(&key, &kb.move_up) {
-            if has_filter {
-                self.handle_filter_navigation("pr", false);
-            } else {
-                self.prs.selected_pr = self.prs.selected_pr.saturating_sub(1);
-            }
+            self.pr_list_move_up();
             return Ok(());
         }
 
@@ -134,14 +120,7 @@ impl App {
         }
 
         if self.matches_single_key(&key, &kb.open_panel) {
-            if self.is_filter_selection_empty("pr") {
-                return Ok(());
-            }
-            if let Some(prs) = self.prs.pr_list.as_loaded() {
-                if let Some(pr) = prs.get(self.prs.selected_pr) {
-                    self.select_pr(pr.number);
-                }
-            }
+            self.open_selected_pr();
             return Ok(());
         }
 
@@ -220,6 +199,69 @@ impl App {
 
         Ok(())
     }
+
+    pub(crate) fn pr_list_move_down(&mut self) {
+        if self.prs.pr_list_filter.is_some() {
+            self.handle_filter_navigation("pr", true);
+            return;
+        }
+
+        let pr_count = self.prs.pr_list.as_loaded().map(|l| l.len()).unwrap_or(0);
+        if pr_count > 0 {
+            self.prs.selected_pr = (self.prs.selected_pr + 1).min(pr_count.saturating_sub(1));
+            if self.prs.pr_list_has_more
+                && !self.prs.pr_list.is_loading()
+                && self.prs.selected_pr + 5 >= pr_count
+            {
+                self.load_more_prs();
+            }
+        }
+    }
+
+    pub(crate) fn pr_list_move_up(&mut self) {
+        if self.prs.pr_list_filter.is_some() {
+            self.handle_filter_navigation("pr", false);
+        } else {
+            self.prs.selected_pr = self.prs.selected_pr.saturating_sub(1);
+        }
+    }
+
+    pub(crate) fn open_selected_pr(&mut self) {
+        if self.is_filter_selection_empty("pr") {
+            return;
+        }
+        if let Some(prs) = self.prs.pr_list.as_loaded() {
+            if let Some(pr) = prs.get(self.prs.selected_pr) {
+                self.select_pr(pr.number);
+            }
+        }
+    }
+
+    pub(crate) fn pr_list_click_select(&mut self, row: usize, index: usize) -> bool {
+        if let Some(filter) = self.prs.pr_list_filter.as_mut() {
+            if filter.selected == Some(row) {
+                return true;
+            }
+            filter.selected = Some(row);
+            self.prs.selected_pr = index;
+            return false;
+        }
+
+        if self.prs.selected_pr == index {
+            return true;
+        }
+
+        self.prs.selected_pr = index;
+        let pr_count = self.prs.pr_list.as_loaded().map(|l| l.len()).unwrap_or(0);
+        if self.prs.pr_list_has_more
+            && !self.prs.pr_list.is_loading()
+            && self.prs.selected_pr + 5 >= pr_count
+        {
+            self.load_more_prs();
+        }
+        false
+    }
+
     pub(crate) fn reload_pr_list(&mut self) {
         self.prs.selected_pr = 0;
         self.prs.pr_list_scroll_offset = 0;

--- a/src/app/shell_command.rs
+++ b/src/app/shell_command.rs
@@ -228,7 +228,7 @@ impl App {
         }
     }
 
-    fn shell_scroll_by(&mut self, delta: i32) {
+    pub(crate) fn shell_scroll_by(&mut self, delta: i32) {
         let Some(ref mut shell) = self.shell_state else {
             return;
         };

--- a/src/app/symbol.rs
+++ b/src/app/symbol.rs
@@ -234,7 +234,7 @@ impl App {
             &full_path,
             line_number.unwrap_or(1) as usize,
         );
-        *terminal = crate::ui::setup_terminal()?;
+        *terminal = crate::ui::setup_terminal(self.mouse_capture_active)?;
 
         Ok(())
     }
@@ -307,9 +307,9 @@ impl App {
         } else if Self::is_shift_char_shortcut(&key, 'g') {
             self.pr_description_scroll_offset = usize::MAX;
         } else if self.matches_single_key(&key, &kb.move_down) {
-            self.pr_description_scroll_offset = self.pr_description_scroll_offset.saturating_add(1);
+            self.pr_description_wheel(true);
         } else if self.matches_single_key(&key, &kb.move_up) {
-            self.pr_description_scroll_offset = self.pr_description_scroll_offset.saturating_sub(1);
+            self.pr_description_wheel(false);
         } else if self.matches_single_key(&key, &kb.page_down) {
             self.pr_description_scroll_offset =
                 self.pr_description_scroll_offset.saturating_add(half_page);
@@ -319,6 +319,14 @@ impl App {
         }
 
         Ok(())
+    }
+
+    pub(crate) fn pr_description_wheel(&mut self, down: bool) {
+        self.pr_description_scroll_offset = if down {
+            self.pr_description_scroll_offset.saturating_add(1)
+        } else {
+            self.pr_description_scroll_offset.saturating_sub(1)
+        };
     }
 
     pub(crate) fn handle_help_input(
@@ -383,9 +391,11 @@ impl App {
         } else if Self::is_shift_char_shortcut(&key, 'g') {
             offset = usize::MAX;
         } else if self.matches_single_key(&key, &kb.move_down) {
-            offset = offset.saturating_add(1);
+            self.help_wheel(true);
+            return;
         } else if self.matches_single_key(&key, &kb.move_up) {
-            offset = offset.saturating_sub(1);
+            self.help_wheel(false);
+            return;
         } else if self.matches_single_key(&key, &kb.page_down) {
             offset = offset.saturating_add(half_page);
         } else if self.matches_single_key(&key, &kb.page_up) {
@@ -395,6 +405,18 @@ impl App {
         match self.help_tab {
             HelpTab::Keybindings => self.help_scroll_offset = offset,
             HelpTab::Config => self.config_scroll_offset = offset,
+        };
+    }
+
+    pub(crate) fn help_wheel(&mut self, down: bool) {
+        let offset = match self.help_tab {
+            HelpTab::Keybindings => &mut self.help_scroll_offset,
+            HelpTab::Config => &mut self.config_scroll_offset,
+        };
+        *offset = if down {
+            offset.saturating_add(1)
+        } else {
+            offset.saturating_sub(1)
         };
     }
 }

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -8287,3 +8287,59 @@ fn test_diff_page_down_in_diff_focus_matches_page_down_step() {
         30 + super::input_diff::DIFF_PAGE_STEP
     );
 }
+
+#[test]
+fn test_mouse_capture_active_initialized_from_config() {
+    let enabled = App::new_cockpit("owner/repo", Config::default(), false);
+    assert!(enabled.mouse_capture_active);
+
+    let mut config = Config::default();
+    config.mouse.enabled = false;
+    let disabled = App::new_cockpit("owner/repo", config, false);
+    assert!(!disabled.mouse_capture_active);
+}
+
+#[test]
+fn test_mouse_capture_target_none_when_disabled_in_config() {
+    let mut config = Config::default();
+    config.mouse.enabled = false;
+    let app = App::new_cockpit("owner/repo", config, false);
+    assert_eq!(app.mouse_capture_target(), None);
+}
+
+#[test]
+fn test_mouse_capture_target_flips_from_current_state() {
+    let mut app = App::new_cockpit("owner/repo", Config::default(), false);
+    assert_eq!(app.mouse_capture_target(), Some(false));
+    app.set_mouse_capture_active(false);
+    assert_eq!(app.mouse_capture_target(), Some(true));
+}
+
+#[test]
+#[serial]
+fn test_toggle_mouse_key_flips_capture_state() {
+    let mut app = App::new_cockpit("owner/repo", Config::default(), false);
+    let f2 = KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE);
+
+    assert!(app.handle_toggle_mouse_key(&f2));
+    assert!(!app.mouse_capture_active);
+
+    assert!(app.handle_toggle_mouse_key(&f2));
+    assert!(app.mouse_capture_active);
+
+    let other = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+    assert!(!app.handle_toggle_mouse_key(&other));
+    assert!(app.mouse_capture_active);
+}
+
+#[test]
+#[serial]
+fn test_toggle_mouse_key_ignored_when_disabled_in_config() {
+    let mut config = Config::default();
+    config.mouse.enabled = false;
+    let mut app = App::new_cockpit("owner/repo", config, false);
+    let f2 = KeyEvent::new(KeyCode::F(2), KeyModifiers::NONE);
+
+    assert!(!app.handle_toggle_mouse_key(&f2));
+    assert!(!app.mouse_capture_active);
+}

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2106,6 +2106,98 @@ async fn test_multiline_select_extend_and_confirm_via_key_dispatch() {
     );
 }
 
+#[tokio::test]
+#[serial]
+async fn test_shift_enter_multiline_confirm_via_full_key_path() {
+    let mut app = make_app_with_patch("@@ -1,3 +1,4 @@\n context\n+added\n more context");
+    app.state = AppState::DiffView;
+    app.diff_scroll.line_count = 4;
+    app.diff_scroll.selected_line = 1;
+    let mut terminal =
+        ratatui::Terminal::new(ratatui::backend::CrosstermBackend::new(std::io::stdout())).unwrap();
+
+    let press = |code: KeyCode, mods: KeyModifiers| KeyEvent {
+        code,
+        modifiers: mods,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    };
+
+    // handle_key_event = F2/シェル/ガード込みのフル経路
+    app.handle_key_event(press(KeyCode::Enter, KeyModifiers::SHIFT), &mut terminal)
+        .await
+        .unwrap();
+    assert!(
+        app.multiline_selection.is_some(),
+        "Shift+Enter で選択が始まる"
+    );
+
+    app.handle_key_event(press(KeyCode::Char('j'), KeyModifiers::NONE), &mut terminal)
+        .await
+        .unwrap();
+    app.handle_key_event(press(KeyCode::Char('c'), KeyModifiers::NONE), &mut terminal)
+        .await
+        .unwrap();
+
+    assert_eq!(app.state, AppState::TextInput);
+    let Some(InputMode::Comment(ref ctx)) = app.input_mode else {
+        panic!("expected comment input mode, got {:?}", app.input_mode);
+    };
+    assert_eq!(
+        ctx.start_line_number,
+        Some(1),
+        "範囲コメントとして確定される"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_shift_enter_starts_selection_even_while_comment_panel_open() {
+    let mut app = make_app_with_patch("@@ -1,3 +1,4 @@\n context\n+added\n more context");
+    app.state = AppState::DiffView;
+    app.diff_scroll.line_count = 4;
+    app.diff_scroll.selected_line = 1;
+    // マウスの再クリック等でパネルが開いたままの状態を再現
+    app.cmt.comment_panel_open = true;
+    let mut terminal =
+        ratatui::Terminal::new(ratatui::backend::CrosstermBackend::new(std::io::stdout())).unwrap();
+
+    let press = |code: KeyCode, mods: KeyModifiers| KeyEvent {
+        code,
+        modifiers: mods,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    };
+
+    app.handle_key_event(press(KeyCode::Enter, KeyModifiers::SHIFT), &mut terminal)
+        .await
+        .unwrap();
+    assert!(
+        app.multiline_selection.is_some(),
+        "パネルが開いていても Shift+Enter で範囲選択が始まる"
+    );
+
+    app.handle_key_event(press(KeyCode::Char('j'), KeyModifiers::NONE), &mut terminal)
+        .await
+        .unwrap();
+    app.handle_key_event(press(KeyCode::Char('c'), KeyModifiers::NONE), &mut terminal)
+        .await
+        .unwrap();
+
+    assert_eq!(app.state, AppState::TextInput, "c で範囲コメントに入る");
+    let Some(InputMode::Comment(ref ctx)) = app.input_mode else {
+        panic!(
+            "expected multiline comment input, got {:?} (パネル分岐が c を単一行コメントに吸っている)",
+            app.input_mode
+        );
+    };
+    assert_eq!(
+        ctx.start_line_number,
+        Some(1),
+        "パネルが開いた状態から始めても範囲が保持される"
+    );
+}
+
 #[test]
 fn test_multiline_comment_preserves_selection_on_invalid_range() {
     let patch = "@@ -1,2 +1,2 @@\n line1\n+new line2\n@@ -10,2 +10,2 @@\n line10\n+new line11";

--- a/src/app/tests.rs
+++ b/src/app/tests.rs
@@ -2053,6 +2053,59 @@ fn test_enter_multiline_selection_rejected_on_header() {
     assert!(app.multiline_selection.is_none());
 }
 
+#[tokio::test]
+#[serial]
+async fn test_multiline_select_extend_and_confirm_via_key_dispatch() {
+    let mut app = make_app_with_patch("@@ -1,3 +1,4 @@\n context\n+added\n more context");
+    app.state = AppState::DiffView;
+    app.diff_scroll.line_count = 4;
+    app.diff_scroll.selected_line = 1;
+    let mut terminal =
+        ratatui::Terminal::new(ratatui::backend::CrosstermBackend::new(std::io::stdout())).unwrap();
+
+    let press = |code: KeyCode, mods: KeyModifiers| KeyEvent {
+        code,
+        modifiers: mods,
+        kind: KeyEventKind::Press,
+        state: KeyEventState::NONE,
+    };
+
+    app.handle_diff_view_input(
+        press(KeyCode::Char('V'), KeyModifiers::SHIFT),
+        &mut terminal,
+    )
+    .await
+    .unwrap();
+    assert!(
+        app.multiline_selection.is_some(),
+        "V で複数行選択モードに入る"
+    );
+
+    app.handle_diff_view_input(press(KeyCode::Char('j'), KeyModifiers::NONE), &mut terminal)
+        .await
+        .unwrap();
+    let sel = app.multiline_selection.as_ref().unwrap();
+    assert_eq!(
+        (sel.anchor_line, sel.cursor_line),
+        (1, 2),
+        "j で選択が伸びる"
+    );
+
+    app.handle_diff_view_input(press(KeyCode::Char('c'), KeyModifiers::NONE), &mut terminal)
+        .await
+        .unwrap();
+    assert_eq!(app.state, AppState::TextInput, "c で確定して入力へ");
+    let Some(InputMode::Comment(ref ctx)) = app.input_mode else {
+        panic!("expected comment input mode, got {:?}", app.input_mode);
+    };
+    assert_eq!(ctx.line_number, 2, "終了行は new-side 2 行目");
+    assert_eq!(
+        ctx.start_line_number,
+        Some(1),
+        "開始行が保持され複数行コメントになる"
+    );
+}
+
 #[test]
 fn test_multiline_comment_preserves_selection_on_invalid_range() {
     let patch = "@@ -1,2 +1,2 @@\n line1\n+new line2\n@@ -10,2 +10,2 @@\n line10\n+new line11";

--- a/src/config/keybindings.rs
+++ b/src/config/keybindings.rs
@@ -69,6 +69,7 @@ pub struct KeybindingsConfig {
 
     pub tree_toggle: KeySequence,
     pub shell_command: KeySequence,
+    pub toggle_mouse: KeySequence,
 
     pub repo_browse: KeySequence,
     pub symbol_outline: KeySequence,
@@ -155,6 +156,7 @@ impl Default for KeybindingsConfig {
             mark_viewed_dir: KeySequence::single(KeyBinding::char('V')),
             tree_toggle: KeySequence::single(KeyBinding::char('t')),
             shell_command: KeySequence::single(KeyBinding::char('!')),
+            toggle_mouse: KeySequence::single(KeyBinding::named(NamedKey::F(2))),
 
             repo_browse: KeySequence::single(KeyBinding::char('b')),
             symbol_outline: KeySequence::single(KeyBinding::char('o')),
@@ -252,6 +254,7 @@ impl KeybindingsConfig {
             ("open_blame_pr", &self.open_blame_pr),
             ("open_line_discussion", &self.open_line_discussion),
             ("shell_command", &self.shell_command),
+            ("toggle_mouse", &self.toggle_mouse),
             ("filter_open", &self.filter_open),
             ("filter_closed", &self.filter_closed),
             ("filter_all", &self.filter_all),
@@ -534,6 +537,7 @@ impl Serialize for KeybindingsConfig {
         map.serialize_entry("mark_viewed", &seq_to_value(&self.mark_viewed))?;
         map.serialize_entry("mark_viewed_dir", &seq_to_value(&self.mark_viewed_dir))?;
         map.serialize_entry("tree_toggle", &seq_to_value(&self.tree_toggle))?;
+        map.serialize_entry("toggle_mouse", &seq_to_value(&self.toggle_mouse))?;
         map.serialize_entry("repo_browse", &seq_to_value(&self.repo_browse))?;
         map.serialize_entry("symbol_outline", &seq_to_value(&self.symbol_outline))?;
         map.serialize_entry("symbol_search", &seq_to_value(&self.symbol_search))?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,7 +5,8 @@ mod schema;
 pub use keybindings::KeybindingsConfig;
 pub use loader::{find_project_root, find_project_root_in};
 pub use schema::{
-    AiConfig, DiffConfig, GitOpsConfig, LayoutConfig, ProposalPostStrategy, ShellConfig,
+    AiConfig, DiffConfig, GitOpsConfig, LayoutConfig, MouseConfig, ProposalPostStrategy,
+    ShellConfig,
 };
 
 use serde::{Deserialize, Serialize};
@@ -39,6 +40,7 @@ pub struct Config {
     #[serde(alias = "git_log")]
     pub git_ops: GitOpsConfig,
     pub shell: ShellConfig,
+    pub mouse: MouseConfig,
     #[serde(skip)]
     pub project_root: PathBuf,
     /// Path of the global config file if it was loaded successfully.
@@ -1500,6 +1502,98 @@ zen_mode = true
     fn test_layout_zen_mode_default() {
         let config: Config = toml::from_str("").unwrap();
         assert!(!config.layout.zen_mode);
+    }
+
+    #[test]
+    fn test_mouse_defaults() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.mouse.enabled);
+        assert_eq!(config.mouse.wheel_step, 3);
+    }
+
+    #[test]
+    fn test_mouse_custom() {
+        let config: Config = toml::from_str(
+            r#"
+            [mouse]
+            enabled = false
+            wheel_step = 5
+        "#,
+        )
+        .unwrap();
+        assert!(!config.mouse.enabled);
+        assert_eq!(config.mouse.wheel_step, 5);
+    }
+
+    #[test]
+    fn test_mouse_partial_section_keeps_defaults() {
+        let config: Config = toml::from_str(
+            r#"
+            [mouse]
+            enabled = false
+        "#,
+        )
+        .unwrap();
+        assert!(!config.mouse.enabled);
+        assert_eq!(config.mouse.wheel_step, 3);
+    }
+
+    #[test]
+    fn test_mouse_wheel_step_clamped() {
+        let low: Config = toml::from_str(
+            r#"
+            [mouse]
+            wheel_step = 0
+        "#,
+        )
+        .unwrap();
+        assert_eq!(low.mouse.wheel_step, 1, "wheel_step below 1 clamps to 1");
+
+        let high: Config = toml::from_str(
+            r#"
+            [mouse]
+            wheel_step = 20
+        "#,
+        )
+        .unwrap();
+        assert_eq!(
+            high.mouse.wheel_step, 10,
+            "wheel_step above 10 clamps to 10"
+        );
+    }
+
+    #[test]
+    fn test_toggle_mouse_default_is_f2() {
+        let kb = KeybindingsConfig::default();
+        assert_eq!(kb.toggle_mouse.display(), "F2");
+    }
+
+    #[test]
+    fn test_toggle_mouse_custom_binding() {
+        let config: Config = toml::from_str(
+            r#"
+            [keybindings]
+            toggle_mouse = "F5"
+        "#,
+        )
+        .unwrap();
+        assert_eq!(config.keybindings.toggle_mouse.display(), "F5");
+        assert!(config.keybindings.validate().is_ok());
+    }
+
+    #[test]
+    fn test_serialize_roundtrip_includes_toggle_mouse() {
+        let config = KeybindingsConfig::default();
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(
+            serialized.contains("toggle_mouse"),
+            "Serialized output should include toggle_mouse"
+        );
+        let deserialized: KeybindingsConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            deserialized.toggle_mouse.display(),
+            config.toggle_mouse.display()
+        );
     }
 
     #[test]

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -193,6 +193,42 @@ impl LayoutConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MouseConfig {
+    /// マウスキャプチャを起動時に有効化するかどうか。
+    /// 有効中は端末ネイティブのテキスト選択が効かなくなる(F2 で一時切替)。
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// ホイール1ノッチあたりのカーソル/選択移動行数
+    #[serde(
+        default = "default_wheel_step",
+        deserialize_with = "deserialize_wheel_step"
+    )]
+    pub wheel_step: u16,
+}
+
+fn default_wheel_step() -> u16 {
+    3
+}
+
+fn deserialize_wheel_step<'de, D>(deserializer: D) -> Result<u16, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u16::deserialize(deserializer)?;
+    Ok(value.clamp(1, 10))
+}
+
+impl Default for MouseConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            wheel_step: default_wheel_step(),
+        }
+    }
+}
+
 const DEFAULT_SHELL_TIMEOUT_SECS: u64 = 10;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/init.rs
+++ b/src/init.rs
@@ -29,6 +29,14 @@ tab_width = 4
 # Hide header/footer for focused editing (default: false)
 # zen_mode = false
 
+[mouse]
+# Mouse support (click to select, wheel to scroll, drag to select diff lines).
+# While capture is on, use F2 (toggle_mouse) to copy text with the terminal,
+# or disable entirely here. (default: true)
+# enabled = true
+# Lines moved per wheel notch (1-10, default: 3)
+# wheel_step = 3
+
 [keybindings]
 approve = 'a'
 request_changes = 'r'
@@ -78,6 +86,10 @@ pub(crate) const DEFAULT_LOCAL_CONFIG: &str = r#"# Project-local octorus configu
 # [layout]
 # left_panel_width = 35
 # zen_mode = false
+
+# [mouse]
+# enabled = true
+# wheel_step = 3
 
 # [ai]
 # reviewer = "claude"
@@ -899,10 +911,10 @@ mod tests {
 
         // config.toml matches a known default hash, so version should be detected
         let config_version = &manifest.files["config.toml"].version;
-        // DEFAULT_LOCAL_CONFIG currently matches the 0.5.8 hash in DEFAULT_HASHES
+        // DEFAULT_LOCAL_CONFIG currently matches the 0.8.0 hash in DEFAULT_HASHES
         assert!(
-            config_version == "0.5.8",
-            "skipped file should detect version 0.5.8 from hash, got {}",
+            config_version == "0.8.0",
+            "skipped file should detect version 0.8.0 from hash, got {}",
             config_version
         );
     }

--- a/src/keybinding.rs
+++ b/src/keybinding.rs
@@ -31,6 +31,8 @@ pub enum NamedKey {
     PageUp,
     PageDown,
     BackTab,
+    /// Function key F1-F12 (validated at parse time)
+    F(u8),
 }
 
 impl NamedKey {
@@ -51,7 +53,10 @@ impl NamedKey {
             "pageup" | "pgup" => Some(NamedKey::PageUp),
             "pagedown" | "pgdn" => Some(NamedKey::PageDown),
             "backtab" | "shifttab" => Some(NamedKey::BackTab),
-            _ => None,
+            other => {
+                let n: u8 = other.strip_prefix('f')?.parse().ok()?;
+                (1..=12).contains(&n).then_some(NamedKey::F(n))
+            }
         }
     }
 
@@ -72,6 +77,7 @@ impl NamedKey {
             NamedKey::PageUp => KeyCode::PageUp,
             NamedKey::PageDown => KeyCode::PageDown,
             NamedKey::BackTab => KeyCode::BackTab,
+            NamedKey::F(n) => KeyCode::F(n),
         }
     }
 
@@ -92,6 +98,21 @@ impl NamedKey {
             NamedKey::PageUp => "PageUp",
             NamedKey::PageDown => "PageDown",
             NamedKey::BackTab => "Shift-Tab",
+            NamedKey::F(n) => match n {
+                1 => "F1",
+                2 => "F2",
+                3 => "F3",
+                4 => "F4",
+                5 => "F5",
+                6 => "F6",
+                7 => "F7",
+                8 => "F8",
+                9 => "F9",
+                10 => "F10",
+                11 => "F11",
+                12 => "F12",
+                _ => "F?",
+            },
         }
     }
 }
@@ -686,6 +707,7 @@ pub fn event_to_keybinding(event: &KeyEvent) -> Option<KeyBinding> {
         KeyCode::End => KeyCodeConfig::Named(NamedKey::End),
         KeyCode::PageUp => KeyCodeConfig::Named(NamedKey::PageUp),
         KeyCode::PageDown => KeyCodeConfig::Named(NamedKey::PageDown),
+        KeyCode::F(n) if (1..=12).contains(&n) => KeyCodeConfig::Named(NamedKey::F(n)),
         _ => return None,
     };
 
@@ -886,5 +908,49 @@ mod tests {
     #[test]
     fn test_display_named() {
         assert_eq!(KeyBinding::named(NamedKey::Enter).display(), "Enter");
+    }
+
+    #[test]
+    fn test_parse_f_key() {
+        assert_eq!(NamedKey::parse("f1"), Some(NamedKey::F(1)));
+        assert_eq!(NamedKey::parse("F2"), Some(NamedKey::F(2)));
+        assert_eq!(NamedKey::parse("f12"), Some(NamedKey::F(12)));
+        assert_eq!(NamedKey::parse("f0"), None);
+        assert_eq!(NamedKey::parse("f13"), None);
+        assert_eq!(NamedKey::parse("f"), None);
+    }
+
+    #[test]
+    fn test_parse_key_string_f_key() {
+        let key = parse_key_string("F2").unwrap();
+        assert_eq!(key.code, KeyCodeConfig::Named(NamedKey::F(2)));
+        assert!(key.modifiers.is_empty());
+    }
+
+    #[test]
+    fn test_f_key_to_keycode() {
+        assert_eq!(NamedKey::F(2).to_keycode(), KeyCode::F(2));
+        assert_eq!(NamedKey::F(12).to_keycode(), KeyCode::F(12));
+    }
+
+    #[test]
+    fn test_f_key_display() {
+        assert_eq!(NamedKey::F(2).display_name(), "F2");
+        assert_eq!(KeyBinding::named(NamedKey::F(2)).display(), "F2");
+    }
+
+    #[test]
+    fn test_event_to_keybinding_f_key() {
+        let kb = event_to_keybinding(&key_event(KeyCode::F(2))).unwrap();
+        assert_eq!(kb.code, KeyCodeConfig::Named(NamedKey::F(2)));
+        assert!(event_to_keybinding(&key_event(KeyCode::F(13))).is_none());
+    }
+
+    #[test]
+    fn test_keybinding_matches_f_key() {
+        let binding = KeyBinding::named(NamedKey::F(2));
+        assert!(binding.matches(&key_event(KeyCode::F(2))));
+        assert!(!binding.matches(&key_event(KeyCode::F(3))));
+        assert!(!binding.matches(&key_event(KeyCode::Char('2'))));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,7 @@ fn is_root_help(raw_args: &[OsString]) -> bool {
 
 /// Restore terminal to normal state
 fn restore_terminal() {
+    octorus::ui::cleanup_mouse_capture();
     octorus::ui::cleanup_keyboard_enhancement();
     let _ = disable_raw_mode();
     let _ = execute!(io::stdout(), LeaveAlternateScreen);

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -179,6 +179,56 @@ const DEFAULT_HASHES: &[DefaultFileHash] = &[
         filename: "rereview.md",
         sha256: HASH_REREVIEW_0_5_6,
     },
+    // 0.8.0 — config.toml updated with [mouse] section
+    DefaultFileHash {
+        scope: FileScope::Global,
+        version: "0.8.0",
+        filename: "config.toml",
+        sha256: HASH_GLOBAL_CONFIG_0_8_0,
+    },
+    DefaultFileHash {
+        scope: FileScope::Local,
+        version: "0.8.0",
+        filename: "config.toml",
+        sha256: HASH_LOCAL_CONFIG_0_8_0,
+    },
+    // 0.8.0 — prompts unchanged from 0.5.6
+    DefaultFileHash {
+        scope: FileScope::Global,
+        version: "0.8.0",
+        filename: "reviewer.md",
+        sha256: HASH_REVIEWER_0_5_6,
+    },
+    DefaultFileHash {
+        scope: FileScope::Local,
+        version: "0.8.0",
+        filename: "reviewer.md",
+        sha256: HASH_REVIEWER_0_5_6,
+    },
+    DefaultFileHash {
+        scope: FileScope::Global,
+        version: "0.8.0",
+        filename: "reviewee.md",
+        sha256: HASH_REVIEWEE_0_5_6,
+    },
+    DefaultFileHash {
+        scope: FileScope::Local,
+        version: "0.8.0",
+        filename: "reviewee.md",
+        sha256: HASH_REVIEWEE_0_5_6,
+    },
+    DefaultFileHash {
+        scope: FileScope::Global,
+        version: "0.8.0",
+        filename: "rereview.md",
+        sha256: HASH_REREVIEW_0_5_6,
+    },
+    DefaultFileHash {
+        scope: FileScope::Local,
+        version: "0.8.0",
+        filename: "rereview.md",
+        sha256: HASH_REREVIEW_0_5_6,
+    },
     // SKILL.md
     DefaultFileHash {
         scope: FileScope::Skill,
@@ -217,6 +267,10 @@ const HASH_GLOBAL_CONFIG_0_5_8: &str =
     "432c5a06806123c2a3a944353c826d004ab775759e158728541f87039240560e";
 const HASH_LOCAL_CONFIG_0_5_8: &str =
     "db391a2874904add6f193366aaa0d5eb7b35689f5fae04cf4a2d8d740c1c353e";
+const HASH_GLOBAL_CONFIG_0_8_0: &str =
+    "dadbe4ae340835ca5ee1a9c82ea11f81afb464a7a20ea510c56d6aec9f395428";
+const HASH_LOCAL_CONFIG_0_8_0: &str =
+    "6e480ef3ed4b1af4f53fad299613e0639c88f1b0b173db6d40f6e78d5c6f611c";
 const HASH_REVIEWER_0_5_6: &str =
     "d9dfdd90d4041ef424edbab3754ab94bafbdad9d69e7297db195cf6194701e58";
 const HASH_REVIEWEE_0_5_6: &str =
@@ -1193,13 +1247,13 @@ mod tests {
                 FileScope::Global,
                 "config.toml",
                 DEFAULT_CONFIG,
-                HASH_GLOBAL_CONFIG_0_5_8,
+                HASH_GLOBAL_CONFIG_0_8_0,
             ),
             (
                 FileScope::Local,
                 "config.toml",
                 DEFAULT_LOCAL_CONFIG,
-                HASH_LOCAL_CONFIG_0_5_8,
+                HASH_LOCAL_CONFIG_0_8_0,
             ),
             (
                 FileScope::Global,
@@ -1296,13 +1350,13 @@ mod tests {
         .unwrap();
 
         let manifest = Some(VersionManifest {
-            binary_version: "0.5.8".to_string(),
+            binary_version: "0.8.0".to_string(),
             initialized_at: "2024-01-01T00:00:00Z".to_string(),
             last_migrated_at: None,
             files: HashMap::new(),
         });
 
-        let actions = build_migration_plan(&config_dir, None, &manifest, "0.5.8", false, false);
+        let actions = build_migration_plan(&config_dir, None, &manifest, "0.8.0", false, false);
 
         // Should only have skips + WriteManifest
         assert!(
@@ -1558,7 +1612,7 @@ mod tests {
         )
         .unwrap();
 
-        let version = "0.5.8";
+        let version = "0.8.0";
 
         // First migration — should be "all up to date" but write manifest
         let actions = build_migration_plan(&config_dir, None, &None, version, false, false);
@@ -1596,7 +1650,7 @@ mod tests {
         )
         .unwrap();
 
-        let version = "0.5.8";
+        let version = "0.8.0";
         let manifest_path = config_dir.join(".version");
 
         // Run 1

--- a/src/ui/ai_rally.rs
+++ b/src/ui/ai_rally.rs
@@ -13,11 +13,18 @@ use super::common::{build_pr_info, truncate_with_width};
 use crate::ai::{RallyState, ReviewAction, RevieweeStatus};
 use crate::app::{AiRallyState, App, LogEntry, LogEventType, PauseState};
 use crate::config::KeybindingsConfig;
+use crate::ui::hit::{HitMap, HitTarget, ListKind, PaneKind};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let pr_info = build_pr_info(app);
 
-    let Some(rally_state) = &mut app.ai_rally_state else {
+    let App {
+        ai_rally_state,
+        config,
+        hit_map,
+        ..
+    } = app;
+    let Some(rally_state) = ai_rally_state else {
         return;
     };
 
@@ -30,9 +37,9 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         ])
         .split(frame.area());
 
-    let kb = &app.config.keybindings;
+    let kb = &config.keybindings;
     render_header(frame, chunks[0], rally_state, &pr_info);
-    render_main_content(frame, chunks[1], rally_state, kb);
+    render_main_content(frame, chunks[1], rally_state, kb, hit_map);
     render_status_bar(frame, chunks[2], rally_state, kb);
 
     if rally_state.showing_log_detail {
@@ -117,9 +124,10 @@ fn render_main_content(
     area: Rect,
     state: &mut AiRallyState,
     kb: &KeybindingsConfig,
+    hit_map: &mut HitMap,
 ) {
     if state.pending_config_warning.is_some() {
-        render_config_warning(frame, area, state, kb);
+        render_config_warning(frame, area, state, kb, hit_map);
         return;
     }
 
@@ -149,10 +157,10 @@ fn render_main_content(
     render_history(frame, chunks[0], state);
 
     if is_waiting {
-        render_waiting_prompt(frame, chunks[1], state, kb);
-        render_logs(frame, chunks[2], state);
+        render_logs(frame, chunks[2], state, hit_map);
+        render_waiting_prompt(frame, chunks[1], state, kb, hit_map);
     } else {
-        render_logs(frame, chunks[1], state);
+        render_logs(frame, chunks[1], state, hit_map);
     }
 }
 
@@ -161,6 +169,7 @@ fn render_config_warning(
     area: Rect,
     state: &AiRallyState,
     kb: &KeybindingsConfig,
+    hit_map: &mut HitMap,
 ) {
     let warnings = match &state.pending_config_warning {
         Some(w) => w,
@@ -211,6 +220,8 @@ fn render_config_warning(
     );
 
     frame.render_widget(warning, area);
+    hit_map.push(frame.area(), HitTarget::Backdrop { dismiss: false });
+    hit_map.push(area, HitTarget::OverlaySurface);
 }
 
 fn render_waiting_prompt(
@@ -218,6 +229,7 @@ fn render_waiting_prompt(
     area: Rect,
     state: &AiRallyState,
     kb: &KeybindingsConfig,
+    hit_map: &mut HitMap,
 ) {
     let yes = kb.confirm_yes.display();
     let no = kb.confirm_no.display();
@@ -344,6 +356,8 @@ fn render_waiting_prompt(
     );
 
     frame.render_widget(prompt, area);
+    hit_map.push(frame.area(), HitTarget::Backdrop { dismiss: false });
+    hit_map.push(area, HitTarget::OverlaySurface);
 }
 
 fn render_history(frame: &mut Frame, area: Rect, state: &AiRallyState) {
@@ -469,7 +483,7 @@ fn render_history(frame: &mut Frame, area: Rect, state: &AiRallyState) {
     frame.render_widget(list, area);
 }
 
-fn render_logs(frame: &mut Frame, area: Rect, state: &mut AiRallyState) {
+fn render_logs(frame: &mut Frame, area: Rect, state: &mut AiRallyState, hit_map: &mut HitMap) {
     let visible_height = area.height.saturating_sub(2) as usize;
     state.last_visible_log_height = visible_height;
     let total_logs = state.logs.len();
@@ -506,6 +520,28 @@ fn render_logs(frame: &mut Frame, area: Rect, state: &mut AiRallyState) {
 
     let list = List::new(items);
     frame.render_widget(list, inner_area);
+
+    hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::List(ListKind::AiRallyLog),
+        },
+    );
+    for (visible_row, index) in (scroll_offset..total_logs).take(visible_height).enumerate() {
+        hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y.saturating_add(visible_row as u16),
+                width: inner_area.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::AiRallyLog,
+                row: index,
+                index,
+            },
+        );
+    }
 
     if total_logs > visible_height {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)

--- a/src/ui/browse.rs
+++ b/src/ui/browse.rs
@@ -28,6 +28,7 @@ use crate::diff::LineType;
 use crate::github::{CommitPullRequest, CommitPullRequestState};
 use crate::symbols::Symbol;
 use crate::ui::common::truncate_with_width;
+use crate::ui::hit::{HitMap, HitTarget, ListKind, PaneKind, TabGroup};
 
 /// Narrowest the line-number gutter ever gets.
 ///
@@ -107,9 +108,12 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             };
             render_module_graph_pane(frame, state, right_panes[1], graph_focused, &graph_help);
         }
+        register_module_graph_hits(app, right_panes[1]);
     } else {
         render_content(frame, app, panes[1], !tree_focused);
     }
+
+    super::split_view::register_split_divider(app, panes[0], body);
 
     if !zen {
         render_footer(frame, app, chunks[2]);
@@ -155,7 +159,7 @@ fn render_header(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(header, area);
 }
 
-fn render_tree(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
+fn render_tree(frame: &mut Frame, app: &mut App, area: Rect, focused: bool) {
     let Some(state) = app.browse_state.as_ref() else {
         return;
     };
@@ -264,13 +268,43 @@ fn render_tree(frame: &mut Frame, app: &App, area: Rect, focused: bool) {
         _ => "Files".to_string(),
     };
 
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(border_style)
-            .title(title),
-    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style)
+        .title(title);
+    let inner_area = block.inner(area);
+    let list = List::new(items).block(block);
     frame.render_widget(list, area);
+
+    app.hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::List(ListKind::BrowseTree),
+        },
+    );
+    for (i, _) in state
+        .tree
+        .visible_rows
+        .iter()
+        .skip(offset)
+        .take(inner_height)
+        .enumerate()
+    {
+        let row = offset + i;
+        app.hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y + i as u16,
+                width: inner_area.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::BrowseTree,
+                row,
+                index: row,
+            },
+        );
+    }
 }
 
 fn render_content(frame: &mut Frame, app: &mut App, area: Rect, focused: bool) {
@@ -290,6 +324,17 @@ fn render_content(frame: &mut Frame, app: &mut App, area: Rect, focused: bool) {
         render_commit_diff(frame, state, area, border_style, bg_color, &spinner);
         return;
     }
+
+    let inner_area = area.inner(Margin {
+        vertical: 1,
+        horizontal: 1,
+    });
+    app.hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::BrowseFile,
+        },
+    );
 
     let Some(open) = state.open.as_ref() else {
         let paragraph = Paragraph::new(Line::from(Span::styled(
@@ -341,7 +386,7 @@ fn render_content(frame: &mut Frame, app: &mut App, area: Rect, focused: bool) {
         _ => None,
     };
     let content_width = area.width.saturating_sub(2) as usize;
-    let lines = content_lines(
+    let (lines, logical_lines) = content_lines_with_logical_lines(
         &window,
         state.cursor_line,
         bg_color,
@@ -365,6 +410,21 @@ fn render_content(frame: &mut Frame, app: &mut App, area: Rect, focused: bool) {
             .title(title),
     );
     frame.render_widget(paragraph, area);
+
+    for (rendered_row, line) in logical_lines.into_iter().enumerate() {
+        app.hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y.saturating_add(rendered_row as u16),
+                width: inner_area.width,
+                height: 1,
+            },
+            HitTarget::ContentLine {
+                pane: PaneKind::BrowseFile,
+                line,
+            },
+        );
+    }
 
     if total > inner_height {
         let max_scroll = total.saturating_sub(inner_height);
@@ -565,6 +625,7 @@ fn gutter_width(total: usize) -> usize {
 /// A file line wider than the pane continues on extra visual rows instead of
 /// being cut off; `max_rows` caps the emitted rows at the viewport height so
 /// the work stays O(viewport) even when every visible line wraps.
+#[cfg(test)]
 fn content_lines<'a>(
     window: &ContentWindow<'a>,
     cursor_line: usize,
@@ -574,14 +635,35 @@ fn content_lines<'a>(
     content_width: usize,
     max_rows: usize,
 ) -> Vec<Line<'a>> {
+    content_lines_with_logical_lines(
+        window,
+        cursor_line,
+        bg_color,
+        blame,
+        discussion,
+        content_width,
+        max_rows,
+    )
+    .0
+}
+
+fn content_lines_with_logical_lines<'a>(
+    window: &ContentWindow<'a>,
+    cursor_line: usize,
+    bg_color: bool,
+    blame: Option<&'a BlameGutter>,
+    discussion: Option<&DiscussionIndex>,
+    content_width: usize,
+    max_rows: usize,
+) -> (Vec<Line<'a>>, Vec<usize>) {
     let width = gutter_width(window.total);
     let discussion_width = discussion.map_or(0, |_| DISCUSSION_GUTTER_WIDTH);
     let blame_width =
         blame_gutter_width(content_width.saturating_sub(discussion_width), window.total);
 
-    let mut rows: Vec<Line<'a>> = Vec::new();
+    let mut out = WrappedRows::default();
     for (offset, cached) in window.lines.iter().enumerate() {
-        if rows.len() >= max_rows {
+        if out.len() >= max_rows {
             break;
         }
         let line_index = window.first_line + offset;
@@ -612,8 +694,6 @@ fn content_lines<'a>(
                 Color::DarkGray
             }),
         ));
-        let prefix_width: usize = prefix.iter().map(|span| span.content.width()).sum();
-
         let content: Vec<(&'a str, Style)> = cached
             .spans
             .iter()
@@ -635,16 +715,34 @@ fn content_lines<'a>(
             .collect();
 
         push_wrapped_line(
-            &mut rows,
+            &mut out,
+            line_index,
             prefix,
-            prefix_width,
             &content,
             content_width,
             max_rows,
             is_cursor && bg_color,
         );
     }
-    rows
+    (out.rows, out.logical_lines)
+}
+
+/// 折返し描画の出力バッファ。可視行とその論理行番号を常に同数で保持する。
+#[derive(Default)]
+struct WrappedRows<'a> {
+    rows: Vec<Line<'a>>,
+    logical_lines: Vec<usize>,
+}
+
+impl<'a> WrappedRows<'a> {
+    fn push(&mut self, logical_line: usize, row: Line<'a>) {
+        self.rows.push(row);
+        self.logical_lines.push(logical_line);
+    }
+
+    fn len(&self) -> usize {
+        self.rows.len()
+    }
 }
 
 /// Append one file line as visual rows no wider than `content_width` cells.
@@ -655,14 +753,15 @@ fn content_lines<'a>(
 /// keeping the line-number column straight. Sub-spans borrow slices of the
 /// same interned text as the unwrapped path, and emission stops at `max_rows`.
 fn push_wrapped_line<'a>(
-    rows: &mut Vec<Line<'a>>,
+    out: &mut WrappedRows<'a>,
+    line_index: usize,
     prefix: Vec<Span<'a>>,
-    prefix_width: usize,
     content: &[(&'a str, Style)],
     content_width: usize,
     max_rows: usize,
     cursor_bg: bool,
 ) {
+    let prefix_width: usize = prefix.iter().map(|span| span.content.width()).sum();
     let text_width = content_width.saturating_sub(prefix_width);
     // Degenerate pane: no room for text next to the gutter. Emit the single
     // row the unwrapped path produced and let the renderer clip it.
@@ -673,7 +772,7 @@ fn push_wrapped_line<'a>(
                 .iter()
                 .map(|&(text, style)| Span::styled(text, style)),
         );
-        rows.push(Line::from(spans));
+        out.push(line_index, Line::from(spans));
         return;
     }
 
@@ -710,8 +809,8 @@ fn push_wrapped_line<'a>(
                 if byte > start {
                     current.push(Span::styled(&text[start..byte], style));
                 }
-                rows.push(Line::from(std::mem::take(&mut current)));
-                if rows.len() >= max_rows {
+                out.push(line_index, Line::from(std::mem::take(&mut current)));
+                if out.len() >= max_rows {
                     return;
                 }
                 current.push(pad());
@@ -724,7 +823,7 @@ fn push_wrapped_line<'a>(
             current.push(Span::styled(&text[start..], style));
         }
     }
-    rows.push(Line::from(current));
+    out.push(line_index, Line::from(current));
 }
 
 fn blame_gutter_width(content_width: usize, total: usize) -> Option<BlameGutterWidth> {
@@ -888,7 +987,9 @@ fn render_footer(frame: &mut Frame, app: &App, area: Rect) {
 }
 
 fn render_overlay(frame: &mut Frame, app: &mut App) {
-    let Some(state) = app.browse_state.as_mut() else {
+    let frame_area = frame.area();
+    let (browse_state, hit_map) = (&mut app.browse_state, &mut app.hit_map);
+    let Some(state) = browse_state.as_mut() else {
         return;
     };
 
@@ -896,7 +997,10 @@ fn render_overlay(frame: &mut Frame, app: &mut App) {
         LineDiscussionState::Ready { index, view, .. }
             if !matches!(view, DiscussionView::Closed) =>
         {
-            render_line_discussion(frame, index, view);
+            let area = overlay_rect(frame_area, 80, 75);
+            hit_map.push(frame_area, HitTarget::Backdrop { dismiss: true });
+            hit_map.push(area, HitTarget::OverlaySurface);
+            render_line_discussion(frame, hit_map, area, index, view);
             return;
         }
         _ => {}
@@ -906,22 +1010,40 @@ fn render_overlay(frame: &mut Frame, app: &mut App) {
         pulls, selected, ..
     } = &state.pr_lookup
     {
-        render_pr_selection(frame, pulls, *selected);
+        let area = overlay_rect(frame_area, 70, 60);
+        hit_map.push(frame_area, HitTarget::Backdrop { dismiss: true });
+        hit_map.push(area, HitTarget::OverlaySurface);
+        render_pr_selection(frame, hit_map, area, pulls, *selected);
         return;
     }
 
     match state.overlay {
         BrowseOverlay::None => {}
-        BrowseOverlay::Outline { selected } => render_outline(frame, state, selected),
+        BrowseOverlay::Outline { selected } => {
+            let area = overlay_rect(frame_area, 60, 70);
+            hit_map.push(frame_area, HitTarget::Backdrop { dismiss: true });
+            hit_map.push(area, HitTarget::OverlaySurface);
+            render_outline(frame, hit_map, area, state, selected);
+        }
         BrowseOverlay::SymbolSearch {
             ref query,
             selected,
-        } => render_symbol_search(frame, state, query, selected),
+        } => {
+            let area = overlay_rect(frame_area, 80, 70);
+            hit_map.push(frame_area, HitTarget::Backdrop { dismiss: true });
+            hit_map.push(area, HitTarget::OverlaySurface);
+            render_symbol_search(frame, hit_map, area, state, query, selected);
+        }
     }
 }
 
-fn render_line_discussion(frame: &mut Frame, index: &DiscussionIndex, view: &mut DiscussionView) {
-    let area = overlay_rect(frame.area(), 80, 75);
+fn render_line_discussion(
+    frame: &mut Frame,
+    hit_map: &mut HitMap,
+    area: Rect,
+    index: &DiscussionIndex,
+    view: &mut DiscussionView,
+) {
     clear_overlay_area(frame, area);
     let content_area = if let Some(note) = index.confidence_note() {
         let rows = Layout::default()
@@ -939,6 +1061,34 @@ fn render_line_discussion(frame: &mut Frame, index: &DiscussionIndex, view: &mut
     } else {
         area
     };
+    let register_rows = |hit_map: &mut HitMap, item_heights: &[usize], offset: usize| {
+        let inner = Block::default().borders(Borders::ALL).inner(content_area);
+        let bottom = inner.y.saturating_add(inner.height);
+        let mut y = inner.y;
+        for (row, &item_height) in item_heights.iter().enumerate().skip(offset) {
+            if y >= bottom {
+                break;
+            }
+            let remaining_height = usize::from(bottom - y);
+            if item_height > remaining_height {
+                break;
+            }
+            hit_map.push(
+                Rect {
+                    x: inner.x,
+                    y,
+                    width: inner.width,
+                    height: item_height as u16,
+                },
+                HitTarget::ListRow {
+                    list: ListKind::BrowseLineDiscussion,
+                    row,
+                    index: row,
+                },
+            );
+            y = y.saturating_add(item_height as u16);
+        }
+    };
     let resolved = HashSet::new();
     match view {
         DiscussionView::Closed => {}
@@ -946,18 +1096,35 @@ fn render_line_discussion(frame: &mut Frame, index: &DiscussionIndex, view: &mut
             line,
             selected,
             scroll,
-        } => crate::ui::comment_list::render_review_thread_list_data(
-            frame,
-            content_area,
-            crate::ui::comment_list::ReviewThreadListData {
-                comments: &index.comments,
-                threads: &index.threads,
-                visible_threads: Some(index.thread_indices_at(*line)),
-                selected: *selected,
-                resolved_ids: &resolved,
-            },
-            scroll,
-        ),
+        } => {
+            let body_width = (content_area.width.saturating_sub(4) as usize).saturating_sub(4);
+            let visible_threads = index.thread_indices_at(*line);
+            let item_heights = visible_threads
+                .iter()
+                .filter_map(|thread_index| index.threads.get(*thread_index))
+                .map(|thread| {
+                    let comment = &index.comments[thread.root];
+                    2 + comment
+                        .body
+                        .lines()
+                        .map(|line| crate::ui::common::wrap_text(line, body_width).len())
+                        .sum::<usize>()
+                })
+                .collect::<Vec<_>>();
+            crate::ui::comment_list::render_review_thread_list_data(
+                frame,
+                content_area,
+                crate::ui::comment_list::ReviewThreadListData {
+                    comments: &index.comments,
+                    threads: &index.threads,
+                    visible_threads: Some(visible_threads),
+                    selected: *selected,
+                    resolved_ids: &resolved,
+                },
+                scroll,
+            );
+            register_rows(hit_map, &item_heights, *scroll);
+        }
         DiscussionView::Expanded {
             line,
             thread_position,
@@ -970,6 +1137,18 @@ fn render_line_discussion(frame: &mut Frame, index: &DiscussionIndex, view: &mut
             let Some(thread) = index.threads.get(*thread_index) else {
                 return;
             };
+            let body_width = (content_area.width.saturating_sub(4) as usize).saturating_sub(6);
+            let item_heights = std::iter::once(thread.root)
+                .chain(thread.replies.iter().copied())
+                .map(|comment_index| {
+                    let comment = &index.comments[comment_index];
+                    2 + comment
+                        .body
+                        .lines()
+                        .map(|line| crate::ui::common::wrap_text(line, body_width).len())
+                        .sum::<usize>()
+                })
+                .collect::<Vec<_>>();
             crate::ui::comment_list::render_review_thread_data(
                 frame,
                 content_area,
@@ -979,12 +1158,18 @@ fn render_line_discussion(frame: &mut Frame, index: &DiscussionIndex, view: &mut
                 scroll,
                 &resolved,
             );
+            register_rows(hit_map, &item_heights, *scroll);
         }
     }
 }
 
-fn render_pr_selection(frame: &mut Frame, pulls: &[CommitPullRequest], selected: usize) {
-    let area = overlay_rect(frame.area(), 70, 60);
+fn render_pr_selection(
+    frame: &mut Frame,
+    hit_map: &mut HitMap,
+    area: Rect,
+    pulls: &[CommitPullRequest],
+    selected: usize,
+) {
     clear_overlay_area(frame, area);
     let inner_height = area.height.saturating_sub(2) as usize;
     let offset = scroll_offset(selected, pulls.len(), inner_height);
@@ -1014,20 +1199,36 @@ fn render_pr_selection(frame: &mut Frame, pulls: &[CommitPullRequest], selected:
             )))
         })
         .collect::<Vec<_>>();
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan))
-            .title(format!(
-                "Pull requests containing this commit ({})",
-                pulls.len()
-            ))
-            .title_bottom(Line::from(Span::styled(
-                " j/k move | Enter open | Esc cancel ",
-                Style::default().fg(Color::DarkGray),
-            ))),
-    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(format!(
+            "Pull requests containing this commit ({})",
+            pulls.len()
+        ))
+        .title_bottom(Line::from(Span::styled(
+            " j/k move | Enter open | Esc cancel ",
+            Style::default().fg(Color::DarkGray),
+        )));
+    let inner_area = block.inner(area);
+    let list = List::new(items).block(block);
     frame.render_widget(list, area);
+    for visible_row in 0..pulls.len().saturating_sub(offset).min(inner_height) {
+        let row = offset + visible_row;
+        hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y.saturating_add(visible_row as u16),
+                width: inner_area.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::BrowsePrChoice,
+                row,
+                index: row,
+            },
+        );
+    }
 }
 
 /// Clear `area` for an overlay, blanking the double-width glyph it lands inside.
@@ -1063,8 +1264,13 @@ fn clear_overlay_area(frame: &mut Frame, area: Rect) {
     }
 }
 
-fn render_outline(frame: &mut Frame, state: &BrowseState, selected: usize) {
-    let area = overlay_rect(frame.area(), 60, 70);
+fn render_outline(
+    frame: &mut Frame,
+    hit_map: &mut HitMap,
+    area: Rect,
+    state: &BrowseState,
+    selected: usize,
+) {
     clear_overlay_area(frame, area);
 
     let inner_height = area.height.saturating_sub(2) as usize;
@@ -1079,17 +1285,33 @@ fn render_outline(frame: &mut Frame, state: &BrowseState, selected: usize) {
         .map(|(index, symbol)| ListItem::new(outline_row(symbol, index == selected)))
         .collect();
 
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan))
-            .title(format!("Outline ({} symbols)", symbols.len()))
-            .title_bottom(Line::from(Span::styled(
-                " j/k move | Enter jump | Esc close ",
-                Style::default().fg(Color::DarkGray),
-            ))),
-    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(format!("Outline ({} symbols)", symbols.len()))
+        .title_bottom(Line::from(Span::styled(
+            " j/k move | Enter jump | Esc close ",
+            Style::default().fg(Color::DarkGray),
+        )));
+    let inner_area = block.inner(area);
+    let list = List::new(items).block(block);
     frame.render_widget(list, area);
+    for visible_row in 0..symbols.len().saturating_sub(offset).min(inner_height) {
+        let row = offset + visible_row;
+        hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y.saturating_add(visible_row as u16),
+                width: inner_area.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::BrowseOutline,
+                row,
+                index: row,
+            },
+        );
+    }
 }
 
 fn render_module_graph_pane(
@@ -1241,6 +1463,67 @@ fn render_module_graph_ready_pane(
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
+/// モジュールグラフペインのヒット領域を登録する。
+/// レンダラーは &BrowseState 借用中で app に触れないため、同じ
+/// scroll_offset / 1 ノード 3 行のレイアウト計算をここで共有して逆写像する。
+fn register_module_graph_hits(app: &mut App, area: Rect) {
+    let Some(state) = app.browse_state.as_ref() else {
+        return;
+    };
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    let mut regions: Vec<(Rect, HitTarget)> = vec![
+        (
+            inner,
+            HitTarget::Pane {
+                pane: PaneKind::ModuleGraph,
+            },
+        ),
+        // 上枠(タイトル行)クリックで方向トグル
+        (
+            Rect {
+                x: area.x,
+                y: area.y,
+                width: area.width,
+                height: 1,
+            },
+            HitTarget::Tab {
+                group: TabGroup::GraphDirection,
+                index: 0,
+            },
+        ),
+    ];
+
+    if let ModuleGraphPaneState::Ready(panel) = &state.module_graph_pane {
+        let rows = panel.current_rows();
+        let inner_height = usize::from(inner.height);
+        let visible_nodes = inner_height.saturating_sub(3) / 3;
+        let offset = scroll_offset(panel.selected, rows.len(), visible_nodes);
+        for (visible_index, index) in (offset..rows.len().min(offset + visible_nodes)).enumerate() {
+            let y = inner.y.saturating_add(3 + (visible_index * 3) as u16);
+            if y >= inner.bottom() {
+                break;
+            }
+            regions.push((
+                Rect {
+                    x: inner.x,
+                    y,
+                    width: inner.width,
+                    height: 3.min(inner.bottom().saturating_sub(y)),
+                },
+                HitTarget::ListRow {
+                    list: ListKind::BrowseGraph,
+                    row: index,
+                    index,
+                },
+            ));
+        }
+    }
+
+    for (rect, target) in regions {
+        app.hit_map.push(rect, target);
+    }
+}
+
 fn module_graph_block<'a>(
     title: impl Into<Line<'a>>,
     border_style: Style,
@@ -1357,8 +1640,14 @@ fn outline_row(symbol: &Symbol, selected: bool) -> Line<'static> {
     ))
 }
 
-fn render_symbol_search(frame: &mut Frame, state: &BrowseState, query: &str, selected: usize) {
-    let area = overlay_rect(frame.area(), 80, 70);
+fn render_symbol_search(
+    frame: &mut Frame,
+    hit_map: &mut HitMap,
+    area: Rect,
+    state: &BrowseState,
+    query: &str,
+    selected: usize,
+) {
     clear_overlay_area(frame, area);
 
     let rows = Layout::default()
@@ -1411,17 +1700,33 @@ fn render_symbol_search(frame: &mut Frame, state: &BrowseState, query: &str, sel
         format!("{} matches", hits.len())
     };
 
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(Color::Cyan))
-            .title(title)
-            .title_bottom(Line::from(Span::styled(
-                " ↑/↓ or Ctrl-p/n move | Enter jump | Esc close ",
-                Style::default().fg(Color::DarkGray),
-            ))),
-    );
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(title)
+        .title_bottom(Line::from(Span::styled(
+            " ↑/↓ or Ctrl-p/n move | Enter jump | Esc close ",
+            Style::default().fg(Color::DarkGray),
+        )));
+    let inner_area = block.inner(rows[1]);
+    let list = List::new(items).block(block);
     frame.render_widget(list, rows[1]);
+    for visible_row in 0..hits.len().saturating_sub(offset).min(inner_height) {
+        let row = offset + visible_row;
+        hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y.saturating_add(visible_row as u16),
+                width: inner_area.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::BrowseSymbolSearch,
+                row,
+                index: row,
+            },
+        );
+    }
 }
 
 /// Keep `selected` visible inside a window `height` rows tall.

--- a/src/ui/checks_list.rs
+++ b/src/ui/checks_list.rs
@@ -12,6 +12,7 @@ use ratatui::{
 use super::common::truncate_with_width;
 use crate::app::App;
 use crate::github::CheckItem;
+use crate::ui::hit::{HitTarget, ListKind, PaneKind};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
@@ -88,9 +89,43 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         frame.render_widget(empty, chunks[1]);
     }
 
+    register_checks_list_hits(app, chunks[1]);
+
     let help_text = super::footer::footer_hint_back(&app.config.keybindings);
     let footer = Paragraph::new(help_text).block(Block::default().borders(Borders::ALL));
     frame.render_widget(footer, chunks[2]);
+}
+
+fn register_checks_list_hits(app: &mut App, area: ratatui::layout::Rect) {
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    app.hit_map.push(
+        inner,
+        HitTarget::Pane {
+            pane: PaneKind::List(ListKind::ChecksList),
+        },
+    );
+
+    let total = if app.chk.checks_loading {
+        0
+    } else {
+        app.chk.checks.as_ref().map_or(0, Vec::len)
+    };
+    let offset = app.chk.checks_scroll_offset;
+    for (visible_row, index) in (offset..total).take(usize::from(inner.height)).enumerate() {
+        app.hit_map.push(
+            ratatui::layout::Rect {
+                x: inner.x,
+                y: inner.y.saturating_add(visible_row as u16),
+                width: inner.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::ChecksList,
+                row: index,
+                index,
+            },
+        );
+    }
 }
 
 fn check_status_icon(check: &CheckItem) -> (char, Color) {

--- a/src/ui/cockpit.rs
+++ b/src/ui/cockpit.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    layout::{Alignment, Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
@@ -7,6 +7,7 @@ use ratatui::{
 };
 
 use crate::app::{App, CockpitMenuItem, LoadState};
+use crate::ui::hit::{HitTarget, ListKind, PaneKind};
 
 use super::footer;
 
@@ -32,7 +33,11 @@ fn logo_color(line_index: usize) -> Color {
 }
 
 pub fn render(frame: &mut Frame, app: &mut App) {
-    let Some(ref cockpit) = app.cockpit_state else {
+    let Some((selected, repo_available)) = app
+        .cockpit_state
+        .as_ref()
+        .map(|cockpit| (cockpit.selected_item, cockpit.repo_available))
+    else {
         return;
     };
 
@@ -46,12 +51,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         .split(frame.area());
 
     render_header(frame, app, chunks[0]);
-    render_menu(
-        frame,
-        cockpit.selected_item,
-        cockpit.repo_available,
-        chunks[1],
-    );
+    render_menu(frame, app, selected, repo_available, chunks[1]);
 
     let help_text = "q: quit  ?: help  r: refresh";
     let footer_line = footer::build_footer_line(app, help_text);
@@ -119,9 +119,10 @@ fn format_count_span<'a>(
 
 fn render_menu(
     frame: &mut Frame,
+    app: &mut App,
     selected: CockpitMenuItem,
     repo_available: bool,
-    area: ratatui::layout::Rect,
+    area: Rect,
 ) {
     let items: Vec<ListItem> = CockpitMenuItem::ALL
         .iter()
@@ -140,8 +141,10 @@ fn render_menu(
     let mut list_state = ListState::default();
     list_state.select(Some(selected.index()));
 
+    let block = Block::default().borders(Borders::ALL).title("Navigation");
+    let inner_area = block.inner(area);
     let list = List::new(items)
-        .block(Block::default().borders(Borders::ALL).title("Navigation"))
+        .block(block)
         .highlight_style(
             Style::default()
                 .bg(Color::DarkGray)
@@ -150,6 +153,31 @@ fn render_menu(
         .highlight_symbol("> ");
 
     frame.render_stateful_widget(list, area, &mut list_state);
+
+    app.hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::List(ListKind::CockpitMenu),
+        },
+    );
+    for (visible_row, index) in (list_state.offset()..CockpitMenuItem::ALL.len())
+        .take(inner_area.height as usize)
+        .enumerate()
+    {
+        app.hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y.saturating_add(visible_row as u16),
+                width: inner_area.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::CockpitMenu,
+                row: index,
+                index,
+            },
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/ui/comment_list.rs
+++ b/src/ui/comment_list.rs
@@ -1,7 +1,8 @@
 use super::common::{render_rally_status_bar, wrap_text};
 use crate::app::{App, CommentTab};
+use crate::ui::hit::{HitMap, HitTarget, ListKind, PaneKind, TabGroup};
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Margin},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
@@ -10,6 +11,49 @@ use ratatui::{
     },
     Frame,
 };
+
+fn register_comment_list_hits(
+    hit_map: &mut HitMap,
+    area: Rect,
+    item_heights: &[usize],
+    offset: usize,
+) {
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    hit_map.push(
+        inner,
+        HitTarget::Pane {
+            pane: PaneKind::List(ListKind::CommentList),
+        },
+    );
+
+    let bottom = inner.y.saturating_add(inner.height);
+    let mut y = inner.y;
+    for (row, &item_height) in item_heights.iter().enumerate().skip(offset) {
+        if y >= bottom {
+            break;
+        }
+
+        let remaining_height = usize::from(bottom - y);
+        if item_height > remaining_height {
+            break;
+        }
+        let height = item_height as u16;
+        hit_map.push(
+            Rect {
+                x: inner.x,
+                y,
+                width: inner.width,
+                height,
+            },
+            HitTarget::ListRow {
+                list: ListKind::CommentList,
+                row,
+                index: row,
+            },
+        );
+        y = y.saturating_add(height);
+    }
+}
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     if app.is_local_mode() {
@@ -44,6 +88,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         .split(frame.area());
 
     render_tab_header(frame, app, chunks[0]);
+    register_comment_tab_hits(app, chunks[0]);
 
     match app.cmt.comment_tab {
         CommentTab::Review => render_review_comments(frame, app, chunks[1]),
@@ -131,11 +176,12 @@ fn render_local_comment_list(frame: &mut Frame, app: &mut App) {
 #[allow(clippy::too_many_arguments)]
 fn render_comment_list_generic<T, F>(
     frame: &mut Frame,
-    area: ratatui::layout::Rect,
+    area: Rect,
     comments: Option<&[T]>,
     loading: bool,
     selected_index: usize,
     scroll_offset: &mut usize,
+    hit_map: &mut HitMap,
     label: &str,
     format_item: F,
 ) where
@@ -146,6 +192,7 @@ fn render_comment_list_generic<T, F>(
             .style(Style::default().fg(Color::Yellow))
             .block(Block::default().borders(Borders::ALL));
         frame.render_widget(loading_msg, area);
+        register_comment_list_hits(hit_map, area, &[], 0);
         return;
     }
 
@@ -154,6 +201,7 @@ fn render_comment_list_generic<T, F>(
             .style(Style::default().fg(Color::DarkGray))
             .block(Block::default().borders(Borders::ALL));
         frame.render_widget(empty, area);
+        register_comment_list_hits(hit_map, area, &[], 0);
         return;
     };
 
@@ -162,6 +210,7 @@ fn render_comment_list_generic<T, F>(
             .style(Style::default().fg(Color::DarkGray))
             .block(Block::default().borders(Borders::ALL));
         frame.render_widget(empty, area);
+        register_comment_list_hits(hit_map, area, &[], 0);
         return;
     }
 
@@ -176,6 +225,7 @@ fn render_comment_list_generic<T, F>(
             format_item(item, i, is_selected, body_width)
         })
         .collect();
+    let item_heights: Vec<usize> = items.iter().map(ListItem::height).collect();
 
     let mut list_state = ListState::default()
         .with_offset(*scroll_offset)
@@ -192,6 +242,7 @@ fn render_comment_list_generic<T, F>(
     frame.render_stateful_widget(list, area, &mut list_state);
 
     *scroll_offset = list_state.offset();
+    register_comment_list_hits(hit_map, area, &item_heights, *scroll_offset);
 
     if total_items > 1 {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -208,6 +259,44 @@ fn render_comment_list_generic<T, F>(
                 horizontal: 0,
             }),
             &mut scrollbar_state,
+        );
+    }
+}
+
+/// タブ見出しのクリック領域。ヘッダ行のラベル描画と同じ幅計算で位置を出す。
+fn register_comment_tab_hits(app: &mut App, area: ratatui::layout::Rect) {
+    use unicode_width::UnicodeWidthStr;
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    let review_count = app.cmt.review_threads.len();
+    let discussion_count = app
+        .cmt
+        .discussion_comments
+        .as_ref()
+        .map(|c| c.len())
+        .unwrap_or(0);
+    let review_label = format!("[Review Threads ({})]", review_count);
+    let discussion_label = format!("[Discussion ({})]", discussion_count);
+    let review_width = review_label.width() as u16;
+    let regions = [
+        (inner.x.saturating_add(1), review_width, 0u16),
+        (
+            inner.x.saturating_add(1 + review_width + 2),
+            discussion_label.width() as u16,
+            1,
+        ),
+    ];
+    for (x, width, index) in regions {
+        app.hit_map.push(
+            ratatui::layout::Rect {
+                x,
+                y: inner.y,
+                width,
+                height: 1,
+            },
+            HitTarget::Tab {
+                group: TabGroup::CommentTabs,
+                index: usize::from(index),
+            },
         );
     }
 }
@@ -315,7 +404,7 @@ fn render_review_comments(frame: &mut Frame, app: &mut App, area: ratatui::layou
         return;
     };
 
-    render_review_thread_list_data(
+    render_review_thread_list_data_with_hits(
         frame,
         area,
         ReviewThreadListData {
@@ -326,6 +415,7 @@ fn render_review_comments(frame: &mut Frame, app: &mut App, area: ratatui::layou
             resolved_ids: &resolved_ids,
         },
         &mut app.cmt.thread_scroll_offset,
+        Some(&mut app.hit_map),
     );
 }
 
@@ -339,9 +429,19 @@ pub(crate) struct ReviewThreadListData<'a> {
 
 pub(crate) fn render_review_thread_list_data(
     frame: &mut Frame,
-    area: ratatui::layout::Rect,
+    area: Rect,
     data: ReviewThreadListData<'_>,
     scroll_offset: &mut usize,
+) {
+    render_review_thread_list_data_with_hits(frame, area, data, scroll_offset, None);
+}
+
+fn render_review_thread_list_data_with_hits(
+    frame: &mut Frame,
+    area: Rect,
+    data: ReviewThreadListData<'_>,
+    scroll_offset: &mut usize,
+    hit_map: Option<&mut HitMap>,
 ) {
     let available_width = area.width.saturating_sub(4) as usize;
     let body_width = available_width.saturating_sub(4);
@@ -406,6 +506,7 @@ pub(crate) fn render_review_thread_list_data(
             Some(ListItem::new(lines))
         })
         .collect();
+    let item_heights: Vec<usize> = items.iter().map(ListItem::height).collect();
 
     let mut list_state = ListState::default()
         .with_offset(*scroll_offset)
@@ -420,6 +521,9 @@ pub(crate) fn render_review_thread_list_data(
     frame.render_stateful_widget(list, area, &mut list_state);
 
     *scroll_offset = list_state.offset();
+    if let Some(hit_map) = hit_map {
+        register_comment_list_hits(hit_map, area, &item_heights, *scroll_offset);
+    }
 
     if total_items > 1 {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -467,7 +571,7 @@ fn render_expanded_thread(frame: &mut Frame, app: &mut App, area: ratatui::layou
         HashSet::new()
     };
 
-    render_review_thread_data(
+    render_review_thread_data_with_hits(
         frame,
         area,
         all_comments,
@@ -475,17 +579,41 @@ fn render_expanded_thread(frame: &mut Frame, app: &mut App, area: ratatui::layou
         app.cmt.expanded_selected,
         &mut app.cmt.expanded_scroll_offset,
         &resolved_ids,
+        Some(&mut app.hit_map),
     );
 }
 
 pub(crate) fn render_review_thread_data(
     frame: &mut Frame,
-    area: ratatui::layout::Rect,
+    area: Rect,
     all_comments: &[crate::github::comment::ReviewComment],
     thread: &crate::app::CommentThread,
     selected: usize,
     scroll_offset: &mut usize,
     resolved_ids: &std::collections::HashSet<u64>,
+) {
+    render_review_thread_data_with_hits(
+        frame,
+        area,
+        all_comments,
+        thread,
+        selected,
+        scroll_offset,
+        resolved_ids,
+        None,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_review_thread_data_with_hits(
+    frame: &mut Frame,
+    area: Rect,
+    all_comments: &[crate::github::comment::ReviewComment],
+    thread: &crate::app::CommentThread,
+    selected: usize,
+    scroll_offset: &mut usize,
+    resolved_ids: &std::collections::HashSet<u64>,
+    hit_map: Option<&mut HitMap>,
 ) {
     let available_width = area.width.saturating_sub(4) as usize;
     let body_width = available_width.saturating_sub(6);
@@ -557,6 +685,7 @@ pub(crate) fn render_review_thread_data(
             ListItem::new(lines)
         })
         .collect();
+    let item_heights: Vec<usize> = items.iter().map(ListItem::height).collect();
 
     let total_items = comment_indices.len();
     let root_comment = &all_comments[thread.root];
@@ -582,6 +711,9 @@ pub(crate) fn render_review_thread_data(
     frame.render_stateful_widget(list, area, &mut list_state);
 
     *scroll_offset = list_state.offset();
+    if let Some(hit_map) = hit_map {
+        register_comment_list_hits(hit_map, area, &item_heights, *scroll_offset);
+    }
 
     if total_items > 1 {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -612,6 +744,7 @@ fn render_discussion_comments(frame: &mut Frame, app: &mut App, area: ratatui::l
         app.cmt.discussion_comments_loading,
         app.cmt.selected_discussion_comment,
         &mut app.cmt.discussion_comment_list_scroll_offset,
+        &mut app.hit_map,
         "discussion comments",
         |comment: &DiscussionComment, _i: usize, is_selected: bool, body_width: usize| {
             let prefix = if is_selected { "> " } else { "  " };

--- a/src/ui/diff_view/mod.rs
+++ b/src/ui/diff_view/mod.rs
@@ -1686,6 +1686,10 @@ fn render_comment_context(
         .map(|f| f.filename.as_str())
         .unwrap_or("Unknown file");
 
+    let line_display = match ctx.start_line_number {
+        Some(start) => format!("{}-{}", start, ctx.line_number),
+        None => ctx.line_number.to_string(),
+    };
     let lines = vec![
         Line::from(vec![
             Span::styled("File: ", Style::default().fg(Color::DarkGray)),
@@ -1693,10 +1697,7 @@ fn render_comment_context(
         ]),
         Line::from(vec![
             Span::styled("Line: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                ctx.line_number.to_string(),
-                Style::default().fg(Color::Yellow),
-            ),
+            Span::styled(line_display, Style::default().fg(Color::Yellow)),
         ]),
     ];
 

--- a/src/ui/diff_view/mod.rs
+++ b/src/ui/diff_view/mod.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use lasso::Rodeo;
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Margin},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap},
@@ -22,6 +22,7 @@ use crate::syntax::{
     apply_line_highlights, collect_line_highlights, collect_line_highlights_with_injections,
     get_theme, highlight_code_line, syntax_for_file, Highlighter, ParserPool,
 };
+use crate::ui::hit::{HitMap, HitTarget, PaneKind};
 
 /// Expand tab characters to spaces with fixed width.
 ///
@@ -1157,7 +1158,7 @@ pub fn render_cached_lines<'a>(
         .collect()
 }
 
-pub fn render(frame: &mut Frame, app: &App) {
+pub fn render(frame: &mut Frame, app: &mut App) {
     if app.cmt.comment_panel_open {
         render_with_inline_comment(frame, app);
         return;
@@ -1196,7 +1197,7 @@ pub fn render(frame: &mut Frame, app: &App) {
 }
 
 /// Render diff view with inline comment panel at bottom
-fn render_with_inline_comment(frame: &mut Frame, app: &App) {
+fn render_with_inline_comment(frame: &mut Frame, app: &mut App) {
     let has_rally = app.has_background_rally();
     let constraints = if has_rally {
         vec![
@@ -1250,11 +1251,12 @@ pub(crate) fn render_header(frame: &mut Frame, app: &App, area: ratatui::layout:
     frame.render_widget(header, area);
 }
 
-pub(crate) fn render_diff_content(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
+pub(crate) fn render_diff_content(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
     let visible_height = area.height.saturating_sub(2) as usize;
+    app.diff_scroll.set_visible_lines(visible_height);
 
     // Try to use cached lines if available
-    let (lines, scroll_row) = if let Some(ref cache) = app.diff_store.current {
+    let (lines, scroll_row, first_line) = if let Some(ref cache) = app.diff_store.current {
         let line_count = cache.lines.len();
         // Slice from scroll_offset so Paragraph starts at the correct logical line.
         // This avoids Wrap-induced mismatch between logical and display rows.
@@ -1275,7 +1277,7 @@ pub(crate) fn render_diff_content(frame: &mut Frame, app: &App, area: ratatui::l
             multiline_range,
             area.width.saturating_sub(2),
         );
-        (rendered, 0u16)
+        (rendered, 0u16, start)
     } else {
         // Fallback: parse without cache (should rarely happen)
         let file = app.files().get(app.selected_file);
@@ -1301,11 +1303,20 @@ pub(crate) fn render_diff_content(frame: &mut Frame, app: &App, area: ratatui::l
             },
             None => vec![Line::from("No file selected")],
         };
-        (rendered, app.diff_scroll.scroll_offset as u16)
+        (rendered, app.diff_scroll.scroll_offset as u16, 0)
     };
 
+    let block = Block::default().borders(Borders::ALL);
+    let inner_area = block.inner(area);
+    register_diff_hit_regions(
+        &mut app.hit_map,
+        inner_area,
+        &lines,
+        first_line,
+        scroll_row as usize,
+    );
     let diff_block = Paragraph::new(lines)
-        .block(Block::default().borders(Borders::ALL))
+        .block(block)
         .wrap(Wrap { trim: false })
         .scroll((scroll_row, 0));
 
@@ -1331,6 +1342,49 @@ pub(crate) fn render_diff_content(frame: &mut Frame, app: &App, area: ratatui::l
                 }),
                 &mut scrollbar_state,
             );
+        }
+    }
+}
+
+pub(super) fn register_diff_hit_regions(
+    hit_map: &mut HitMap,
+    inner_area: Rect,
+    lines: &[Line<'_>],
+    first_line: usize,
+    mut hidden_rows: usize,
+) {
+    hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::Diff,
+        },
+    );
+
+    let mut visible_row = 0usize;
+    for (relative_line, line) in lines.iter().enumerate() {
+        let rendered_rows = Paragraph::new(line.clone())
+            .wrap(Wrap { trim: false })
+            .line_count(inner_area.width);
+        let skipped_rows = hidden_rows.min(rendered_rows);
+        hidden_rows -= skipped_rows;
+
+        for _ in skipped_rows..rendered_rows {
+            if visible_row >= inner_area.height as usize {
+                return;
+            }
+            hit_map.push(
+                Rect {
+                    x: inner_area.x,
+                    y: inner_area.y.saturating_add(visible_row as u16),
+                    width: inner_area.width,
+                    height: 1,
+                },
+                HitTarget::ContentLine {
+                    pane: PaneKind::Diff,
+                    line: first_line.saturating_add(relative_line),
+                },
+            );
+            visible_row += 1;
         }
     }
 }
@@ -1470,7 +1524,7 @@ fn render_footer(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 }
 
 /// Render inline comments panel for current line
-fn render_inline_comments(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
+fn render_inline_comments(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
     let indices = app.get_comment_indices_at_current_line();
 
     let mut lines: Vec<Line> = vec![];
@@ -1531,6 +1585,7 @@ fn render_inline_comments(frame: &mut Frame, app: &App, area: ratatui::layout::R
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow))
         .title(title);
+    let inner_area = block.inner(area);
 
     let paragraph = Paragraph::new(lines)
         .block(block)
@@ -1538,6 +1593,12 @@ fn render_inline_comments(frame: &mut Frame, app: &App, area: ratatui::layout::R
         .scroll((app.cmt.comment_panel_scroll, 0));
 
     frame.render_widget(paragraph, area);
+    app.hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::CommentPanel,
+        },
+    );
 
     if total_lines > 1 {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)

--- a/src/ui/file_list.rs
+++ b/src/ui/file_list.rs
@@ -12,9 +12,9 @@ use ratatui::{
 use super::common::{
     build_ci_status_span, build_pr_info, render_rally_status_bar, render_update_bar,
 };
-use crate::app::App;
-use crate::app::TreeRow;
+use crate::app::{App, TreeRow};
 use crate::github::ChangedFile;
+use crate::ui::hit::{HitTarget, ListKind, PaneKind};
 use std::collections::HashMap;
 
 pub fn render(frame: &mut Frame, app: &mut App) {
@@ -205,6 +205,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         }
     }
 
+    register_file_list_hits(app, chunks[1]);
+
     let mut next_chunk = 2;
 
     if has_filter_bar {
@@ -228,6 +230,64 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     let footer_line = super::footer::build_footer_line(app, &help_text);
     let footer = Paragraph::new(footer_line).block(super::footer::build_footer_block(app));
     frame.render_widget(footer, chunks[next_chunk]);
+}
+
+pub(super) fn register_file_list_hits(app: &mut App, area: ratatui::layout::Rect) {
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    app.hit_map.push(
+        inner,
+        HitTarget::Pane {
+            pane: PaneKind::List(ListKind::FileList),
+        },
+    );
+
+    let visible_height = usize::from(inner.height);
+    let rows: Vec<(usize, usize)> = if let Some(ref filter) = app.file_list_filter {
+        filter
+            .matched_indices
+            .iter()
+            .enumerate()
+            .skip(app.file_list_scroll_offset)
+            .take(visible_height)
+            .map(|(row, &index)| (row, index))
+            .collect()
+    } else if app.is_file_tree_active() {
+        let tree = app.file_tree_state.as_ref().unwrap();
+        tree.visible_rows
+            .iter()
+            .enumerate()
+            .skip(tree.scroll_offset)
+            .take(visible_height)
+            .map(|(row, entry)| {
+                let index = match entry {
+                    TreeRow::File { index, .. } => *index,
+                    TreeRow::Dir { .. } => row,
+                };
+                (row, index)
+            })
+            .collect()
+    } else {
+        (app.file_list_scroll_offset..app.files().len())
+            .take(visible_height)
+            .map(|index| (index, index))
+            .collect()
+    };
+
+    for (visible_row, (row, index)) in rows.into_iter().enumerate() {
+        app.hit_map.push(
+            ratatui::layout::Rect {
+                x: inner.x,
+                y: inner.y.saturating_add(visible_row as u16),
+                width: inner.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::FileList,
+                row,
+                index,
+            },
+        );
+    }
 }
 
 pub fn render_loading(frame: &mut Frame, app: &App) {

--- a/src/ui/git_ops.rs
+++ b/src/ui/git_ops.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Margin},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
@@ -15,6 +15,7 @@ use super::common::render_rally_status_bar;
 use super::diff_view;
 use crate::app::{App, AppState, CommitLogState, FileStatus, GitOpsState, LeftPaneFocus, TreeRow};
 use crate::github::{format_relative_time, PrCommit};
+use crate::ui::hit::{HitMap, HitTarget, ListKind, PaneKind};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let has_rally = app.has_background_rally();
@@ -62,7 +63,8 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
     render_tree_pane(frame, app, left_chunks[0], is_tree_focused);
     render_commits_pane(frame, app, left_chunks[1], is_commits_focused);
-    render_diff_pane(frame, &*app, h_chunks[1], is_diff_focused);
+    render_diff_pane(frame, app, h_chunks[1], is_diff_focused);
+    super::split_view::register_split_divider(app, h_chunks[0], outer_chunks[0]);
 
     if has_rally {
         render_rally_status_bar(frame, outer_chunks[1], app);
@@ -135,13 +137,13 @@ fn render_tree_pane(
             .map(|(i, row)| build_tree_row_item(ops, row, i == selected))
             .collect();
 
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color))
+            .title(format!("Files ({})", ops.entries.len()));
+        let inner_area = block.inner(chunks[1]);
         let list = List::new(items)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(Style::default().fg(border_color))
-                    .title(format!("Files ({})", ops.entries.len())),
-            )
+            .block(block)
             .highlight_style(Style::default().bg(Color::DarkGray));
 
         let mut list_state = ListState::default()
@@ -152,6 +154,42 @@ fn render_tree_pane(
 
         if let Some(ref mut ops) = app.git_ops_state {
             ops.tree.scroll_offset = list_state.offset();
+        }
+
+        app.hit_map.push(
+            inner_area,
+            HitTarget::Pane {
+                pane: PaneKind::List(ListKind::GitOpsTree),
+            },
+        );
+        let offset = list_state.offset();
+        if let Some(ref ops) = app.git_ops_state {
+            for (row, tree_row) in ops
+                .tree
+                .visible_rows
+                .iter()
+                .enumerate()
+                .skip(offset)
+                .take(inner_area.height as usize)
+            {
+                let index = match tree_row {
+                    TreeRow::File { index, .. } => *index,
+                    TreeRow::Dir { .. } => row,
+                };
+                app.hit_map.push(
+                    Rect {
+                        x: inner_area.x,
+                        y: inner_area.y + (row - offset) as u16,
+                        width: inner_area.width,
+                        height: 1,
+                    },
+                    HitTarget::ListRow {
+                        list: ListKind::GitOpsTree,
+                        row,
+                        index,
+                    },
+                );
+            }
         }
 
         if total > 1 {
@@ -233,7 +271,12 @@ fn render_tree_pane(
     }
 }
 
-fn render_diff_pane(frame: &mut Frame, app: &App, area: ratatui::layout::Rect, is_focused: bool) {
+fn render_diff_pane(
+    frame: &mut Frame,
+    app: &mut App,
+    area: ratatui::layout::Rect,
+    is_focused: bool,
+) {
     let border_color = if is_focused {
         Color::Yellow
     } else {
@@ -278,9 +321,23 @@ fn render_diff_pane(frame: &mut Frame, app: &App, area: ratatui::layout::Rect, i
     frame.render_widget(header, chunks[0]);
 
     if is_commit_diff {
-        render_commit_diff_body(frame, &ops.commit_log, chunks[1], border_color, bg_color);
+        render_commit_diff_body(
+            frame,
+            &ops.commit_log,
+            chunks[1],
+            border_color,
+            bg_color,
+            &mut app.hit_map,
+        );
     } else {
-        render_diff_body(frame, ops, chunks[1], border_color, bg_color);
+        render_diff_body(
+            frame,
+            ops,
+            chunks[1],
+            border_color,
+            bg_color,
+            &mut app.hit_map,
+        );
     }
 
     let footer_text_owned;
@@ -305,33 +362,41 @@ fn render_diff_body(
     area: ratatui::layout::Rect,
     border_color: Color,
     bg_color: bool,
+    hit_map: &mut HitMap,
 ) {
-    let lines: Vec<Line> = if let Some(ref cache) = ops.diff_store.current {
-        let visible_height = area.height.saturating_sub(2) as usize;
-        let line_count = cache.lines.len();
-        let visible_start = ops
-            .diff_scroll
-            .scroll_offset
-            .saturating_sub(2)
-            .min(line_count);
-        let visible_end = (ops.diff_scroll.scroll_offset + visible_height + 5).min(line_count);
+    let (lines, first_logical_line): (Vec<Line>, Option<usize>) =
+        if let Some(ref cache) = ops.diff_store.current {
+            let visible_height = area.height.saturating_sub(2) as usize;
+            let line_count = cache.lines.len();
+            let visible_start = ops
+                .diff_scroll
+                .scroll_offset
+                .saturating_sub(2)
+                .min(line_count);
+            let visible_end = (ops.diff_scroll.scroll_offset + visible_height + 5).min(line_count);
 
-        let empty_comments = HashSet::new();
-        diff_view::render_cached_lines(
-            cache,
-            visible_start..visible_end,
-            ops.diff_scroll.selected_line,
-            &empty_comments,
-            bg_color,
-            None,
-            area.width.saturating_sub(2),
-        )
-    } else {
-        vec![Line::from(Span::styled(
-            "Select a file to preview diff",
-            Style::default().fg(Color::DarkGray),
-        ))]
-    };
+            let empty_comments = HashSet::new();
+            (
+                diff_view::render_cached_lines(
+                    cache,
+                    visible_start..visible_end,
+                    ops.diff_scroll.selected_line,
+                    &empty_comments,
+                    bg_color,
+                    None,
+                    area.width.saturating_sub(2),
+                ),
+                Some(visible_start),
+            )
+        } else {
+            (
+                vec![Line::from(Span::styled(
+                    "Select a file to preview diff",
+                    Style::default().fg(Color::DarkGray),
+                ))],
+                None,
+            )
+        };
 
     let adjusted_scroll = if ops.diff_store.current.is_some() {
         let visible_start = ops.diff_scroll.scroll_offset.saturating_sub(2);
@@ -340,12 +405,20 @@ fn render_diff_body(
         ops.diff_scroll.scroll_offset as u16
     };
 
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    let inner_area = block.inner(area);
+    register_diff_body_hits(
+        hit_map,
+        inner_area,
+        &lines,
+        first_logical_line,
+        adjusted_scroll as usize,
+    );
+
     let diff_block = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(border_color)),
-        )
+        .block(block)
         .wrap(Wrap { trim: false })
         .scroll((adjusted_scroll, 0));
     frame.render_widget(diff_block, area);
@@ -380,17 +453,24 @@ fn render_commit_diff_body(
     area: ratatui::layout::Rect,
     border_color: Color,
     bg_color: bool,
+    hit_map: &mut HitMap,
 ) {
-    let lines: Vec<Line> = if cl.diff_loading {
-        vec![Line::from(Span::styled(
-            "Loading diff...",
-            Style::default().fg(Color::Yellow),
-        ))]
+    let (lines, first_logical_line): (Vec<Line>, Option<usize>) = if cl.diff_loading {
+        (
+            vec![Line::from(Span::styled(
+                "Loading diff...",
+                Style::default().fg(Color::Yellow),
+            ))],
+            None,
+        )
     } else if let Some(ref error) = cl.diff_error {
-        vec![Line::from(Span::styled(
-            format!("Error: {}", error),
-            Style::default().fg(Color::Red),
-        ))]
+        (
+            vec![Line::from(Span::styled(
+                format!("Error: {}", error),
+                Style::default().fg(Color::Red),
+            ))],
+            None,
+        )
     } else if let Some(ref cache) = cl.diff_store.current {
         let visible_height = area.height.saturating_sub(2) as usize;
         let line_count = cache.lines.len();
@@ -402,20 +482,26 @@ fn render_commit_diff_body(
         let visible_end = (cl.diff_scroll.scroll_offset + visible_height + 5).min(line_count);
 
         let empty_comments = HashSet::new();
-        diff_view::render_cached_lines(
-            cache,
-            visible_start..visible_end,
-            cl.diff_scroll.selected_line,
-            &empty_comments,
-            bg_color,
-            None,
-            area.width.saturating_sub(2),
+        (
+            diff_view::render_cached_lines(
+                cache,
+                visible_start..visible_end,
+                cl.diff_scroll.selected_line,
+                &empty_comments,
+                bg_color,
+                None,
+                area.width.saturating_sub(2),
+            ),
+            Some(visible_start),
         )
     } else {
-        vec![Line::from(Span::styled(
-            "Select a commit to preview diff",
-            Style::default().fg(Color::DarkGray),
-        ))]
+        (
+            vec![Line::from(Span::styled(
+                "Select a commit to preview diff",
+                Style::default().fg(Color::DarkGray),
+            ))],
+            None,
+        )
     };
 
     let adjusted_scroll = if cl.diff_store.current.is_some() {
@@ -425,12 +511,20 @@ fn render_commit_diff_body(
         cl.diff_scroll.scroll_offset as u16
     };
 
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    let inner_area = block.inner(area);
+    register_diff_body_hits(
+        hit_map,
+        inner_area,
+        &lines,
+        first_logical_line,
+        adjusted_scroll as usize,
+    );
+
     let diff_block = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(border_color)),
-        )
+        .block(block)
         .wrap(Wrap { trim: false })
         .scroll((adjusted_scroll, 0));
     frame.render_widget(diff_block, area);
@@ -455,6 +549,57 @@ fn render_commit_diff_body(
                 }),
                 &mut scrollbar_state,
             );
+        }
+    }
+}
+
+fn register_diff_body_hits(
+    hit_map: &mut HitMap,
+    area: Rect,
+    lines: &[Line<'_>],
+    first_logical_line: Option<usize>,
+    visual_scroll: usize,
+) {
+    hit_map.push(
+        area,
+        HitTarget::Pane {
+            pane: PaneKind::GitOpsDiff,
+        },
+    );
+
+    let Some(first_logical_line) = first_logical_line else {
+        return;
+    };
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let visible_end = visual_scroll.saturating_add(area.height as usize);
+    let mut rendered_row = 0usize;
+    for (line_offset, line) in lines.iter().enumerate() {
+        let line_height = Paragraph::new(line.clone())
+            .wrap(Wrap { trim: false })
+            .line_count(area.width);
+        let line_end = rendered_row.saturating_add(line_height);
+
+        for row in rendered_row.max(visual_scroll)..line_end.min(visible_end) {
+            hit_map.push(
+                Rect {
+                    x: area.x,
+                    y: area.y.saturating_add((row - visual_scroll) as u16),
+                    width: area.width,
+                    height: 1,
+                },
+                HitTarget::ContentLine {
+                    pane: PaneKind::GitOpsDiff,
+                    line: first_logical_line + line_offset,
+                },
+            );
+        }
+
+        rendered_row = line_end;
+        if rendered_row >= visible_end {
+            break;
         }
     }
 }
@@ -548,13 +693,13 @@ fn render_commits_pane(
         format!("Commits ({})", count_str)
     };
 
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color))
+        .title(title);
+    let inner_area = block.inner(area);
     let list = List::new(items)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(border_color))
-                .title(title),
-        )
+        .block(block)
         .highlight_style(Style::default().bg(Color::DarkGray));
 
     let mut list_state = ListState::default()
@@ -563,6 +708,29 @@ fn render_commits_pane(
 
     frame.render_stateful_widget(list, area, &mut list_state);
     cl.scroll_offset = list_state.offset();
+
+    app.hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::List(ListKind::GitOpsCommits),
+        },
+    );
+    let offset = list_state.offset();
+    for row in offset..total.min(offset.saturating_add(inner_area.height as usize)) {
+        app.hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y + (row - offset) as u16,
+                width: inner_area.width,
+                height: 1,
+            },
+            HitTarget::ListRow {
+                list: ListKind::GitOpsCommits,
+                row,
+                index: row,
+            },
+        );
+    }
 
     if total > 1 {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -1018,7 +1186,7 @@ mod tests {
     }
 
     /// render_diff_pane を描画し、diff body 部分のテキストを返す
-    fn render_diff_pane_body(app: &App) -> String {
+    fn render_diff_pane_body(app: &mut App) -> String {
         let backend = TestBackend::new(80, 15);
         let mut terminal = Terminal::new(backend).unwrap();
         let area = Rect::new(0, 0, 80, 15);
@@ -1055,7 +1223,7 @@ mod tests {
         ops.left_return_focus = LeftPaneFocus::Commits;
         app.git_ops_state = Some(ops);
 
-        assert_snapshot!(render_diff_pane_body(&app), @"
+        assert_snapshot!(render_diff_pane_body(&mut app), @"
         ┌──────────────────────────────────────────────────────────────────────────────┐
         │Loading diff...                                                               │
         │                                                                              │
@@ -1080,7 +1248,7 @@ mod tests {
         ops.left_return_focus = LeftPaneFocus::Commits;
         app.git_ops_state = Some(ops);
 
-        assert_snapshot!(render_diff_pane_body(&app), @"
+        assert_snapshot!(render_diff_pane_body(&mut app), @"
         ┌──────────────────────────────────────────────────────────────────────────────┐
         │Error: gh: Not Found (HTTP 404)                                               │
         │                                                                              │
@@ -1100,7 +1268,7 @@ mod tests {
         ops.left_return_focus = LeftPaneFocus::Commits;
         app.git_ops_state = Some(ops);
 
-        assert_snapshot!(render_diff_pane_body(&app), @"
+        assert_snapshot!(render_diff_pane_body(&mut app), @"
         ┌──────────────────────────────────────────────────────────────────────────────┐
         │Select a commit to preview diff                                               │
         │                                                                              │
@@ -1140,7 +1308,7 @@ mod tests {
         assert!(cl.diff_loading);
         assert!(cl.diff_receiver.is_some());
 
-        assert_snapshot!(render_diff_pane_body(&app), @"
+        assert_snapshot!(render_diff_pane_body(&mut app), @"
         ┌──────────────────────────────────────────────────────────────────────────────┐
         │Loading diff...                                                               │
         │                                                                              │

--- a/src/ui/help.rs
+++ b/src/ui/help.rs
@@ -10,6 +10,7 @@ use crate::ai::{PromptLoader, PromptSource};
 use crate::app::{App, HelpTab};
 use crate::config::{Config, KeybindingsConfig};
 use crate::syntax::available_themes;
+use crate::ui::hit::{HitTarget, PaneKind, TabGroup};
 
 /// Format a key display with padding for alignment
 fn fmt_key(key: &str, width: usize) -> String {
@@ -32,6 +33,15 @@ pub fn render(frame: &mut Frame, app: &mut App) {
         .split(frame.area());
 
     render_tab_header(frame, app, chunks[0]);
+    register_help_tab_hits(app, chunks[0]);
+
+    let body_area = Block::default().borders(Borders::ALL).inner(chunks[1]);
+    app.hit_map.push(
+        body_area,
+        HitTarget::Pane {
+            pane: PaneKind::Help,
+        },
+    );
 
     match app.help_tab {
         HelpTab::Keybindings => render_keybindings_tab(frame, app, chunks[1]),
@@ -39,6 +49,35 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     }
 
     render_help_footer(frame, app, chunks[2]);
+}
+
+/// タブ見出しのクリック領域。Tabs ウィジェットの描画順
+/// (` Keybindings │ Config `)と同じ幅計算で位置を出す。
+fn register_help_tab_hits(app: &mut App, area: Rect) {
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    let first_width = " Keybindings ".len() as u16;
+    let regions = [
+        (inner.x, first_width, 0),
+        (
+            inner.x.saturating_add(first_width + 1),
+            " Config ".len() as u16,
+            1,
+        ),
+    ];
+    for (x, width, index) in regions {
+        app.hit_map.push(
+            Rect {
+                x,
+                y: inner.y,
+                width,
+                height: 1,
+            },
+            HitTarget::Tab {
+                group: TabGroup::HelpTabs,
+                index,
+            },
+        );
+    }
 }
 
 fn render_tab_header(frame: &mut Frame, app: &App, area: Rect) {
@@ -304,6 +343,25 @@ pub fn build_config_lines(config: &Config) -> Vec<Line<'static>> {
         ),
         Line::from(""),
         Line::from(vec![Span::styled(
+            "Mouse Settings",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )]),
+        config_value_line(
+            "Mouse support",
+            &config.mouse.enabled.to_string(),
+            "mouse.enabled",
+            overrides,
+        ),
+        config_value_line(
+            "Wheel step",
+            &config.mouse.wheel_step.to_string(),
+            "mouse.wheel_step",
+            overrides,
+        ),
+        Line::from(""),
+        Line::from(vec![Span::styled(
             "Editor",
             Style::default()
                 .fg(Color::Yellow)
@@ -552,6 +610,10 @@ fn build_help_lines(kb: &KeybindingsConfig) -> Vec<Line<'static>> {
         Line::from(format!(
             "{}  Toggle zen mode",
             fmt_key(&kb.toggle_zen_mode.display(), key_width)
+        )),
+        Line::from(format!(
+            "{}  Toggle mouse capture (release to copy text with the terminal)",
+            fmt_key(&kb.toggle_mouse.display(), key_width)
         )),
         Line::from(format!(
             "{}  Filter list",

--- a/src/ui/hit.rs
+++ b/src/ui/hit.rs
@@ -1,0 +1,273 @@
+//! フレームレイアウトのヒットマップ
+//!
+//! レンダラーは描画のその場で「この矩形はこの意味」を登録する。折返し行・
+//! フィルタ済みインデックス・中央寄せオフセットなどの逆写像を入力側で
+//! 複製しないため、登録時点で解決済みの値(実インデックス・論理行)を持たせる。
+//!
+//! 判定は登録の逆順(後に描いたもの=最上位が勝つ)。オーバーレイは描画順で
+//! 後に登録されるため、z-order が自然に表現される。
+
+use ratatui::layout::{Position, Rect};
+
+/// リスト画面の識別子(HitTarget::ListRow / PaneKind::List が指す先)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListKind {
+    PrList,
+    FileList,
+    ChecksList,
+    IssueList,
+    CockpitMenu,
+    AiRallyLog,
+    CommentList,
+    IssueCommentList,
+    BrowseTree,
+    BrowseGraph,
+    GitOpsTree,
+    GitOpsCommits,
+    IssueLinkedPrs,
+    // オーバーレイ内のリスト
+    SymbolPopup,
+    BrowseOutline,
+    BrowseSymbolSearch,
+    BrowsePrChoice,
+    BrowseLineDiscussion,
+}
+
+/// スクロール/フォーカス対象となるペインの識別子
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PaneKind {
+    List(ListKind),
+    Diff,
+    GitOpsDiff,
+    PrDescription,
+    Help,
+    BrowseFile,
+    IssueBody,
+    TextArea,
+    ShellOutput,
+    ModuleGraph,
+    /// 差分ビューのインラインコメントパネル
+    CommentPanel,
+    /// Git 破壊的操作確認のシミュレーションプレビュー
+    GitOpsPreview,
+}
+
+/// ドラッグでリサイズ可能なスプリット境界
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SplitKind {
+    LeftPanel,
+}
+
+/// クリック可能なタブ群
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TabGroup {
+    CommentTabs,
+    HelpTabs,
+    GraphDirection,
+    IssueDetailFocus,
+}
+
+/// 確認ダイアログの識別子
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DialogKind {
+    GitOpsConfirm,
+    RallyPermission,
+    RallyPost,
+    ApproveEmptyBody,
+}
+
+/// ヒット判定の対象。描画時に解決済みの値を保持する。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HitTarget {
+    /// リストの 1 行。`row` は選択フィールドが使う表示空間の位置
+    /// (フィルタ中は filter.selected、ツリーは行番号)。`index` は
+    /// フィルタ変換等を済ませた実インデックス(非フィルタ時は row と同値)。
+    ListRow {
+        list: ListKind,
+        row: usize,
+        index: usize,
+    },
+    /// スクロールテキスト/差分の 1 行。`line` は論理行(折返し解決済み)。
+    ContentLine { pane: PaneKind, line: usize },
+    /// ペイン全体(行より下に登録し、行以外の余白のホイール/フォーカスを拾う)
+    Pane { pane: PaneKind },
+    /// スプリット境界(ドラッグでリサイズ)。body_x/body_width は分割対象領域の
+    /// 水平範囲で、ドラッグ中の x 座標→パーセント換算に使う。
+    SplitDivider {
+        split: SplitKind,
+        body_x: u16,
+        body_width: u16,
+    },
+    /// クリック可能なタブ
+    Tab { group: TabGroup, index: usize },
+    /// ダイアログの応答ボタン(yes=true が confirm_yes 相当)
+    DialogButton { dialog: DialogKind, yes: bool },
+    /// オーバーレイの背面。dismiss=true なら外側クリックで閉じる。
+    Backdrop { dismiss: bool },
+    /// オーバーレイのコンテンツ面。内部の非操作領域のクリックを消費する。
+    OverlaySurface,
+}
+
+/// 1 フレーム分のヒット領域。描画のたびに clear→登録し直す(容量は維持)。
+#[derive(Debug, Default)]
+pub struct HitMap {
+    regions: Vec<(Rect, HitTarget)>,
+}
+
+impl HitMap {
+    pub fn clear(&mut self) {
+        self.regions.clear();
+    }
+
+    pub fn push(&mut self, rect: Rect, target: HitTarget) {
+        if rect.width > 0 && rect.height > 0 {
+            self.regions.push((rect, target));
+        }
+    }
+
+    /// 座標に重なる最上位(=最後に登録された)ターゲットを返す
+    pub fn hit(&self, x: u16, y: u16) -> Option<HitTarget> {
+        let pos = Position { x, y };
+        self.regions
+            .iter()
+            .rev()
+            .find(|(rect, _)| rect.contains(pos))
+            .map(|(_, target)| *target)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.regions.is_empty()
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.regions.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: u16, y: u16, w: u16, h: u16) -> Rect {
+        Rect {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn test_hit_returns_none_for_empty_map() {
+        let map = HitMap::default();
+        assert_eq!(map.hit(0, 0), None);
+    }
+
+    #[test]
+    fn test_hit_returns_none_outside_all_regions() {
+        let mut map = HitMap::default();
+        map.push(
+            rect(0, 0, 10, 5),
+            HitTarget::Pane {
+                pane: PaneKind::Diff,
+            },
+        );
+        assert_eq!(map.hit(10, 0), None, "右端は排他境界");
+        assert_eq!(map.hit(0, 5), None, "下端は排他境界");
+    }
+
+    #[test]
+    fn test_hit_last_registered_wins() {
+        let mut map = HitMap::default();
+        map.push(
+            rect(0, 0, 20, 20),
+            HitTarget::Pane {
+                pane: PaneKind::Diff,
+            },
+        );
+        map.push(
+            rect(5, 5, 5, 1),
+            HitTarget::ListRow {
+                list: ListKind::PrList,
+                row: 3,
+                index: 3,
+            },
+        );
+        assert_eq!(
+            map.hit(6, 5),
+            Some(HitTarget::ListRow {
+                list: ListKind::PrList,
+                row: 3,
+                index: 3
+            })
+        );
+        assert_eq!(
+            map.hit(1, 1),
+            Some(HitTarget::Pane {
+                pane: PaneKind::Diff
+            })
+        );
+    }
+
+    #[test]
+    fn test_hit_overlay_z_order() {
+        let mut map = HitMap::default();
+        map.push(
+            rect(0, 0, 40, 20),
+            HitTarget::ListRow {
+                list: ListKind::FileList,
+                row: 0,
+                index: 0,
+            },
+        );
+        map.push(rect(0, 0, 40, 20), HitTarget::Backdrop { dismiss: true });
+        map.push(rect(10, 5, 20, 10), HitTarget::OverlaySurface);
+        map.push(
+            rect(11, 6, 18, 1),
+            HitTarget::ListRow {
+                list: ListKind::BrowseTree,
+                row: 2,
+                index: 2,
+            },
+        );
+
+        assert_eq!(
+            map.hit(0, 0),
+            Some(HitTarget::Backdrop { dismiss: true }),
+            "オーバーレイ外は Backdrop(下のリストには届かない)"
+        );
+        assert_eq!(
+            map.hit(15, 8),
+            Some(HitTarget::OverlaySurface),
+            "オーバーレイ内の余白は Surface が消費"
+        );
+        assert_eq!(
+            map.hit(12, 6),
+            Some(HitTarget::ListRow {
+                list: ListKind::BrowseTree,
+                row: 2,
+                index: 2
+            })
+        );
+    }
+
+    #[test]
+    fn test_zero_size_rect_is_not_registered() {
+        let mut map = HitMap::default();
+        map.push(rect(0, 0, 0, 5), HitTarget::OverlaySurface);
+        map.push(rect(0, 0, 5, 0), HitTarget::OverlaySurface);
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn test_clear_keeps_capacity() {
+        let mut map = HitMap::default();
+        for i in 0..100 {
+            map.push(rect(0, i, 10, 1), HitTarget::OverlaySurface);
+        }
+        map.clear();
+        assert_eq!(map.len(), 0);
+        assert_eq!(map.hit(0, 0), None);
+    }
+}

--- a/src/ui/issue_comment_list.rs
+++ b/src/ui/issue_comment_list.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Margin},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
@@ -13,6 +13,7 @@ use unicode_width::UnicodeWidthStr;
 use super::common::{truncate_with_width, wrap_text};
 use crate::app::App;
 use crate::github::IssueComment;
+use crate::ui::hit::{HitTarget, ListKind, PaneKind};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let Some(ref state) = app.issue_state else {
@@ -93,6 +94,7 @@ fn render_list(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
             format_comment_item(comment, i, i == state.selected_issue_comment, body_width)
         })
         .collect();
+    let item_heights: Vec<usize> = items.iter().map(ListItem::height).collect();
 
     let total_items = comments.len();
 
@@ -100,16 +102,45 @@ fn render_list(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
         .with_offset(state.issue_comment_list_scroll_offset)
         .with_selected(Some(state.selected_issue_comment));
 
-    let list = List::new(items)
-        .block(Block::default().borders(Borders::ALL))
-        .highlight_style(
-            Style::default()
-                .fg(Color::Yellow)
-                .add_modifier(Modifier::BOLD),
-        );
+    let block = Block::default().borders(Borders::ALL);
+    let inner_area = block.inner(area);
+    let list = List::new(items).block(block).highlight_style(
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    );
     frame.render_stateful_widget(list, area, &mut list_state);
 
-    state.issue_comment_list_scroll_offset = list_state.offset();
+    let final_offset = list_state.offset();
+    state.issue_comment_list_scroll_offset = final_offset;
+
+    app.hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::List(ListKind::IssueCommentList),
+        },
+    );
+    let mut row_offset = 0usize;
+    for (index, &item_height) in item_heights.iter().enumerate().skip(final_offset) {
+        let remaining_height = (inner_area.height as usize).saturating_sub(row_offset);
+        if item_height > remaining_height {
+            break;
+        }
+        app.hit_map.push(
+            Rect {
+                x: inner_area.x,
+                y: inner_area.y + row_offset as u16,
+                width: inner_area.width,
+                height: item_height as u16,
+            },
+            HitTarget::ListRow {
+                list: ListKind::IssueCommentList,
+                row: index,
+                index,
+            },
+        );
+        row_offset += item_height;
+    }
 
     if total_items > 1 {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)

--- a/src/ui/issue_detail.rs
+++ b/src/ui/issue_detail.rs
@@ -11,6 +11,7 @@ use ratatui::{
 
 use crate::app::{App, IssueDetailFocus};
 use crate::diff::LineType;
+use crate::ui::hit::{HitTarget, ListKind, PaneKind};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     {
@@ -112,6 +113,12 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     };
 
     render_body(frame, app, chunks[1], body_border_style);
+    app.hit_map.push(
+        Block::default().borders(Borders::ALL).inner(chunks[1]),
+        HitTarget::Pane {
+            pane: PaneKind::IssueBody,
+        },
+    );
 
     let linked_prs_chunk_idx = if linked_prs_height > 0 || linked_prs_loading {
         Some(2)
@@ -201,6 +208,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
                 None
             });
 
+            let item_count = items.len();
             let list = List::new(items)
                 .block(
                     Block::default()
@@ -210,6 +218,31 @@ pub fn render(frame: &mut Frame, app: &mut App) {
                 )
                 .highlight_style(Style::default().bg(Color::DarkGray));
             frame.render_stateful_widget(list, chunks[idx], &mut list_state);
+
+            let inner = Block::default().borders(Borders::ALL).inner(chunks[idx]);
+            app.hit_map.push(
+                inner,
+                HitTarget::Pane {
+                    pane: PaneKind::List(ListKind::IssueLinkedPrs),
+                },
+            );
+            let offset = list_state.offset();
+            let visible = usize::from(inner.height);
+            for (visible_row, row) in (offset..item_count.min(offset + visible)).enumerate() {
+                app.hit_map.push(
+                    ratatui::layout::Rect {
+                        x: inner.x,
+                        y: inner.y.saturating_add(visible_row as u16),
+                        width: inner.width,
+                        height: 1,
+                    },
+                    HitTarget::ListRow {
+                        list: ListKind::IssueLinkedPrs,
+                        row,
+                        index: row,
+                    },
+                );
+            }
         }
     }
 

--- a/src/ui/issue_list.rs
+++ b/src/ui/issue_list.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Margin},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
@@ -14,6 +14,7 @@ use unicode_width::UnicodeWidthStr;
 use super::common::truncate_with_width;
 use crate::app::App;
 use crate::github::IssueSummary;
+use crate::ui::hit::{HitTarget, ListKind, PaneKind};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let Some(ref state) = app.issue_state else {
@@ -52,7 +53,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
                 .block(Block::default().borders(Borders::ALL).title("Issues"));
             frame.render_widget(empty, chunks[1]);
         } else {
-            let (display_issues, display_selected, total_display) =
+            let (display_issues, display_selected, total_display, display_indices) =
                 if let Some(ref filter) = state.issue_list_filter {
                     if filter.matched_indices.is_empty() {
                         let empty_msg = format!("No matches for '{}'", filter.query);
@@ -77,12 +78,12 @@ pub fn render(frame: &mut Frame, app: &mut App) {
                         filter.matched_indices.iter().map(|&i| &issues[i]).collect();
                     let sel = filter.selected.unwrap_or(0);
                     let total = filtered.len();
-                    (filtered, sel, total)
+                    (filtered, sel, total, filter.matched_indices.clone())
                 } else {
                     let all: Vec<&IssueSummary> = issues.iter().collect();
                     let sel = state.selected_issue;
                     let total = all.len();
-                    (all, sel, total)
+                    (all, sel, total, (0..issues.len()).collect())
                 };
 
             let total_issues = issues.len();
@@ -103,13 +104,44 @@ pub fn render(frame: &mut Frame, app: &mut App) {
                 .with_offset(state.issue_list_scroll_offset)
                 .with_selected(Some(display_selected));
 
+            let block = Block::default().borders(Borders::ALL).title(title);
+            let inner_area = block.inner(chunks[1]);
             let list = List::new(items)
-                .block(Block::default().borders(Borders::ALL).title(title))
+                .block(block)
                 .highlight_style(Style::default().bg(Color::DarkGray));
             frame.render_stateful_widget(list, chunks[1], &mut list_state);
 
+            let final_offset = list_state.offset();
             if let Some(ref mut state) = app.issue_state {
-                state.issue_list_scroll_offset = list_state.offset();
+                state.issue_list_scroll_offset = final_offset;
+            }
+
+            app.hit_map.push(
+                inner_area,
+                HitTarget::Pane {
+                    pane: PaneKind::List(ListKind::IssueList),
+                },
+            );
+            let visible_end = final_offset
+                .saturating_add(inner_area.height as usize)
+                .min(total_display);
+            for row in final_offset..visible_end {
+                let Some(&index) = display_indices.get(row) else {
+                    break;
+                };
+                app.hit_map.push(
+                    Rect {
+                        x: inner_area.x,
+                        y: inner_area.y + (row - final_offset) as u16,
+                        width: inner_area.width,
+                        height: 1,
+                    },
+                    HitTarget::ListRow {
+                        list: ListKind::IssueList,
+                        row,
+                        index,
+                    },
+                );
             }
 
             if total_display > 1 {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -9,6 +9,7 @@ mod file_list;
 pub(super) mod footer;
 mod git_ops;
 mod help;
+pub mod hit;
 mod issue_comment_list;
 mod issue_detail;
 mod issue_list;
@@ -20,7 +21,10 @@ pub mod text_area;
 
 use anyhow::Result;
 use crossterm::{
-    event::{KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags},
+    event::{
+        DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags,
+        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+    },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -41,8 +45,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::app::{App, AppState, DataState, ShellCommandResult, ShellPhase};
 
 static KITTY_ENABLED: AtomicBool = AtomicBool::new(false);
+static MOUSE_CAPTURE_ENABLED: AtomicBool = AtomicBool::new(false);
 
-pub fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
+pub fn setup_terminal(mouse_capture: bool) -> Result<Terminal<CrosstermBackend<Stdout>>> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -59,17 +64,54 @@ pub fn setup_terminal() -> Result<Terminal<CrosstermBackend<Stdout>>> {
     {
         KITTY_ENABLED.store(true, Ordering::SeqCst);
     }
+    if mouse_capture {
+        write_enable_mouse_capture(&mut stdout)?;
+        MOUSE_CAPTURE_ENABLED.store(true, Ordering::SeqCst);
+    }
     let backend = CrosstermBackend::new(stdout);
-    let terminal = Terminal::new(backend)?;
-    Ok(terminal)
+    match Terminal::new(backend) {
+        Ok(terminal) => Ok(terminal),
+        Err(e) => {
+            cleanup_mouse_capture();
+            Err(e.into())
+        }
+    }
 }
 
 pub fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>) -> Result<()> {
+    cleanup_mouse_capture();
     cleanup_keyboard_enhancement();
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
     Ok(())
+}
+
+pub fn write_enable_mouse_capture(w: &mut impl io::Write) -> io::Result<()> {
+    execute!(w, EnableMouseCapture)
+}
+
+pub fn write_disable_mouse_capture(w: &mut impl io::Write) -> io::Result<()> {
+    execute!(w, DisableMouseCapture)
+}
+
+/// ランタイムトグルでマウスキャプチャを有効化する。
+/// エスケープ発行が成功したときだけ状態を更新する。
+pub fn enable_mouse_capture_runtime() -> io::Result<()> {
+    write_enable_mouse_capture(&mut io::stdout())?;
+    MOUSE_CAPTURE_ENABLED.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+/// Disable mouse capture if previously enabled.
+/// Uses CAS to prevent double-disable. Safe to call multiple times.
+pub fn cleanup_mouse_capture() {
+    if MOUSE_CAPTURE_ENABLED
+        .compare_exchange(true, false, Ordering::SeqCst, Ordering::Relaxed)
+        .is_ok()
+    {
+        let _ = write_disable_mouse_capture(&mut io::stdout());
+    }
 }
 
 /// Pop Kitty keyboard enhancement flags if previously pushed.
@@ -84,6 +126,7 @@ pub fn cleanup_keyboard_enhancement() {
 }
 
 pub fn render(frame: &mut Frame, app: &mut App) {
+    app.hit_map.clear();
     if !app.state.is_data_state_independent() {
         if matches!(app.data_state, DataState::Loading) {
             file_list::render_loading(frame, app);
@@ -133,20 +176,51 @@ pub fn render(frame: &mut Frame, app: &mut App) {
             }
         }
     }
+    simulate_modal::register_hit_regions(app, frame.area());
 
-    if let Some(ref popup) = app.symbol_popup {
-        render_symbol_popup(frame, popup);
+    if app.symbol_popup.is_some() {
+        render_symbol_popup(frame, app);
     }
 
-    if let Some(ref shell) = app.shell_state {
+    let shell_popup = if let Some(ref shell) = app.shell_state {
         match &shell.phase {
-            ShellPhase::Input => {} // Handled by build_footer_line + build_footer_block_with_border
-            ShellPhase::Running => render_shell_running_indicator(frame, app, false),
-            ShellPhase::Cancelling => render_shell_running_indicator(frame, app, true),
-            ShellPhase::Done(result) => {
-                render_shell_output_popup(frame, result, shell.scroll_offset)
+            ShellPhase::Input => Some(None),
+            ShellPhase::Running => {
+                render_shell_running_indicator(frame, app, false);
+                Some(None)
             }
+            ShellPhase::Cancelling => {
+                render_shell_running_indicator(frame, app, true);
+                Some(None)
+            }
+            ShellPhase::Done(result) => Some(Some(render_shell_output_popup(
+                frame,
+                result,
+                shell.scroll_offset,
+            ))),
         }
+    } else {
+        None
+    };
+    match shell_popup {
+        // 出力ポップアップ: 外側クリックで閉じる + 内部はホイールスクロール
+        Some(Some(popup_area)) => {
+            app.hit_map
+                .push(frame.area(), hit::HitTarget::Backdrop { dismiss: true });
+            app.hit_map.push(popup_area, hit::HitTarget::OverlaySurface);
+            app.hit_map.push(
+                Block::default().borders(Borders::ALL).inner(popup_area),
+                hit::HitTarget::Pane {
+                    pane: hit::PaneKind::ShellOutput,
+                },
+            );
+        }
+        // 入力中/実行中はクリックを吸収する(誤操作防止)
+        Some(None) => {
+            app.hit_map
+                .push(frame.area(), hit::HitTarget::Backdrop { dismiss: false });
+        }
+        None => {}
     }
 }
 
@@ -156,7 +230,10 @@ fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
     Rect::new(x, y, width.min(area.width), height.min(area.height))
 }
 
-fn render_symbol_popup(frame: &mut Frame, popup: &crate::app::SymbolPopupState) {
+fn render_symbol_popup(frame: &mut Frame, app: &mut App) {
+    let Some(ref popup) = app.symbol_popup else {
+        return;
+    };
     let area = frame.area();
 
     let max_width = popup
@@ -198,6 +275,27 @@ fn render_symbol_popup(frame: &mut Frame, popup: &crate::app::SymbolPopupState) 
     );
 
     frame.render_widget(list, popup_area);
+
+    let symbol_count = app.symbol_popup.as_ref().map_or(0, |p| p.symbols.len());
+    app.hit_map
+        .push(area, hit::HitTarget::Backdrop { dismiss: true });
+    app.hit_map.push(popup_area, hit::HitTarget::OverlaySurface);
+    let inner = Block::default().borders(Borders::ALL).inner(popup_area);
+    for row in 0..symbol_count.min(usize::from(inner.height)) {
+        app.hit_map.push(
+            Rect {
+                x: inner.x,
+                y: inner.y.saturating_add(row as u16),
+                width: inner.width,
+                height: 1,
+            },
+            hit::HitTarget::ListRow {
+                list: hit::ListKind::SymbolPopup,
+                row,
+                index: row,
+            },
+        );
+    }
 }
 
 fn render_shell_running_indicator(frame: &mut Frame, app: &App, cancelling: bool) {
@@ -226,7 +324,11 @@ fn render_shell_running_indicator(frame: &mut Frame, app: &App, cancelling: bool
     frame.render_widget(paragraph, popup_area);
 }
 
-fn render_shell_output_popup(frame: &mut Frame, result: &ShellCommandResult, scroll_offset: usize) {
+fn render_shell_output_popup(
+    frame: &mut Frame,
+    result: &ShellCommandResult,
+    scroll_offset: usize,
+) -> Rect {
     let area = frame.area();
     let width = (area.width * 80 / 100).max(40).min(area.width);
     let height = (area.height * 70 / 100).max(10).min(area.height);
@@ -301,5 +403,30 @@ fn render_shell_output_popup(frame: &mut Frame, result: &ShellCommandResult, scr
             }),
             &mut scrollbar_state,
         );
+    }
+
+    popup_area
+}
+
+#[cfg(test)]
+mod terminal_tests {
+    use super::*;
+
+    #[test]
+    fn test_write_enable_mouse_capture_emits_tracking_sequences() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_enable_mouse_capture(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("\x1b[?1000h"), "normal tracking on: {out:?}");
+        assert!(out.contains("\x1b[?1006h"), "SGR mode on: {out:?}");
+    }
+
+    #[test]
+    fn test_write_disable_mouse_capture_emits_reset_sequences() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_disable_mouse_capture(&mut buf).unwrap();
+        let out = String::from_utf8(buf).unwrap();
+        assert!(out.contains("\x1b[?1000l"), "normal tracking off: {out:?}");
+        assert!(out.contains("\x1b[?1006l"), "SGR mode off: {out:?}");
     }
 }

--- a/src/ui/pr_description.rs
+++ b/src/ui/pr_description.rs
@@ -9,6 +9,7 @@ use ratatui::{
 use crate::app::App;
 use crate::diff::LineType;
 use crate::ui::common::{build_ci_status_span, build_pr_info};
+use crate::ui::hit::{HitTarget, PaneKind};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
@@ -45,6 +46,13 @@ fn render_header(frame: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 
 fn render_body(frame: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
     let content_height = area.height.saturating_sub(2) as usize;
+    let inner_area = Block::default().borders(Borders::ALL).inner(area);
+    app.hit_map.push(
+        inner_area,
+        HitTarget::Pane {
+            pane: PaneKind::PrDescription,
+        },
+    );
 
     let Some(ref cache) = app.pr_description_cache else {
         let no_desc = Paragraph::new(Line::from(Span::styled(

--- a/src/ui/pr_list.rs
+++ b/src/ui/pr_list.rs
@@ -1,5 +1,5 @@
 use ratatui::{
-    layout::{Constraint, Direction, Layout, Margin},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
@@ -14,6 +14,7 @@ use unicode_width::UnicodeWidthStr;
 use super::common::{render_update_bar, truncate_with_width};
 use crate::app::App;
 use crate::github::{CiStatus, PullRequestSummary};
+use crate::ui::hit::{HitTarget, ListKind, PaneKind};
 
 pub fn render(frame: &mut Frame, app: &mut App) {
     let has_filter_bar = app
@@ -120,12 +121,44 @@ pub fn render(frame: &mut Frame, app: &mut App) {
                 .with_offset(app.prs.pr_list_scroll_offset)
                 .with_selected(Some(display_selected));
 
+            let block = Block::default().borders(Borders::ALL).title(title);
+            let inner_area = block.inner(chunks[1]);
             let list = List::new(items)
-                .block(Block::default().borders(Borders::ALL).title(title))
+                .block(block)
                 .highlight_style(Style::default().bg(Color::DarkGray));
             frame.render_stateful_widget(list, chunks[1], &mut list_state);
 
             app.prs.pr_list_scroll_offset = list_state.offset();
+            app.hit_map.push(
+                inner_area,
+                HitTarget::Pane {
+                    pane: PaneKind::List(ListKind::PrList),
+                },
+            );
+            for i in 0..inner_area.height as usize {
+                let row = list_state.offset() + i;
+                if row >= total_display {
+                    break;
+                }
+                let index = app
+                    .prs
+                    .pr_list_filter
+                    .as_ref()
+                    .map_or(row, |filter| filter.matched_indices[row]);
+                app.hit_map.push(
+                    Rect {
+                        x: inner_area.x,
+                        y: inner_area.y.saturating_add(i as u16),
+                        width: inner_area.width,
+                        height: 1,
+                    },
+                    HitTarget::ListRow {
+                        list: ListKind::PrList,
+                        row,
+                        index,
+                    },
+                );
+            }
 
             if total_display > 1 {
                 let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)

--- a/src/ui/simulate_modal.rs
+++ b/src/ui/simulate_modal.rs
@@ -8,8 +8,9 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::{App, PendingGitOpsConfirm, SimulationResult};
+use crate::app::{App, AppState, PendingGitOpsConfirm, SimulationResult};
 use crate::gitfilm::GitfilmAreaSnapshot;
+use crate::ui::hit::{HitTarget, PaneKind};
 
 /// ファイルがどのエリアにどのステータスで存在するかの要約
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -115,10 +116,7 @@ fn transition_color(label: &str) -> Color {
 }
 
 pub fn render_simulating(frame: &mut Frame, app: &App) {
-    let area = frame.area();
-    let width = 40_u16.min(area.width.saturating_sub(4));
-    let height = 3_u16.min(area.height.saturating_sub(4));
-    let modal_area = centered_rect(width, height, area);
+    let modal_area = simulating_modal_rect(frame.area());
 
     frame.render_widget(Clear, modal_area);
 
@@ -151,14 +149,7 @@ pub fn render_preview(frame: &mut Frame, app: &App) {
         return;
     };
 
-    let area = frame.area();
-    let modal_width = (area.width as f32 * 0.7) as u16;
-    let modal_height = (area.height as f32 * 0.6) as u16;
-    let modal_area = centered_rect(
-        modal_width.max(40).min(area.width.saturating_sub(4)),
-        modal_height.max(10).min(area.height.saturating_sub(4)),
-        area,
-    );
+    let modal_area = preview_modal_rect(frame.area());
 
     frame.render_widget(Clear, modal_area);
 
@@ -214,6 +205,61 @@ pub fn render_preview(frame: &mut Frame, app: &App) {
         .scroll((scroll_offset as u16, 0));
 
     frame.render_widget(paragraph, modal_area);
+}
+
+/// Register hit regions for the active Git Ops simulation modal.
+///
+/// This is safe to call unconditionally after rendering; it is a no-op unless
+/// the pending confirmation is currently simulating or showing a preview.
+pub(crate) fn register_hit_regions(app: &mut App, area: Rect) {
+    if !matches!(
+        app.state,
+        AppState::GitOpsSplitTree | AppState::GitOpsSplitDiff
+    ) {
+        return;
+    }
+
+    let (modal_area, preview_text_area) = match app
+        .git_ops_state
+        .as_ref()
+        .and_then(|ops| ops.pending_confirm.as_ref())
+    {
+        Some(PendingGitOpsConfirm::Simulating { .. }) => (simulating_modal_rect(area), None),
+        Some(PendingGitOpsConfirm::Previewing { .. }) => {
+            let modal_area = preview_modal_rect(area);
+            let text_area = Block::default().borders(Borders::ALL).inner(modal_area);
+            (modal_area, Some(text_area))
+        }
+        _ => return,
+    };
+
+    app.hit_map
+        .push(area, HitTarget::Backdrop { dismiss: false });
+    app.hit_map.push(modal_area, HitTarget::OverlaySurface);
+    if let Some(preview_text_area) = preview_text_area {
+        app.hit_map.push(
+            preview_text_area,
+            HitTarget::Pane {
+                pane: PaneKind::GitOpsPreview,
+            },
+        );
+    }
+}
+
+fn simulating_modal_rect(area: Rect) -> Rect {
+    let width = 40_u16.min(area.width.saturating_sub(4));
+    let height = 3_u16.min(area.height.saturating_sub(4));
+    centered_rect(width, height, area)
+}
+
+fn preview_modal_rect(area: Rect) -> Rect {
+    let modal_width = (area.width as f32 * 0.7) as u16;
+    let modal_height = (area.height as f32 * 0.6) as u16;
+    centered_rect(
+        modal_width.max(40).min(area.width.saturating_sub(4)),
+        modal_height.max(10).min(area.height.saturating_sub(4)),
+        area,
+    )
 }
 
 fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {

--- a/src/ui/split_view.rs
+++ b/src/ui/split_view.rs
@@ -42,10 +42,33 @@ pub fn render(frame: &mut Frame, app: &mut App) {
 
     render_file_list_pane(frame, app, h_chunks[0], is_file_focused);
     render_diff_pane(frame, app, h_chunks[1], is_diff_focused);
+    register_split_divider(app, h_chunks[0], outer_chunks[0]);
 
     if has_rally {
         render_rally_status_bar(frame, outer_chunks[1], app);
     }
+}
+
+/// スプリット境界(左ペイン右端の 2 桁)をドラッグリサイズ対象として登録する。
+/// ペイン内容の登録より後に呼ぶことで最上位ヒットになる。
+pub(super) fn register_split_divider(
+    app: &mut App,
+    left_pane: ratatui::layout::Rect,
+    body: ratatui::layout::Rect,
+) {
+    app.hit_map.push(
+        ratatui::layout::Rect {
+            x: left_pane.right().saturating_sub(1),
+            y: left_pane.y,
+            width: 2,
+            height: left_pane.height,
+        },
+        crate::ui::hit::HitTarget::SplitDivider {
+            split: crate::ui::hit::SplitKind::LeftPanel,
+            body_x: body.x,
+            body_width: body.width,
+        },
+    );
 }
 
 fn render_file_list_pane(
@@ -258,6 +281,8 @@ fn render_file_list_pane(
         }
     }
 
+    super::file_list::register_file_list_hits(app, chunks[1]);
+
     let mut next_chunk = 2;
 
     if has_filter_bar {
@@ -294,7 +319,12 @@ fn render_file_list_pane(
     frame.render_widget(footer, chunks[next_chunk]);
 }
 
-fn render_diff_pane(frame: &mut Frame, app: &App, area: ratatui::layout::Rect, is_focused: bool) {
+fn render_diff_pane(
+    frame: &mut Frame,
+    app: &mut App,
+    area: ratatui::layout::Rect,
+    is_focused: bool,
+) {
     let border_color = if is_focused {
         Color::Yellow
     } else {
@@ -312,7 +342,7 @@ fn render_diff_pane(frame: &mut Frame, app: &App, area: ratatui::layout::Rect, i
 
 fn render_diff_pane_normal(
     frame: &mut Frame,
-    app: &App,
+    app: &mut App,
     area: ratatui::layout::Rect,
     border_color: Color,
     is_focused: bool,
@@ -359,7 +389,7 @@ fn render_diff_footer(
 
 fn render_diff_pane_with_comments(
     frame: &mut Frame,
-    app: &App,
+    app: &mut App,
     area: ratatui::layout::Rect,
     border_color: Color,
 ) {
@@ -418,16 +448,22 @@ fn render_diff_pane_with_comments(
     let title = "Comments (j/k/↑↓: scroll, c: comment, s: suggest, r: reply)";
     let total_lines = lines.len();
 
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow))
+        .title(title);
+    let inner_area = block.inner(chunks[2]);
     let paragraph = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Yellow))
-                .title(title),
-        )
+        .block(block)
         .wrap(Wrap { trim: true })
         .scroll((app.cmt.comment_panel_scroll, 0));
     frame.render_widget(paragraph, chunks[2]);
+    app.hit_map.push(
+        inner_area,
+        crate::ui::hit::HitTarget::Pane {
+            pane: crate::ui::hit::PaneKind::CommentPanel,
+        },
+    );
 
     if total_lines > 1 {
         let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
@@ -480,12 +516,13 @@ fn render_diff_header(
 
 fn render_diff_body(
     frame: &mut Frame,
-    app: &App,
+    app: &mut App,
     area: ratatui::layout::Rect,
     border_color: Color,
 ) {
     let visible_height = area.height.saturating_sub(2) as usize;
-    let (lines, scroll_row) = if let Some(ref cache) = app.diff_store.current {
+    app.diff_scroll.set_visible_lines(visible_height);
+    let (lines, scroll_row, first_line) = if let Some(ref cache) = app.diff_store.current {
         let line_count = cache.lines.len();
         // Slice from scroll_offset, bounded to visible viewport + buffer for wrap handling.
         let max_scroll = line_count.saturating_sub(visible_height);
@@ -504,7 +541,7 @@ fn render_diff_body(
             multiline_range,
             area.width.saturating_sub(2),
         );
-        (rendered, 0u16)
+        (rendered, 0u16, start)
     } else {
         let file = app.files().get(app.selected_file);
         let rendered = match file {
@@ -520,15 +557,22 @@ fn render_diff_body(
             },
             None => vec![Line::from("No file selected")],
         };
-        (rendered, app.diff_scroll.scroll_offset as u16)
+        (rendered, app.diff_scroll.scroll_offset as u16, 0)
     };
 
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    let inner_area = block.inner(area);
+    diff_view::register_diff_hit_regions(
+        &mut app.hit_map,
+        inner_area,
+        &lines,
+        first_line,
+        scroll_row as usize,
+    );
     let diff_block = Paragraph::new(lines)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_style(Style::default().fg(border_color)),
-        )
+        .block(block)
         .wrap(Wrap { trim: false })
         .scroll((scroll_row, 0));
 


### PR DESCRIPTION
## Summary

Adds mouse support to every screen (20 `AppState` variants plus the overlay/dialog substates). Keyboard behavior is unchanged — mouse actions call the exact same methods the key branches call, so lazy fetching, diff prefetching, and state transitions behave identically on both input paths.

### What works

- **Click**: selects a list row / diff line; clicking the already-selected row opens it (`Enter` equivalent). Works on all lists, diff views, the repository browser (tree / file / module graph), overlays' inner lists, and the Help / CommentList tab headers
- **Wheel**: moves the cursor/selection under the pointer by `wheel_step` (default 3) lines, including unfocused panes
- **Drag**: multi-line diff selection (`V` equivalent — promoted only on the first drag so plain clicks stay clicks) and split-border resizing (session-only `left_panel_width`)
- **Focus**: clicking a pane performs the same state transitions as `h`/`l`/`Tab`; a focus-changing click selects but never activates
- **Overlays**: informational overlays close on outside click; destructive confirmations (Git ops, AI Rally, empty-body approve) ignore outside clicks and stay keyboard-only by design
- **F2** (`toggle_mouse`): releases mouse capture anywhere — including loading/error states and TextInput — so terminal-native copy keeps working; `[mouse] enabled = false` opts out entirely

### Architecture

- `src/ui/hit.rs`: per-frame `HitMap` — renderers register resolved regions (real indices through filter mappings, wrapped-line logical lines, centered tree offsets, 3-row graph nodes) at draw time; the input side only does rect containment and dispatch. Overlay z-order is expressed by registration order (backdrop → surface → rows)
- `src/app/input_mouse.rs`: pure `coalesce()` (same-direction scroll merging, drag last-wins, `Moved` dropped for the `?1003h` motion flood, keys re-queued), `DragState` state machine, and exhaustive `HitTarget` dispatch
- Terminal capture follows the existing Kitty-protocol CAS pattern across all 7 setup and 6 restore paths (panic hook included), with rollback on setup failure
- Version bumped to 0.8.0 with new default-config hashes registered in `migrate.rs` (same procedure as the 0.5.8 `[layout]` addition)

### Testing

- ~60 new tests (config parsing/clamping, F-key round-trips, coalescer rules, HitMap z-order, per-archetype click/wheel dispatch, drag promotion, focus suppression, capture-sequence assertions against an injected writer)
- Full gates green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check`, full test suite (1861 tests); existing snapshots unchanged
- `browse_render` benches stay at ~48–51 µs per frame; hit registration is O(visible rows) pushes into a capacity-reused Vec

### Notes for review

- Confirmation dialogs intentionally have no clickable y/n buttons (mis-click safety); answering stays on the keyboard
- TextArea wheel is a deliberate no-op (its viewport is cursor-driven and recomputed every render)
- Manual real-terminal pass recommended: launch → click/wheel/drag → F2 → copy → quit → panic path, verifying no mouse escape sequences leak into the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gvc6rW1kqf7Dn7diXDSyLy