### PR TITLE
ci: run tests on PRs and fix release rollback

### DIFF
--- a/.claude/skills/cargo-release/SKILL.md
+++ b/.claude/skills/cargo-release/SKILL.md
@@ -93,7 +93,7 @@ Rust/Cargoプロジェクトのリリース手順を実行するスキル。
    gh run watch <run-id>
    ```
    - ワークフローがtest/build/release/publishを自動実行
-   - 失敗時はバージョンバンプコミットが自動revertされる
+   - 失敗時はバンプコミットのrevert PRが自動作成される（マージは手動）
 
 ## 前提条件
 
@@ -104,14 +104,15 @@ Rust/Cargoプロジェクトのリリース手順を実行するスキル。
 
 ## 注意事項
 
-- ワークフローが失敗した場合、バンプコミットは自動revertされる（ただしHEADが移動していない場合のみ）
+- ワークフローが失敗した場合、バンプコミットのrevert PR（`revert-bump-v{version}` ブランチ）が自動作成される（ただしHEADが移動していない場合のみ）。mainのルールセットがPR必須のためワークフローからは直接pushできず、マージはユーザーの手動操作
 - `cargo publish` の失敗ではrollbackされない（GitHub Releaseは成功済みのため）
 
 ## エラー時のリカバリ
 
 ### validate/test/build/release の失敗
-- 自動rollback（バンプコミットrevert + タグ/リリース削除）が実行される
-- 原因を修正後、Phase 2 からやり直す（バージョン更新 → コミット → プッシュ → ワークフロー起動）
+- rollbackジョブがrevert PRの作成とタグ/リリース削除を自動実行する
+- **fix-forwardする場合**（原因を修正して同じバージョンで再リリース）: revert PRをクローズし、修正をmainに反映後、新HEADのSHAで `gh workflow run release.yml -f version={version} -f bump_sha=$(git rev-parse HEAD)` を再実行（bump_shaはorigin/mainのHEADであれば、バンプコミット自体でなくてよい）
+- **リリースを取りやめる場合**: revert PRをマージしてバンプを打ち消し、原因修正後にPhase 2 からやり直す
 
 ### publish のみ失敗（GitHub Release は成功済み）
 - **推奨**: GitHub Actions UI から "Re-run failed jobs" で `publish` ジョブのみ再実行

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,6 +47,22 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets --workspace -- -D warnings
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
+        with:
+          toolchain: 1.95.0
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@ad397744b0d591a723ab90405b7247fac0e6b8db # v2
+
+      - name: Run tests
+        run: cargo test
+
   # The blame parser's design rests on a memory layout — eight bytes per line
   # (commit index plus original line),
   # and an allocation count that does not scale with the commit count. The

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,12 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+# Jobs that need more (release, publish, rollback) elevate per-job. In
+# particular, id-token stays out of test/build, whose cargo invocations run
+# third-party build scripts that could otherwise mint the trusted-publishing
+# OIDC token.
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -175,6 +178,8 @@ jobs:
   release:
     needs: [validate, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -207,6 +212,9 @@ jobs:
   publish:
     needs: [validate, release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,9 @@ jobs:
     needs: [validate, test, build, release]
     if: always() && (needs.test.result == 'failure' || needs.build.result == 'failure' || needs.release.result == 'failure')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -249,15 +252,30 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Revert bump commit
+      # The main ruleset requires changes via PR (with review), so the revert
+      # cannot be pushed directly — open a PR and leave the merge to a human.
+      - name: Open revert PR
         if: steps.check.outputs.skip != 'true'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUMP_SHA: ${{ inputs.bump_sha }}
+          VERSION: ${{ inputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="revert-bump-v${VERSION}"
+          git switch -c "$BRANCH"
           git revert --no-edit "$BUMP_SHA"
-          git push origin main
+          git push --force origin "$BRANCH"
+          if [ -z "$(gh pr list --head "$BRANCH" --state open --json number --jq '.[].number')" ]; then
+            BODY=$(printf 'Reverts the v%s bump because the release failed: %s\n\nMerge this PR to restore main, fix the cause, then restart the release from the version bump.' "$VERSION" "$RUN_URL")
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: revert version bump v${VERSION}" \
+              --body "$BODY"
+          fi
 
       - name: Delete tag
         if: always()


### PR DESCRIPTION
## Summary

Two CI gaps surfaced during the v0.7.2 release:

- **PRs never ran `cargo test`** — lint.yml only ran fmt/clippy/bench-assertions, so PR #182 merged green while 6 of its tests could not pass in a tty-less environment; the breakage only surfaced in the release workflow. lint.yml now has a `test` job (ubuntu, toolchain 1.95.0, rust-cache).
- **The release rollback job could never push its revert** — the `main` ruleset requires changes via PR with review, which `GITHUB_TOKEN` cannot bypass, so the automatic `git push origin main` always failed (seen twice during the v0.7.2 attempts). The rollback job now pushes a `revert-bump-v{version}` branch and opens a revert PR instead (idempotent on re-runs); merging it stays a human decision. Tag/release deletion remains automated. The cargo-release skill docs are updated to match, including the fix-forward recovery path.

## Verification

- `python3 yaml.safe_load` and `actionlint`: both workflows pass with no findings
- The SHA-pinning check enforced by release.yml's validate job passes (no new action refs; existing pinned SHAs reused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bWRBmxjoGUXuwncpy5zpC